### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ It's a Poseidon v4.5 driver. Current status is:
 well, unsure yet. What I'm using:
 - AmigaOS 3.2.3 + AmiKit 12.8.3 on an A1200
 - Poseidon 4.5
-- Pistorm with Raspberry Pi 4B (the USB controller here is Via VL805 XHCI on PCIe bus. **Note that CM4 is currently not supported**)
+- Pistorm32-lite with Raspberry Pi 4B (the USB controller here is Via VL805 XHCI on PCIe bus. **Note that CM4 is not yet supported**)
 - Emu68... 1.1 or 1.0.99 This is necessary to set up MMU mapping for the PCIe BAR window into low 4GB.
+- gic400.library - https://github.com/rondoval/emu68-gic400-library/releases
 
 ## Building
 


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to clarify hardware compatibility and add a new dependency. The most important changes include specifying the correct hardware variant, updating support notes, and listing a required library.

Hardware compatibility updates:

* Changed the hardware description from `Pistorm` to `Pistorm32-lite` with Raspberry Pi 4B to accurately reflect the supported configuration.
* Updated the note regarding Compute Module 4 (CM4) support to clarify that it is "not yet supported" rather than "currently not supported".

Dependency additions:

* Added `gic400.library` as a required component, including a link to its release page.