### PR TITLE
SuperSpeed and bug fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-xhci-driver VERSION 1.7)
+project(emu68-xhci-driver VERSION 2.0)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION} ${CURRENT_DATE}")

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ It's a Poseidon v4.5 driver. Current status is:
 - external hubs work
 - control, bulk, interrupt and RT isochronous (both directions) transfers seem to be working
 - HID devices, thumb drives, audio cards are useable
+- experimental support for SuperSpeed devices connected directly to root hub port
 
 ## Unimplemented / Planned Features
 
 - the non-RT isochronous is not tested
 - support for CM4 and OTG port on Pi4
-- SuperSpeed support
+- SuperSpeed support - hub devices
 
 ## Requirements
 

--- a/xhci.device/include/xhci/ch9.h
+++ b/xhci.device/include/xhci/ch9.h
@@ -295,6 +295,16 @@ struct usb_config_descriptor {
 
 /*-------------------------------------------------------------------------*/
 
+/* USB_DT_STRING: String descriptor information. */
+struct usb_string_descriptor {
+	__u8  bLength;
+	__u8  bDescriptorType;
+
+	__u8  bString[];	/* UTF-16LE encoded string */
+} __attribute__ ((packed));
+
+/*-------------------------------------------------------------------------*/
+
 /* USB_DT_INTERFACE: Interface descriptor */
 struct usb_interface_descriptor {
 	__u8  bLength;

--- a/xhci.device/include/xhci/xhci-udev.h
+++ b/xhci.device/include/xhci/xhci-udev.h
@@ -152,6 +152,7 @@ struct usb_device {
 
 	struct MinList configurations; /* configurations captured from GET_CONFIGURATION replies */
 	struct usb_config *active_config;
+	u8 product_string_index; /* iProduct from device descriptor */
 
 	/* Split routing data */
 	struct usb_device *parent;    /* Parent hub device, NULL for root */

--- a/xhci.device/src/xhci/xhci-context.c
+++ b/xhci.device/src/xhci/xhci-context.c
@@ -860,7 +860,7 @@ void xhci_dump_slot_ctx(const char *tag, struct usb_device *udev, BOOL in_ctx)
 
     ULONG address = dev_state & DEV_ADDR_MASK;
     ULONG slot_state = GET_SLOT_STATE(dev_state);
-    Kprintf("%s Slot context @%lx\n", pfx, (ULONG)slot_ctx);
+    Kprintf("%s Slot context %s @%lx\n", pfx, (in_ctx) ? "IN" : "OUT", (ULONG)slot_ctx);
     Kprintf("%s  dev_info=0x%08lx route=0x%05lx speed=%s hub=%ld mtt=%ld last_ctx=%lu (last_ep=%ld)\n",
             pfx,
             dev_info,

--- a/xhci.device/src/xhci/xhci-root-hub.c
+++ b/xhci.device/src/xhci/xhci-root-hub.c
@@ -471,6 +471,8 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct IOUsbHWRe
 			tmpbuf[0] |= USB_PORT_STAT_OVERCURRENT;
 		if (reg & (PORT_RESET | PORT_WR))
 			tmpbuf[0] |= USB_PORT_STAT_RESET;
+		if ((reg & DEV_SPEED_MASK) == XDEV_SS && (reg & PORT_CONNECT) && (reg & PORT_PE) == 0)
+			tmpbuf[0] |= USB_PORT_STAT_RESET;
 		if (reg & PORT_POWER)
 			/*
 			 * XXX: This Port power bit (for USB 3.0 hub)

--- a/xhci.device/src/xhci/xhci-root-hub.c
+++ b/xhci.device/src/xhci/xhci-root-hub.c
@@ -66,14 +66,14 @@ static struct descriptor
 	.device = {
 		.bLength = sizeof(struct usb_device_descriptor), /* size of device descriptor */
 		.bDescriptorType = USB_DT_DEVICE,				 /* device descriptor */
-		.bcdUSB = cpu_to_le16(0x0200),					 /* advertise as USB 2.0 */
+		.bcdUSB = cpu_to_le16(0x0320),					 /* advertise as USB 3.2 */
 		.bDeviceClass = USB_CLASS_HUB,					 /* hub */
 		.bDeviceSubClass = 0,							 /* no subclass */
 		.bDeviceProtocol = USB_HUB_PR_HS_SINGLE_TT,		 /* single-TT */
 		.bMaxPacketSize0 = 64,							 /* control endpoint max packet */
 		.idVendor = 0x0000,								 /* virtual root hub: leave VID zero */
 		.idProduct = 0x0000,							 /* virtual root hub: leave PID zero */
-		.bcdDevice = cpu_to_le16(0x0100),				 /* device revision */
+		.bcdDevice = cpu_to_le16(0x0101),				 /* device revision */
 		.iManufacturer = 1,								 /* string index */
 		.iProduct = 2,									 /* string index */
 		.iSerialNumber = 0,								 /* no serial */
@@ -131,7 +131,7 @@ struct xhci_root_hub *xhci_roothub_create(struct usb_device *udev, io_reply_data
 		return NULL;
 
 	rh->udev = udev;
-	rh->udev->speed = USB_SPEED_HIGH;
+	rh->udev->speed = USB_SPEED_SUPER;
 	rh->io_reply_data = io_reply_data;
 
 	CopyMem(&prototype_descriptor, &rh->descriptor, sizeof(prototype_descriptor));
@@ -226,7 +226,7 @@ static void xhci_roothub_clear_port_change_bit(u16 wValue, u16 wIndex, volatile 
 	switch (wValue)
 	{
 	case USB_PORT_FEAT_C_RESET:
-		status = PORT_RC;
+		status = PORT_RC | PORT_WRC;
 		port_change_bit = "reset";
 		break;
 	case USB_PORT_FEAT_C_CONNECTION:
@@ -403,8 +403,8 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct IOUsbHWRe
 		break;
 	case DeviceRequest | USB_REQ_GET_STATUS:
 		/* Device GET_STATUS: bit0=self-powered, bit1=remote-wakeup */
-		tmpbuf[0] = 1; /* self-powered */
-		tmpbuf[1] = 0; /* remote-wakeup disabled */
+		tmpbuf[0] = 0;
+		tmpbuf[1] = 1; /* self-powered, remote-wakeup disabled */
 		srcptr = tmpbuf;
 		srclen = 2;
 		KprintfH("USB_REQ_GET_STATUS\n");
@@ -432,8 +432,8 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct IOUsbHWRe
 		/* Do nothing */
 		break;
 	case USB_REQ_GET_STATUS | ((USB_DIR_IN | USB_RT_HUB) << 8):
-		tmpbuf[0] = 1; /* USB_STATUS_SELFPOWERED */
-		tmpbuf[1] = 0;
+		tmpbuf[0] = 0;
+		tmpbuf[1] = 1; /* self-powered, remote-wakeup disabled */
 		srcptr = tmpbuf;
 		srclen = 2;
 		KprintfH("USB_REQ_GET_STATUS HUB\n");
@@ -469,7 +469,7 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct IOUsbHWRe
 			tmpbuf[0] |= USB_PORT_STAT_SUSPEND;
 		if (reg & PORT_OC)
 			tmpbuf[0] |= USB_PORT_STAT_OVERCURRENT;
-		if (reg & PORT_RESET)
+		if (reg & (PORT_RESET | PORT_WR))
 			tmpbuf[0] |= USB_PORT_STAT_RESET;
 		if (reg & PORT_POWER)
 			/*
@@ -488,7 +488,7 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct IOUsbHWRe
 			tmpbuf[2] |= USB_PORT_STAT_C_ENABLE;
 		if (reg & PORT_OCC)
 			tmpbuf[2] |= USB_PORT_STAT_C_OVERCURRENT;
-		if (reg & PORT_RC)
+		if (reg & (PORT_RC | PORT_WRC))
 			tmpbuf[2] |= USB_PORT_STAT_C_RESET;
 
 		srcptr = tmpbuf;
@@ -514,8 +514,16 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct IOUsbHWRe
 			writel(reg, status_reg);
 			break;
 		case USB_PORT_FEAT_RESET:
-			KprintfH("Set PORT_RESET\n");
-			reg |= PORT_RESET;
+			if ((reg & DEV_SPEED_MASK) == XDEV_SS)
+			{
+				KprintfH("Set PORT_WR (warm reset)\n");
+				reg |= PORT_WR;
+			}
+			else
+			{
+				KprintfH("Set PORT_RESET\n");
+				reg |= PORT_RESET;
+			}
 			writel(reg, status_reg);
 			break;
 		case USB_PORT_FEAT_SUSPEND:

--- a/xhci.device/src/xhci/xhci-udev.c
+++ b/xhci.device/src/xhci/xhci-udev.c
@@ -1169,7 +1169,6 @@ static void xhci_udev_parse_control_message(struct usb_device *udev, struct IOUs
             const u16 string_index = LE16(io->iouh_SetupData.wValue) & 0xFF;
             if (string_index && string_index == udev->product_string_index)
             {
-                Kprintf("rewriting string index %ld for device addr %ld\n", (LONG)string_index, (LONG)udev->poseidon_address);
                 xhci_trim_string_descriptor(io);
                 xhci_append_ss_suffix(udev, io);
             }


### PR DESCRIPTION
This pull request upgrades the driver to version 2.0 and introduces experimental support for SuperSpeed (USB 3.x) devices connected directly to the root hub port. It also implements several changes to improve compatibility with Poseidon and USB 3.x devices, including enhanced descriptor handling, proper speed reporting, and fixes for root hub and port status logic.

Note that USB 3.0 hubs connected to USB 3.0 ports are not yet supported - e.g. a 3.0 pendrive needs to be plugged directly to USB 3.0 port on RPI to work in SS mode. 3.0 hubs will fail in 3.0 ports. 2.0 devices in 3.0 ports are OK.

* Changed root hub device descriptor in `xhci-root-hub.c` to advertise as USB 3.2 (`bcdUSB = 0x0320`), updated device revision, and set root hub speed to `USB_SPEED_SUPER`.
* Modified device speed handling throughout `xhci-udev.c` to correctly recognize and report SuperSpeed devices, including updating speed detection logic and reporting high speed to Poseidon for SuperSpeed devices.
* Updated device descriptor handling to clamp `bMaxPacketSize0` to 64 for SuperSpeed devices for Poseidon only (internally true bMaxPacketSize0 is used).
* Implemented filtering of SuperSpeed endpoint companion descriptors from configuration descriptors to avoid compatibility issues with Poseidon.
* Added `usb_string_descriptor` struct in `xhci/ch9.h` and implemented functions to trim string descriptors and append "(SS)" suffix for SuperSpeed devices.
* Improved root hub port status and reset handling, including proper warm reset logic for SuperSpeed ports.
* Fixed root hub GET_STATUS responses to match expected values for self-powered.
* Enhanced slot context debug output to indicate IN/OUT context.
