### PR TITLE
merge v4.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+# emu68-xhci-driver Agent Notes
+
+## Build
+
+- Required installed dependencies: `emu68-common`, `emu68-pcie-library`, and `emu68-gic400-library`.
+- Preferred commands:
+  - `cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain.cmake -DCMAKE_PREFIX_PATH=/path/to/emu68-driver-stack -DCMAKE_INSTALL_PREFIX=/path/to/emu68-driver-stack`
+  - `cmake --build build`
+  - `cmake --install build`
+- The installed binary goes to `DEVS/USBHardware/xhci.device` under the selected prefix.
+
+## Code Handling
+
+- Treat `unit_task.c` as the owner of ongoing controller work, watchdog handling, and queued command submission.
+- Treat UnitTask as the owner of command-ring submission and `pending_commands` mutation.
+- Do not issue xHCI recovery commands directly from arbitrary caller context when the UnitTask path exists.
+- Internal helper messages posted to UnitTask must be allocated from `unit->memoryPool`, not `ctrl->memoryPool`.
+- Safe `AbortIO()` behavior is to mark and defer hardware teardown work to UnitTask rather than manipulating command or transfer rings directly from caller context.
+- Root-hub emulation and descriptor translation in `xhci-root-hub.c` and `xhci-udev.c` are compatibility glue for Poseidon; preserve behavior unless the task is explicitly about hub semantics.
+- Prefer targeted fixes in `xhci/` internals over broad reshaping of the public device-layer code.
+
+## Validation
+
+- Check Problems on changed files first.
+- If changes touch shared interfaces or build outputs, validate through `emu68-driver-stack`.
+- If changes are local to the driver, a repo-local build is appropriate once `build/` has been configured.
+- Keep the internal notes in `README-internal.md` in mind for timeout, abort, and queue-depth related work, but do not treat them as a design spec.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@
 - Safe `AbortIO()` behavior is to mark and defer hardware teardown work to UnitTask rather than manipulating command or transfer rings directly from caller context.
 - Root-hub emulation and descriptor translation in `xhci-root-hub.c` and `xhci-udev.c` are compatibility glue for Poseidon; preserve behavior unless the task is explicitly about hub semantics.
 - Prefer targeted fixes in `xhci/` internals over broad reshaping of the public device-layer code.
+- Licensing in this repo was audited against Linux/U-Boot provenance; preserve the current GPL-family SPDX headers and do not reintroduce broader dual-license wording without new provenance evidence.
 
 ## Validation
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-xhci-driver VERSION 4.0)
+project(emu68-xhci-driver VERSION 4.1)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION} ${CURRENT_DATE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-xhci-driver VERSION 4.1)
+project(emu68-xhci-driver VERSION 4.2)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION} ${CURRENT_DATE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-xhci-driver VERSION 4.2)
+project(emu68-xhci-driver VERSION 4.3)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION} ${CURRENT_DATE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-xhci-driver VERSION 4.3)
+project(emu68-xhci-driver VERSION 4.4)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION} ${CURRENT_DATE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-xhci-driver VERSION 3.9)
+project(emu68-xhci-driver VERSION 4.0)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION} ${CURRENT_DATE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,3 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 endif()
 
 add_subdirectory(xhci.device)
-
-# install(FILES ${CMAKE_SOURCE_DIR}/Install DESTINATION .)
-# install(FILES ${CMAKE_SOURCE_DIR}/Install.info DESTINATION .)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-xhci-driver VERSION 3.7)
+project(emu68-xhci-driver VERSION 3.8)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION} ${CURRENT_DATE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-xhci-driver VERSION 3.8)
+project(emu68-xhci-driver VERSION 3.9)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION} ${CURRENT_DATE}")

--- a/README.md
+++ b/README.md
@@ -223,12 +223,19 @@ Build dependencies (must be installed first):
 | `GIC400` | `emu68-gic400-library` | ARM GIC-400 interrupt controller (MSI) |
 
 ```sh
-cd build
-make -j4
-make install    # installs xhci.device into ./install/
+cmake -S . -B build \
+  -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain.cmake \
+  -DCMAKE_PREFIX_PATH=/path/to/emu68-sdk \
+  -DCMAKE_INSTALL_PREFIX=/path/to/emu68-sdk
+cmake --build build
+cmake --install build
 ```
 
-Copy `install/xhci.device` to `DEVS:USBHardware/` on the Amiga.
+Recommended workflow: install all dependencies and this package into the same prefix.
+
+If you keep dependencies in separate install trees instead, set `CMAKE_PREFIX_PATH` to the `emu68-common` and `emu68-pcie-library` install prefixes.
+
+The installed binary is written to `/path/to/emu68-sdk/DEVS/USBHardware/xhci.device`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The API is not an exact match — certain fields passed by the stack are intenti
 
 > **Note for users upgrading from 3.x releases:** `bcmpcie.library` must be installed
 > in `LIBS:` for PCIe-based units (unit 1+, VL805 on Pi 4B) to work.
-> See [RELEASE-NOTES-4.0.md](RELEASE-NOTES-4.0.md) for details.
+> See release notes for the full change log from 3.7 to 4.4.
 
 ---
 
@@ -30,7 +30,7 @@ The following has been verified:
 Known gaps / issues:
 
 - Non-RT isochronous transfers not tested
-- RT isochronous audio has glitches
+- RT isochronous audio may have glitches
 - AHI 4.x not yet supported
 
 > Data corruption is possible in edge cases.  Back up before heavy use.

--- a/README.md
+++ b/README.md
@@ -225,8 +225,8 @@ Build dependencies (must be installed first):
 ```sh
 cmake -S . -B build \
   -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain.cmake \
-  -DCMAKE_PREFIX_PATH=/path/to/emu68-sdk \
-  -DCMAKE_INSTALL_PREFIX=/path/to/emu68-sdk
+  -DCMAKE_PREFIX_PATH=/path/to/emu68-driver-stack \
+  -DCMAKE_INSTALL_PREFIX=/path/to/emu68-driver-stack
 cmake --build build
 cmake --install build
 ```
@@ -235,7 +235,7 @@ Recommended workflow: install all dependencies and this package into the same pr
 
 If you keep dependencies in separate install trees instead, set `CMAKE_PREFIX_PATH` to the `emu68-common` and `emu68-pcie-library` install prefixes.
 
-The installed binary is written to `/path/to/emu68-sdk/DEVS/USBHardware/xhci.device`.
+The installed binary is written to `/path/to/emu68-driver-stack/DEVS/USBHardware/xhci.device`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The API is not an exact match — certain fields passed by the stack are intenti
 > Unit 0 used to be the VL805 (PCIe).  It is now the onboard OTG port.
 > Unit 1 is now the VL805.  Update your USB stack configuration accordingly.
 
+> **Note for users upgrading from 3.x releases:** `bcmpcie.library` must be installed
+> in `LIBS:` for PCIe-based units (unit 1+, VL805 on Pi 4B) to work.
+> See [RELEASE-NOTES-4.0.md](RELEASE-NOTES-4.0.md) for details.
+
 ---
 
 ## Status
@@ -57,11 +61,11 @@ On `OpenDevice()`:
 
 1. For unit 0 (OTG), the BCM2711 onboard xHCI controller is located via the Emu68
    device tree (`/scb/xhci`).
-2. For unit 1+ (PCIe), [`emu68-pcie-library`](https://github.com/rondoval/emu68-pcie-library)
-   initialises the Broadcom STB PCIe controller, enumerates the bus and assigns BARs.
+2. For unit 1+ (PCIe), `bcmpcie.library` initialises the Broadcom STB PCIe
+   controller, enumerates the bus and assigns BARs.
    If a VIA VL805 is found, its firmware is loaded via the VideoCore mailbox.
-   Because `emu68-pcie-library` is statically linked, the PCIe bus state is private to
-   this driver — no other driver can share the bus while it is open.
+   `bcmpcie.library` is a shared dynamic library; it must be present in `LIBS:`
+   before opening any PCIe-based unit.
 3. The xHCI controller is reset: command, event and transfer rings are allocated, the
    DCBAA is set up and the controller is started.
 4. An interrupt handler is registered via `gic400.library` (MSI) or a wired IRQ line.
@@ -209,6 +213,7 @@ interrupt is removed and the PCIe controller is left in a quiescent state.
 - [PiStorm32-lite](https://github.com/PiStorm/pistorm32-lite) with Raspberry Pi 4B or CM4
 - Emu68 1.1 alpha.1 or later — required for MMU mapping of the PCIe BAR window into the lower 4 GB
 - `gic400.library` — [emu68-gic400-library](https://github.com/rondoval/emu68-gic400-library)
+- `bcmpcie.library` — [emu68-pcie-library](https://github.com/rondoval/emu68-pcie-library) — **required for unit 1+ (VL805 / PCIe)**
 
 ---
 
@@ -219,7 +224,7 @@ Build dependencies (must be installed first):
 | Package | Where | Purpose |
 |---|---|---|
 | `Emu68Common` | `emu68-common` | Pool allocators, shared utilities |
-| `Emu68PCIe` | `emu68-pcie-library` | BCM2711 PCIe controller + bus enumeration |
+| `Emu68PCIe` | `emu68-pcie-library` | BCM2711 PCIe controller + bus enumeration (builds `bcmpcie.library`) |
 | `GIC400` | `emu68-gic400-library` | ARM GIC-400 interrupt controller (MSI) |
 
 ```sh

--- a/xhci.device/CMakeLists.txt
+++ b/xhci.device/CMakeLists.txt
@@ -30,7 +30,7 @@ target_include_directories(xhci.device PRIVATE include)
 target_link_libraries(xhci.device
     PRIVATE
         Emu68Common::common
-        Emu68PCIe::pcie
+        Emu68PCIe::pcie_headers
 )
 
 install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/xhci.device DESTINATION DEVS/USBHardware)

--- a/xhci.device/CMakeLists.txt
+++ b/xhci.device/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14.0)
 project(xhci.device VERSION ${CMAKE_PROJECT_VERSION})
 
 add_link_options(-ffreestanding -nostdlib -nostartfiles -s -Wl,-e,_doNotExecute)
-add_compile_options(-Os -m68040 -Wall -Wextra -DDEBUG -fomit-frame-pointer)
+add_compile_options(-Os -m68040 -Wall -Wextra -Wconversion -Wsign-conversion -Wshadow -Wmissing-prototypes -Wstrict-prototypes -DDEBUG -fomit-frame-pointer)
 add_compile_definitions(PRIVATE DEVICE_IDSTRING="${VERSTRING}" DEVICE_VERSION=${PROJECT_VERSION_MAJOR} DEVICE_REVISION=${PROJECT_VERSION_MINOR} DEVICE_NAME="${PROJECT_NAME}" DEVICE_USE_MSI=TRUE)
 
 add_executable(xhci.device

--- a/xhci.device/CMakeLists.txt
+++ b/xhci.device/CMakeLists.txt
@@ -1,10 +1,39 @@
 cmake_minimum_required(VERSION 3.14.0)
 project(xhci.device VERSION ${CMAKE_PROJECT_VERSION})
 
-add_link_options(-ffreestanding -nostdlib -nostartfiles -s -Wl,-e,_doNotExecute)
-add_compile_options(-Os -m68040 -Wall -Wextra -Wconversion -Wsign-conversion -Wshadow -Wmissing-prototypes -Wstrict-prototypes -DDEBUG -fomit-frame-pointer)
-add_compile_definitions(PRIVATE DEVICE_IDSTRING="${VERSTRING}" DEVICE_VERSION=${PROJECT_VERSION_MAJOR} DEVICE_REVISION=${PROJECT_VERSION_MINOR} DEVICE_NAME="${PROJECT_NAME}" DEVICE_USE_MSI=TRUE)
+# Toolchain and compile options
+add_link_options(
+    -ffreestanding
+    -nostdlib
+    -nostartfiles
+    -s
+    -Wl,-e,_doNotExecute
+)
 
+add_compile_options(
+    -Os
+    -m68040
+    -Wall
+    -Wextra
+    -Wconversion
+    -Wsign-conversion
+    -Wshadow
+    -Wmissing-prototypes
+    -Wstrict-prototypes
+    -DDEBUG
+    -fomit-frame-pointer
+)
+
+add_compile_definitions(
+    PRIVATE
+        DEVICE_IDSTRING="${VERSTRING}"
+        DEVICE_VERSION=${PROJECT_VERSION_MAJOR}
+        DEVICE_REVISION=${PROJECT_VERSION_MINOR}
+        DEVICE_NAME="${PROJECT_NAME}"
+        DEVICE_USE_MSI=TRUE
+)
+
+# Sources
 add_executable(xhci.device
     src/device.c
     src/device_beginio.c
@@ -26,11 +55,18 @@ add_executable(xhci.device
     src/device_end.c
 )
 
-target_include_directories(xhci.device PRIVATE include)
+target_include_directories(xhci.device
+    PRIVATE
+        include
+)
+
 target_link_libraries(xhci.device
     PRIVATE
         Emu68Common::common
         Emu68PCIe::pcie_headers
 )
 
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/xhci.device DESTINATION DEVS/USBHardware)
+install(
+    PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/xhci.device
+    DESTINATION DEVS/USBHardware
+)

--- a/xhci.device/CMakeLists.txt
+++ b/xhci.device/CMakeLists.txt
@@ -33,4 +33,4 @@ target_link_libraries(xhci.device
         Emu68PCIe::pcie
 )
 
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/xhci.device DESTINATION .)
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/xhci.device DESTINATION DEVS/USBHardware)

--- a/xhci.device/include/config.h
+++ b/xhci.device/include/config.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifndef XHCI_DEVICE_CONFIG_H
 #define XHCI_DEVICE_CONFIG_H
 

--- a/xhci.device/include/config.h
+++ b/xhci.device/include/config.h
@@ -30,7 +30,13 @@
 #define CMD_TIMEOUT_MS 5000
 
 /* Target RT ISO IN scheduling horizon in ms */
-#define RT_ISO_IN_TARGET_FRAMES 10
+#define RT_ISO_IN_TARGET_FRAMES 16
+#define XHCI_INITIAL_SEGMENTS_PER_RING 1
+#define XHCI_SEGMENTS_PER_RING 4
+#define XHCI_MAX_SEGMENTS_PER_RING 64 // Hard ceiling for dynamic transfer ring growth
+
+/* Event ring sizing: fixed at startup */
+#define XHCI_INITIAL_SEGS_PER_EVENT_RING 8
 
 /* Minimum interval between interrupts (in 250ns intervals).  The interval
  * between interrupts will be longer if there are no events on the event ring.

--- a/xhci.device/include/config.h
+++ b/xhci.device/include/config.h
@@ -29,7 +29,10 @@
 /* Command ring timeout: 5 seconds */
 #define CMD_TIMEOUT_MS 5000
 
-#define RT_ISO_IN_TARGET_TDS 16
-#define XHCI_SEGMENTS_PER_RING 1
+
+/* Minimum interval between interrupts (in 250ns intervals).  The interval
+ * between interrupts will be longer if there are no events on the event ring.
+ * Default is 4000 (1 ms). */
+#define IRQ_INTERVAL 4000
 
 #endif

--- a/xhci.device/include/config.h
+++ b/xhci.device/include/config.h
@@ -29,6 +29,8 @@
 /* Command ring timeout: 5 seconds */
 #define CMD_TIMEOUT_MS 5000
 
+/* Target RT ISO IN scheduling horizon in ms */
+#define RT_ISO_IN_TARGET_FRAMES 10
 
 /* Minimum interval between interrupts (in 250ns intervals).  The interval
  * between interrupts will be longer if there are no events on the event ring.

--- a/xhci.device/include/device.h
+++ b/xhci.device/include/device.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 #ifndef _GENET_DEVICE_H
 #define _GENET_DEVICE_H
 

--- a/xhci.device/include/device.h
+++ b/xhci.device/include/device.h
@@ -28,6 +28,7 @@ struct XHCIUnit
 {
 	struct Unit unit;
 	APTR memoryPool;
+	struct XHCIDevice *device;
 
 	/* config */
 	LONG unitNumber;
@@ -40,12 +41,17 @@ struct XHCIUnit
 	struct Interrupt irq_isr;
 	LONG irq_line;
 	BYTE irq_signal;
+	char vendor_str[5];
+	char device_str[5];
 };
 
 struct XHCIDevice
 {
 	struct Device device;
 	ULONG segList;
+	struct Library *utilityBase;
+	struct Library *gic400Base;
+	struct pci_controller *pcie;
 
 	struct MinList units;
 };

--- a/xhci.device/include/device.h
+++ b/xhci.device/include/device.h
@@ -51,13 +51,16 @@ struct XHCIDevice
 	ULONG segList;
 	struct Library *utilityBase;
 	struct Library *gic400Base;
-	struct pci_controller *pcie;
+	struct Library *pcieBase;    /* NULL until first PCIe unit opens */
 
 	struct MinList units;
 };
 
 void beginIO(struct USBIORequest *io asm("a1"), struct XHCIDevice *base asm("a6"));
 LONG abortIO(struct USBIORequest *io asm("a1"), struct XHCIDevice *base asm("a6"));
+
+/* PCI library: lazy-open on first PCIe unit, tries bcmpcie.library then openpci.library */
+s32 xhci_open_pcie_library(struct XHCIDevice *base);
 
 /* Unit interface */
 s32 UnitTaskStart(struct XHCIUnit *unit);

--- a/xhci.device/include/device.h
+++ b/xhci.device/include/device.h
@@ -39,7 +39,7 @@ struct XHCIUnit
 	struct xhci_ctrl *xhci_ctrl;
 
 	struct Interrupt irq_isr;
-	LONG irq_line;
+	u32 irq_line;
 	BYTE irq_signal;
 	char vendor_str[5];
 	char device_str[5];
@@ -56,16 +56,19 @@ struct XHCIDevice
 	struct MinList units;
 };
 
+void beginIO(struct USBIORequest *io asm("a1"), struct XHCIDevice *base asm("a6"));
+LONG abortIO(struct USBIORequest *io asm("a1"), struct XHCIDevice *base asm("a6"));
+
 /* Unit interface */
-int UnitTaskStart(struct XHCIUnit *unit);
+s32 UnitTaskStart(struct XHCIUnit *unit);
 void UnitTaskStop(struct XHCIUnit *unit);
 
-int UnitOpen(struct XHCIUnit *unit, LONG unitNumber, LONG flags);
-int UnitClose(struct XHCIUnit *unit);
+s32 UnitOpen(struct XHCIUnit *unit, LONG unitNumber, LONG flags);
+s32 UnitClose(struct XHCIUnit *unit);
 
 void ProcessCommand(struct USBIORequest *io);
 
-int xhci_int_enable(struct XHCIUnit *unit);
+s32 xhci_int_enable(struct XHCIUnit *unit);
 void xhci_int_shutdown(struct XHCIUnit *unit);
 void xhci_int_rearm(struct XHCIUnit *unit);
 

--- a/xhci.device/include/devices/hcd_api.h
+++ b/xhci.device/include/devices/hcd_api.h
@@ -5,6 +5,7 @@
 
 #include <types.h>
 #include <exec/io.h>
+#include <bits.h>
 
 #pragma pack(2)
 
@@ -12,9 +13,9 @@ struct USBSetupPacket
 {
     u8 bmRequestType;
     u8 bRequest;
-    u16 wValue;
-    u16 wIndex;
-    u16 wLength;
+    __le16 wValue;
+    __le16 wIndex;
+    __le16 wLength;
 };
 
 struct USBBufferRequest
@@ -61,14 +62,14 @@ struct USBIORequest
 #define DIRECTION_IN 2
 #define DIRECTION_OUT 1
 
-#define DRIVER_FLAG_TIMEOUT_DEFINED (1 << 3)
-#define DRIVER_FLAG_IGNORE_SHORT_TRANSFER (1 << 4)
+#define DRIVER_FLAG_TIMEOUT_DEFINED BIT(3)
+#define DRIVER_FLAG_IGNORE_SHORT_TRANSFER BIT(4)
 
 /* driver states */
-#define DRIVER_STATE_OPERATIONAL (1 << 0)
-#define DRIVER_STATE_SUSPENDED (1 << 2)
-#define DRIVER_STATE_RESUMING (1 << 1)
-#define DRIVER_STATE_RESETING (1 << 3)
+#define DRIVER_STATE_OPERATIONAL BIT(0)
+#define DRIVER_STATE_SUSPENDED BIT(2)
+#define DRIVER_STATE_RESUMING BIT(1)
+#define DRIVER_STATE_RESETING BIT(3)
 
 /* driver tags */
 #define TAG_DEVICE_VENDOR (TAG_USER + 0x4721)
@@ -83,11 +84,11 @@ struct USBIORequest
 #define TAG_DRIVER_FEATURES (TAG_USER + 0x4732)
 
 /* driver feature flags */
-#define DRIVER_FEAT_USB2 (1 << 0)
-#define DRIVER_FEAT_USB3 (1 << 31)
-#define DRIVER_FEAT_QUICK_IO (1 << 3)
-#define DRIVER_FEAT_ISOCHRONOUS (1 << 1)
-#define DRIVER_FEAT_ISOCHRONOUS_HOOKS (1 << 2)
+#define DRIVER_FEAT_USB2 BIT(0)
+#define DRIVER_FEAT_USB3 BIT(31)
+#define DRIVER_FEAT_QUICK_IO BIT(3)
+#define DRIVER_FEAT_ISOCHRONOUS BIT(1)
+#define DRIVER_FEAT_ISOCHRONOUS_HOOKS BIT(2)
 
 /* driver commands */
 #define CMD_DEVICE_QUERY (CMD_NONSTD + 0)

--- a/xhci.device/include/devices/hcd_api.h
+++ b/xhci.device/include/devices/hcd_api.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifndef __DRIVER_IFACE_H
 #define __DRIVER_IFACE_H
 

--- a/xhci.device/include/devices/hcd_api.h
+++ b/xhci.device/include/devices/hcd_api.h
@@ -1,7 +1,7 @@
 #ifndef __DRIVER_IFACE_H
 #define __DRIVER_IFACE_H
 
-#include <compat.h>
+#include <emu_types.h>
 #include <exec/io.h>
 
 #pragma pack(2)

--- a/xhci.device/include/devices/hcd_api.h
+++ b/xhci.device/include/devices/hcd_api.h
@@ -1,7 +1,7 @@
 #ifndef __DRIVER_IFACE_H
 #define __DRIVER_IFACE_H
 
-#include <emu_types.h>
+#include <types.h>
 #include <exec/io.h>
 
 #pragma pack(2)

--- a/xhci.device/include/devices/hcd_api.h
+++ b/xhci.device/include/devices/hcd_api.h
@@ -52,8 +52,7 @@ struct USBIORequest
     u32 timeout;
     struct USBSetupPacket setup;
     u32 reserved3;
-    u16 reserved4;
-    u16 usb_frame;
+    u32 reserved4;
     u32 reserved5;
     u32 driver_private_flags;
     void *driver_private_dma_address;

--- a/xhci.device/include/xhci/ch9.h
+++ b/xhci.device/include/xhci/ch9.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 /*
  * This file holds USB constants and structures that are needed for
  * USB device APIs.  These are used by the USB device model, which is

--- a/xhci.device/include/xhci/ch9.h
+++ b/xhci.device/include/xhci/ch9.h
@@ -33,8 +33,8 @@
 #ifndef __LINUX_USB_CH9_H
 #define __LINUX_USB_CH9_H
 
-#include <emu_byteorder.h>
-#include <emu_types.h>
+#include <byteorder.h>
+#include <types.h>
 
 /*-------------------------------------------------------------------------*/
 
@@ -221,21 +221,21 @@
 /* USB_DT_DEVICE: Device descriptor */
 struct usb_device_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
+	u8 bLength;
+	u8 bDescriptorType;
 
 	__le16 bcdUSB;
-	__u8 bDeviceClass;
-	__u8 bDeviceSubClass;
-	__u8 bDeviceProtocol;
-	__u8 bMaxPacketSize0;
+	u8 bDeviceClass;
+	u8 bDeviceSubClass;
+	u8 bDeviceProtocol;
+	u8 bMaxPacketSize0;
 	__le16 idVendor;
 	__le16 idProduct;
 	__le16 bcdDevice;
-	__u8 iManufacturer;
-	__u8 iProduct;
-	__u8 iSerialNumber;
-	__u8 bNumConfigurations;
+	u8 iManufacturer;
+	u8 iProduct;
+	u8 iSerialNumber;
+	u8 bNumConfigurations;
 } __attribute__((packed));
 
 #define USB_DT_DEVICE_SIZE 18
@@ -277,15 +277,15 @@ struct usb_device_descriptor
  */
 struct usb_config_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
+	u8 bLength;
+	u8 bDescriptorType;
 
 	__le16 wTotalLength;
-	__u8 bNumInterfaces;
-	__u8 bConfigurationValue;
-	__u8 iConfiguration;
-	__u8 bmAttributes;
-	__u8 bMaxPower;
+	u8 bNumInterfaces;
+	u8 bConfigurationValue;
+	u8 iConfiguration;
+	u8 bmAttributes;
+	u8 bMaxPower;
 } __attribute__((packed));
 
 #define USB_DT_CONFIG_SIZE 9
@@ -301,10 +301,10 @@ struct usb_config_descriptor
 /* USB_DT_STRING: String descriptor information. */
 struct usb_string_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
+	u8 bLength;
+	u8 bDescriptorType;
 
-	__u8 bString[]; /* UTF-16LE encoded string */
+	u8 bString[]; /* UTF-16LE encoded string */
 } __attribute__((packed));
 
 /*-------------------------------------------------------------------------*/
@@ -312,16 +312,16 @@ struct usb_string_descriptor
 /* USB_DT_INTERFACE: Interface descriptor */
 struct usb_interface_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
+	u8 bLength;
+	u8 bDescriptorType;
 
-	__u8 bInterfaceNumber;
-	__u8 bAlternateSetting;
-	__u8 bNumEndpoints;
-	__u8 bInterfaceClass;
-	__u8 bInterfaceSubClass;
-	__u8 bInterfaceProtocol;
-	__u8 iInterface;
+	u8 bInterfaceNumber;
+	u8 bAlternateSetting;
+	u8 bNumEndpoints;
+	u8 bInterfaceClass;
+	u8 bInterfaceSubClass;
+	u8 bInterfaceProtocol;
+	u8 iInterface;
 } __attribute__((packed));
 
 #define USB_DT_INTERFACE_SIZE 9
@@ -331,18 +331,18 @@ struct usb_interface_descriptor
 /* USB_DT_ENDPOINT: Endpoint descriptor */
 struct usb_endpoint_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
+	u8 bLength;
+	u8 bDescriptorType;
 
-	__u8 bEndpointAddress;
-	__u8 bmAttributes;
+	u8 bEndpointAddress;
+	u8 bmAttributes;
 	__le16 wMaxPacketSize;
-	__u8 bInterval;
+	u8 bInterval;
 
 	/* NOTE:  these two are _only_ in audio endpoints. */
 	/* use USB_DT_ENDPOINT*_SIZE in bLength, not sizeof. */
-	__u8 bRefresh;
-	__u8 bSynchAddress;
+	u8 bRefresh;
+	u8 bSynchAddress;
 } __attribute__((packed));
 
 #define USB_DT_ENDPOINT_SIZE 7
@@ -507,7 +507,7 @@ static inline int usb_endpoint_is_isoc_out(
  */
 static inline int usb_endpoint_maxp(const struct usb_endpoint_descriptor *epd)
 {
-	return LE16(epd->wMaxPacketSize);
+	return le16(epd->wMaxPacketSize);
 }
 
 /**
@@ -519,7 +519,7 @@ static inline int usb_endpoint_maxp(const struct usb_endpoint_descriptor *epd)
 static inline int
 usb_endpoint_maxp_mult(const struct usb_endpoint_descriptor *epd)
 {
-	int maxp = LE16(epd->wMaxPacketSize);
+	int maxp = le16(epd->wMaxPacketSize);
 
 	return USB_EP_MAXP_MULT(maxp) + 1;
 }
@@ -535,11 +535,11 @@ static inline int usb_endpoint_interrupt_type(
 /* USB_DT_SS_ENDPOINT_COMP: SuperSpeed Endpoint Companion descriptor */
 struct usb_ss_ep_comp_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
+	u8 bLength;
+	u8 bDescriptorType;
 
-	__u8 bMaxBurst;
-	__u8 bmAttributes;
+	u8 bMaxBurst;
+	u8 bmAttributes;
 	__le16 wBytesPerInterval;
 } __attribute__((packed));
 
@@ -587,11 +587,11 @@ enum usb_device_speed
 /* USB 3.0 BOS descriptor */
 struct usb_bos_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
+	u8 bLength;
+	u8 bDescriptorType;
 
 	__le16 wTotalLength;
-	__u8 bNumDeviceCaps;
+	u8 bNumDeviceCaps;
 } __attribute__((packed));
 
 #define USB_CAP_DESC_USB20_EXTENSION 0x02
@@ -603,9 +603,9 @@ struct usb_bos_descriptor
 /* USB 2.0 Extension Capability descriptor */
 struct usb_2_0_extension_capability_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
-	__u8 bDevCapabilityType;
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bDevCapabilityType;
 
 	__le32 bmAttributes;
 } __attribute__((packed));
@@ -615,14 +615,14 @@ struct usb_2_0_extension_capability_descriptor
 /* SuperSpeed USB Device Capability descriptor */
 struct usb_ss_device_capability_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
-	__u8 bDevCapabilityType;
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bDevCapabilityType;
 
-	__u8 bmAttributes;
+	u8 bmAttributes;
 	__le16 wSpeedsSupported;
-	__u8 bFunctionalitySupport;
-	__u8 bU1DevExitLat;
+	u8 bFunctionalitySupport;
+	u8 bU1DevExitLat;
 	__le16 wU2DevExitLat;
 } __attribute__((packed));
 
@@ -635,22 +635,22 @@ struct usb_ss_device_capability_descriptor
 /* Container ID Capability descriptor */
 struct usb_container_id_capability_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
-	__u8 bDevCapabilityType;
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bDevCapabilityType;
 
-	__u8 bReserved;
-	__u8 ContainerID[16];
+	u8 bReserved;
+	u8 ContainerID[16];
 } __attribute__((packed));
 
 /* SuperSpeedPlus USB Device Capability descriptor */
 struct usb_ssp_device_capability_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
-	__u8 bDevCapabilityType;
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bDevCapabilityType;
 
-	__u8 bReserved;
+	u8 bReserved;
 	__le32 bmAttributes;
 	__le16 wFunctionalitySupport;
 	__le16 wReserved;
@@ -685,9 +685,9 @@ struct usb_ssp_device_capability_descriptor
 /* Precision Time Measurement Capability Descriptor */
 struct usb_ptm_capability_descriptor
 {
-	__u8 bLength;
-	__u8 bDescriptorType;
-	__u8 bDevCapabilityType;
+	u8 bLength;
+	u8 bDescriptorType;
+	u8 bDevCapabilityType;
 } __attribute__((packed));
 
 #endif /* __LINUX_USB_CH9_H */

--- a/xhci.device/include/xhci/ch9.h
+++ b/xhci.device/include/xhci/ch9.h
@@ -37,6 +37,7 @@
 
 #include <byteorder.h>
 #include <types.h>
+#include <bits.h>
 
 /*-------------------------------------------------------------------------*/
 
@@ -223,21 +224,21 @@
 /* USB_DT_DEVICE: Device descriptor */
 struct usb_device_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
+	__le8 bLength;
+	__le8 bDescriptorType;
 
 	__le16 bcdUSB;
-	u8 bDeviceClass;
-	u8 bDeviceSubClass;
-	u8 bDeviceProtocol;
-	u8 bMaxPacketSize0;
+	__le8 bDeviceClass;
+	__le8 bDeviceSubClass;
+	__le8 bDeviceProtocol;
+	__le8 bMaxPacketSize0;
 	__le16 idVendor;
 	__le16 idProduct;
 	__le16 bcdDevice;
-	u8 iManufacturer;
-	u8 iProduct;
-	u8 iSerialNumber;
-	u8 bNumConfigurations;
+	__le8 iManufacturer;
+	__le8 iProduct;
+	__le8 iSerialNumber;
+	__le8 bNumConfigurations;
 } __attribute__((packed));
 
 #define USB_DT_DEVICE_SIZE 18
@@ -279,34 +280,34 @@ struct usb_device_descriptor
  */
 struct usb_config_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
+	__le8 bLength;
+	__le8 bDescriptorType;
 
 	__le16 wTotalLength;
-	u8 bNumInterfaces;
-	u8 bConfigurationValue;
-	u8 iConfiguration;
-	u8 bmAttributes;
-	u8 bMaxPower;
+	__le8 bNumInterfaces;
+	__le8 bConfigurationValue;
+	__le8 iConfiguration;
+	__le8 bmAttributes;
+	__le8 bMaxPower;
 } __attribute__((packed));
 
 #define USB_DT_CONFIG_SIZE 9
 
 /* from config descriptor bmAttributes */
-#define USB_CONFIG_ATT_ONE (1 << 7)		  /* must be set */
-#define USB_CONFIG_ATT_SELFPOWER (1 << 6) /* self powered */
-#define USB_CONFIG_ATT_WAKEUP (1 << 5)	  /* can wakeup */
-#define USB_CONFIG_ATT_BATTERY (1 << 4)	  /* battery powered */
+#define USB_CONFIG_ATT_ONE BIT(7)		  /* must be set */
+#define USB_CONFIG_ATT_SELFPOWER BIT(6) /* self powered */
+#define USB_CONFIG_ATT_WAKEUP BIT(5)	  /* can wakeup */
+#define USB_CONFIG_ATT_BATTERY BIT(4)	  /* battery powered */
 
 /*-------------------------------------------------------------------------*/
 
 /* USB_DT_STRING: String descriptor information. */
 struct usb_string_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
+	__le8 bLength;
+	__le8 bDescriptorType;
 
-	u8 bString[]; /* UTF-16LE encoded string */
+	__le8 bString[]; /* UTF-16LE encoded string bytes */
 } __attribute__((packed));
 
 /*-------------------------------------------------------------------------*/
@@ -314,16 +315,16 @@ struct usb_string_descriptor
 /* USB_DT_INTERFACE: Interface descriptor */
 struct usb_interface_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
+	__le8 bLength;
+	__le8 bDescriptorType;
 
-	u8 bInterfaceNumber;
-	u8 bAlternateSetting;
-	u8 bNumEndpoints;
-	u8 bInterfaceClass;
-	u8 bInterfaceSubClass;
-	u8 bInterfaceProtocol;
-	u8 iInterface;
+	__le8 bInterfaceNumber;
+	__le8 bAlternateSetting;
+	__le8 bNumEndpoints;
+	__le8 bInterfaceClass;
+	__le8 bInterfaceSubClass;
+	__le8 bInterfaceProtocol;
+	__le8 iInterface;
 } __attribute__((packed));
 
 #define USB_DT_INTERFACE_SIZE 9
@@ -333,18 +334,18 @@ struct usb_interface_descriptor
 /* USB_DT_ENDPOINT: Endpoint descriptor */
 struct usb_endpoint_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
+	__le8 bLength;
+	__le8 bDescriptorType;
 
-	u8 bEndpointAddress;
-	u8 bmAttributes;
+	__le8 bEndpointAddress;
+	__le8 bmAttributes;
 	__le16 wMaxPacketSize;
-	u8 bInterval;
+	__le8 bInterval;
 
 	/* NOTE:  these two are _only_ in audio endpoints. */
 	/* use USB_DT_ENDPOINT*_SIZE in bLength, not sizeof. */
-	u8 bRefresh;
-	u8 bSynchAddress;
+	__le8 bRefresh;
+	__le8 bSynchAddress;
 } __attribute__((packed));
 
 #define USB_DT_ENDPOINT_SIZE 7
@@ -372,11 +373,11 @@ struct usb_endpoint_descriptor
 /* The USB 3.0 spec redefines bits 5:4 of bmAttributes as interrupt ep type. */
 #define USB_ENDPOINT_INTRTYPE 0x30
 #define USB_ENDPOINT_INTR_PERIODIC (0 << 4)
-#define USB_ENDPOINT_INTR_NOTIFICATION (1 << 4)
+#define USB_ENDPOINT_INTR_NOTIFICATION BIT(4)
 
 #define USB_ENDPOINT_SYNCTYPE 0x0c
 #define USB_ENDPOINT_SYNC_NONE (0 << 2)
-#define USB_ENDPOINT_SYNC_ASYNC (1 << 2)
+#define USB_ENDPOINT_SYNC_ASYNC BIT(2)
 #define USB_ENDPOINT_SYNC_ADAPTIVE (2 << 2)
 #define USB_ENDPOINT_SYNC_SYNC (3 << 2)
 
@@ -393,7 +394,7 @@ struct usb_endpoint_descriptor
  *
  * Returns @epd's number: 0 to 15.
  */
-static inline int usb_endpoint_num(const struct usb_endpoint_descriptor *epd)
+static inline u8 usb_endpoint_num(const struct usb_endpoint_descriptor *epd)
 {
 	return epd->bEndpointAddress & USB_ENDPOINT_NUMBER_MASK;
 }
@@ -507,7 +508,7 @@ static inline int usb_endpoint_is_isoc_out(
  *
  * Returns @epd's max packet
  */
-static inline int usb_endpoint_maxp(const struct usb_endpoint_descriptor *epd)
+static inline u16 usb_endpoint_maxp(const struct usb_endpoint_descriptor *epd)
 {
 	return le16(epd->wMaxPacketSize);
 }
@@ -518,15 +519,15 @@ static inline int usb_endpoint_maxp(const struct usb_endpoint_descriptor *epd)
  *
  * Return @epd's wMaxPacketSize[12:11] + 1
  */
-static inline int
+static inline u8
 usb_endpoint_maxp_mult(const struct usb_endpoint_descriptor *epd)
 {
-	int maxp = le16(epd->wMaxPacketSize);
+	u32 maxp = le16(epd->wMaxPacketSize);
 
-	return USB_EP_MAXP_MULT(maxp) + 1;
+	return (u8)(USB_EP_MAXP_MULT(maxp) + 1);
 }
 
-static inline int usb_endpoint_interrupt_type(
+static inline u32 usb_endpoint_interrupt_type(
 	const struct usb_endpoint_descriptor *epd)
 {
 	return epd->bmAttributes & USB_ENDPOINT_INTRTYPE;
@@ -537,11 +538,11 @@ static inline int usb_endpoint_interrupt_type(
 /* USB_DT_SS_ENDPOINT_COMP: SuperSpeed Endpoint Companion descriptor */
 struct usb_ss_ep_comp_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
+	__le8 bLength;
+	__le8 bDescriptorType;
 
-	u8 bMaxBurst;
-	u8 bmAttributes;
+	__le8 bMaxBurst;
+	__le8 bmAttributes;
 	__le16 wBytesPerInterval;
 } __attribute__((packed));
 
@@ -589,11 +590,11 @@ enum usb_device_speed
 /* USB 3.0 BOS descriptor */
 struct usb_bos_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
+	__le8 bLength;
+	__le8 bDescriptorType;
 
 	__le16 wTotalLength;
-	u8 bNumDeviceCaps;
+	__le8 bNumDeviceCaps;
 } __attribute__((packed));
 
 #define USB_CAP_DESC_USB20_EXTENSION 0x02
@@ -605,9 +606,9 @@ struct usb_bos_descriptor
 /* USB 2.0 Extension Capability descriptor */
 struct usb_2_0_extension_capability_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
-	u8 bDevCapabilityType;
+	__le8 bLength;
+	__le8 bDescriptorType;
+	__le8 bDevCapabilityType;
 
 	__le32 bmAttributes;
 } __attribute__((packed));
@@ -617,42 +618,42 @@ struct usb_2_0_extension_capability_descriptor
 /* SuperSpeed USB Device Capability descriptor */
 struct usb_ss_device_capability_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
-	u8 bDevCapabilityType;
+	__le8 bLength;
+	__le8 bDescriptorType;
+	__le8 bDevCapabilityType;
 
-	u8 bmAttributes;
+	__le8 bmAttributes;
 	__le16 wSpeedsSupported;
-	u8 bFunctionalitySupport;
-	u8 bU1DevExitLat;
+	__le8 bFunctionalitySupport;
+	__le8 bU1DevExitLat;
 	__le16 wU2DevExitLat;
 } __attribute__((packed));
 
-#define USB_SS_DEVICE_ATT_LATENCY_TOLERANCE_MESSAGES (1 << 1)
-#define USB_SS_DEVICE_LOWSPEED_SUPPORT (1 << 0)
-#define USB_SS_DEVICE_FULLSPEED_SUPPORT (1 << 1)
-#define USB_SS_DEVICE_HIGHSPEED_SUPPORT (1 << 2)
-#define USB_SS_DEVICE_SUPERSPEED_SUPPORT (1 << 3)
+#define USB_SS_DEVICE_ATT_LATENCY_TOLERANCE_MESSAGES BIT(1)
+#define USB_SS_DEVICE_LOWSPEED_SUPPORT BIT(0)
+#define USB_SS_DEVICE_FULLSPEED_SUPPORT BIT(1)
+#define USB_SS_DEVICE_HIGHSPEED_SUPPORT BIT(2)
+#define USB_SS_DEVICE_SUPERSPEED_SUPPORT BIT(3)
 
 /* Container ID Capability descriptor */
 struct usb_container_id_capability_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
-	u8 bDevCapabilityType;
+	__le8 bLength;
+	__le8 bDescriptorType;
+	__le8 bDevCapabilityType;
 
-	u8 bReserved;
-	u8 ContainerID[16];
+	__le8 bReserved;
+	__le8 ContainerID[16];
 } __attribute__((packed));
 
 /* SuperSpeedPlus USB Device Capability descriptor */
 struct usb_ssp_device_capability_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
-	u8 bDevCapabilityType;
+	__le8 bLength;
+	__le8 bDescriptorType;
+	__le8 bDevCapabilityType;
 
-	u8 bReserved;
+	__le8 bReserved;
 	__le32 bmAttributes;
 	__le16 wFunctionalitySupport;
 	__le16 wReserved;
@@ -676,20 +677,20 @@ struct usb_ssp_device_capability_descriptor
 #define USB_SSP_SUBLINK_LANE_SPEED_EXPONENT_MASK 0x3
 #define USB_SSP_SUBLINK_LANE_SPEED_EXPONENT_SHIFT 4
 #define USB_SSP_SUBLINK_TYPE_SYMMETRIC (0 << 6)
-#define USB_SSP_SUBLINK_TYPE_ASYMMETRIC (1 << 6)
+#define USB_SSP_SUBLINK_TYPE_ASYMMETRIC BIT(6)
 #define USB_SSP_SUBLINK_RECEIVE_MODE (0 << 7)
-#define USB_SSP_SUBLINK_TRANSMIT_MODE (1 << 7)
+#define USB_SSP_SUBLINK_TRANSMIT_MODE BIT(7)
 #define USB_SSP_SUBLINK_PROTOCOL_SUPERSPEED (0 << 14)
-#define USB_SSP_SUBLINK_PROTOCOL_SUPERSPEED_PLUS (1 << 14)
+#define USB_SSP_SUBLINK_PROTOCOL_SUPERSPEED_PLUS BIT(14)
 #define USB_SSP_SUBLINK_LANE_SPEED_MANTISSA_MASK 0xffff
 #define USB_SSP_SUBLINK_LANE_SPEED_MANTISSA_SHIFT 16
 
 /* Precision Time Measurement Capability Descriptor */
 struct usb_ptm_capability_descriptor
 {
-	u8 bLength;
-	u8 bDescriptorType;
-	u8 bDevCapabilityType;
+	__le8 bLength;
+	__le8 bDescriptorType;
+	__le8 bDevCapabilityType;
 } __attribute__((packed));
 
 #endif /* __LINUX_USB_CH9_H */

--- a/xhci.device/include/xhci/ch9.h
+++ b/xhci.device/include/xhci/ch9.h
@@ -33,7 +33,8 @@
 #ifndef __LINUX_USB_CH9_H
 #define __LINUX_USB_CH9_H
 
-#include <compat.h>
+#include <emu_byteorder.h>
+#include <emu_types.h>
 
 /*-------------------------------------------------------------------------*/
 

--- a/xhci.device/include/xhci/usb_defs.h
+++ b/xhci.device/include/xhci/usb_defs.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0+ */
+/* SPDX-License-Identifier: GPL-2.0-only */
 /*
  * (C) Copyright 2001
  * Denis Peter, MPL AG Switzerland

--- a/xhci.device/include/xhci/xhci-commands.h
+++ b/xhci.device/include/xhci/xhci-commands.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifndef XHCI_COMMANDS_H
 #define XHCI_COMMANDS_H
 

--- a/xhci.device/include/xhci/xhci-commands.h
+++ b/xhci.device/include/xhci/xhci-commands.h
@@ -10,12 +10,12 @@ union xhci_trb;
 void xhci_dispatch_command_event(struct xhci_ctrl *ctrl, union xhci_trb *event);
 void xhci_process_command_timeouts(struct xhci_ctrl *ctrl);
 
-void xhci_reset_ep(struct usb_device *udev, u32 ep_index);
-void xhci_stop_ring(struct usb_device *udev, u32 ep_index);
+void xhci_reset_ep(struct usb_device *udev, u8 ep_index);
+void xhci_stop_ring(struct usb_device *udev, u8 ep_index);
 void xhci_configure_endpoints(struct usb_device *udev, BOOL ctx_change, struct USBIORequest *req);
 void xhci_address_device(struct usb_device *udev, struct USBIORequest *req);
 void xhci_reset_device(struct usb_device *udev);
-void xhci_set_deq_pointer(struct usb_device *udev, u32 ep_index, u32 deq_ptr);
+void xhci_set_deq_pointer(struct usb_device *udev, u8 ep_index, u32 deq_ptr);
 void xhci_disable_slot(struct usb_device *udev);
 void xhci_enable_slot(struct usb_device *udev, struct USBIORequest *req);
 

--- a/xhci.device/include/xhci/xhci-context.h
+++ b/xhci.device/include/xhci/xhci-context.h
@@ -64,7 +64,7 @@ struct xhci_slot_ctx
 #define EP0_FLAG BIT(1)
 
 /* dev_info2 bitmasks */
-/* Max Exit Latency (ms) - worst case time to wake up all links in dev path */
+/* Max Exit Latency (µs) - worst case time to wake up all links in dev path */
 #define MAX_EXIT (0xffffU)
 /* Root hub port number that is needed to access the USB device */
 #define ROOT_HUB_PORT(p) (((u32)(p) & 0xffU) << 16)

--- a/xhci.device/include/xhci/xhci-context.h
+++ b/xhci.device/include/xhci/xhci-context.h
@@ -1,7 +1,7 @@
 #ifndef __XHCI_CONTEXT_H
 #define __XHCI_CONTEXT_H
 
-#include <compat.h>
+#include <emu_types.h>
 
 /**
  * struct xhci_container_ctx

--- a/xhci.device/include/xhci/xhci-context.h
+++ b/xhci.device/include/xhci/xhci-context.h
@@ -1,7 +1,7 @@
 #ifndef __XHCI_CONTEXT_H
 #define __XHCI_CONTEXT_H
 
-#include <emu_types.h>
+#include <types.h>
 
 /**
  * struct xhci_container_ctx

--- a/xhci.device/include/xhci/xhci-context.h
+++ b/xhci.device/include/xhci/xhci-context.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifndef __XHCI_CONTEXT_H
 #define __XHCI_CONTEXT_H
 

--- a/xhci.device/include/xhci/xhci-context.h
+++ b/xhci.device/include/xhci/xhci-context.h
@@ -4,6 +4,7 @@
 #define __XHCI_CONTEXT_H
 
 #include <types.h>
+#include <bits.h>
 
 /**
  * struct xhci_container_ctx
@@ -16,11 +17,11 @@
  */
 struct xhci_container_ctx
 {
-	unsigned type;
+	u32 type;
 #define XHCI_CTX_TYPE_DEVICE 0x1
 #define XHCI_CTX_TYPE_INPUT 0x2
 
-	int size;
+	u32 size;
 	u8 *bytes;
 };
 
@@ -47,31 +48,31 @@ struct xhci_slot_ctx
 
 /* dev_info bitmasks */
 /* Route String - 0:19 */
-#define ROUTE_STRING_MASK (0xfffff)
+#define ROUTE_STRING_MASK (0xfffffU)
 /* Device speed - values defined by PORTSC Device Speed field - 20:23 */
-#define DEV_SPEED (0xf << 20)
+#define DEV_SPEED (0xfU << 20)
 /* bit 24 reserved */
 /* Is this LS/FS device connected through a HS hub? - bit 25 */
-#define DEV_MTT (0x1 << 25)
+#define DEV_MTT (0x1U << 25)
 /* Set if the device is a hub - bit 26 */
-#define DEV_HUB (0x1 << 26)
+#define DEV_HUB (0x1U << 26)
 /* Index of the last valid endpoint context in this device context - 27:31 */
-#define LAST_CTX_MASK (0x1f << 27)
-#define LAST_CTX(p) ((p) << 27)
+#define LAST_CTX_MASK (0x1fU << 27)
+#define LAST_CTX(p) ((u32)(p) << 27)
 #define LAST_CTX_TO_EP_NUM(p) (((p) >> 27) - 1)
-#define SLOT_FLAG (1 << 0)
-#define EP0_FLAG (1 << 1)
+#define SLOT_FLAG BIT(0)
+#define EP0_FLAG BIT(1)
 
 /* dev_info2 bitmasks */
 /* Max Exit Latency (ms) - worst case time to wake up all links in dev path */
-#define MAX_EXIT (0xffff)
+#define MAX_EXIT (0xffffU)
 /* Root hub port number that is needed to access the USB device */
-#define ROOT_HUB_PORT(p) (((p) & 0xff) << 16)
-#define ROOT_HUB_PORT_MASK (0xff)
+#define ROOT_HUB_PORT(p) (((u32)(p) & 0xffU) << 16)
+#define ROOT_HUB_PORT_MASK (0xffU)
 #define ROOT_HUB_PORT_SHIFT (16)
 #define DEVINFO_TO_ROOT_HUB_PORT(p) (((p) >> 16) & 0xff)
 /* Maximum number of ports under a hub device */
-#define XHCI_MAX_PORTS(p) (((p) & 0xff) << 24)
+#define XHCI_MAX_PORTS(p) (((u32)(p) & 0xffU) << 24)
 
 /* tt_info bitmasks */
 /*
@@ -79,21 +80,21 @@ struct xhci_slot_ctx
  * The Slot ID of the hub that isolates the high speed signaling from
  * this low or full-speed device.  '0' if attached to root hub port.
  */
-#define TT_SLOT(p) (((p) & 0xff) << 0)
+#define TT_SLOT(p) (((u32)(p) & 0xffU) << 0)
 /*
  * The number of the downstream facing port of the high-speed hub
  * '0' if the device is not low or full speed.
  */
-#define TT_PORT(p) (((p) & 0xff) << 8)
-#define TT_THINK_TIME(p) (((p) & 0x3) << 16)
+#define TT_PORT(p) (((u32)(p) & 0xffU) << 8)
+#define TT_THINK_TIME(p) (((u32)(p) & 0x3U) << 16)
 
 /* dev_state bitmasks */
 /* USB device address - assigned by the HC */
-#define DEV_ADDR_MASK (0xff)
+#define DEV_ADDR_MASK (0xffU)
 /* bits 8:26 reserved */
 /* Slot state */
-#define SLOT_STATE (0x1f << 27)
-#define GET_SLOT_STATE(p) (((p) & (0x1f << 27)) >> 27)
+#define SLOT_STATE (0x1fU << 27)
+#define GET_SLOT_STATE(p) (((p) & (0x1fU << 27)) >> 27)
 
 #define SLOT_STATE_DISABLED 0
 #define SLOT_STATE_ENABLED SLOT_STATE_DISABLED
@@ -146,28 +147,28 @@ struct xhci_ep_ctx
 #define EP_STATE_STOPPED 3
 #define EP_STATE_ERROR 4
 /* Mult - Max number of burtst within an interval, in EP companion desc. */
-#define EP_MULT(p) (((p) & 0x3) << 8)
+#define EP_MULT(p) (((u32)(p) & 0x3U) << 8)
 #define CTX_TO_EP_MULT(p) (((p) >> 8) & 0x3)
 /* bits 10:14 are Max Primary Streams */
 /* bit 15 is Linear Stream Array */
 /* Interval - period between requests to an endpoint - 125u increments. */
-#define EP_INTERVAL(p) (((p) & 0xff) << 16)
+#define EP_INTERVAL(p) (((u32)(p) & 0xffU) << 16)
 #define EP_INTERVAL_TO_UFRAMES(p) (1 << (((p) >> 16) & 0xff))
 #define CTX_TO_EP_INTERVAL(p) (((p) >> 16) & 0xff)
-#define EP_MAXPSTREAMS_MASK (0x1f << 10)
-#define EP_MAXPSTREAMS(p) (((p) << 10) & EP_MAXPSTREAMS_MASK)
+#define EP_MAXPSTREAMS_MASK (0x1fU << 10)
+#define EP_MAXPSTREAMS(p) (((u32)(p) << 10) & EP_MAXPSTREAMS_MASK)
 /* Endpoint is set up with a Linear Stream Array (vs. Secondary Stream Array) */
-#define EP_HAS_LSA (1 << 15)
+#define EP_HAS_LSA BIT(15)
 
 /* ep_info2 bitmasks */
 /*
  * Force Event - generate transfer events for all TRBs for this endpoint
  * This will tell the HC to ignore the IOC and ISP flags (for debugging only).
  */
-#define FORCE_EVENT (0x1)
-#define ERROR_COUNT(p) (((p) & 0x3) << 1)
+#define FORCE_EVENT (0x1U)
+#define ERROR_COUNT(p) (((u32)(p) & 0x3U) << 1)
 #define CTX_TO_EP_TYPE(p) (((p) >> 3) & 0x7)
-#define EP_TYPE(p) ((p) << 3)
+#define EP_TYPE(p) ((u32)(p) << 3)
 #define ISOC_OUT_EP 1
 #define BULK_OUT_EP 2
 #define INT_OUT_EP 3
@@ -177,7 +178,7 @@ struct xhci_ep_ctx
 #define INT_IN_EP 7
 /* bit 6 reserved */
 /* bit 7 is Host Initiate Disable - for disabling stream selection */
-#define MAX_BURST(p) (((p) & 0xff) << 8)
+#define MAX_BURST(p) (((u32)(p) & 0xffU) << 8)
 #define CTX_TO_MAX_BURST(p) (((p) >> 8) & 0xff)
 #define MAX_PACKET(p) (((p) & 0xffff) << 16)
 #define MAX_PACKET_MASK (0xffff)
@@ -195,7 +196,7 @@ struct xhci_ep_ctx
 #define CTX_TO_MAX_ESIT_PAYLOAD(p) (((p) >> 16) & 0xffff)
 
 /* deq bitmasks */
-#define EP_CTX_CYCLE_MASK (1 << 0)
+#define EP_CTX_CYCLE_MASK BIT(0)
 
 /* reserved[0] bitmasks, MediaTek xHCI used */
 #define EP_BPKTS(p) (((p) & 0x7f) << 0)
@@ -217,19 +218,19 @@ struct xhci_input_control_ctx
 	__le32 rsvd2[6];
 };
 
-struct xhci_container_ctx *xhci_alloc_container_ctx(struct xhci_ctrl *ctrl, int type);
+struct xhci_container_ctx *xhci_alloc_container_ctx(struct xhci_ctrl *ctrl, u32 type);
 void xhci_free_container_ctx(struct xhci_ctrl *ctrl, struct xhci_container_ctx *ctx);
 
 u32 xhci_get_hardware_address(struct usb_device *udev);
-u64 xhci_get_endpoint_deq_ptr(struct usb_device *udev, unsigned int ep_index);
+u64 xhci_get_endpoint_deq_ptr(struct usb_device *udev, u8 ep_index);
 
 void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *udev);
 
-void xhci_update_maxpacket(struct usb_device *udev, unsigned int max_packet_size);
-int xhci_set_configuration(struct usb_device *udev, int config_value);
-int xhci_set_interface(struct usb_device *udev, unsigned int iface_number, unsigned int alt_setting);
+void xhci_update_maxpacket(struct usb_device *udev, u16 max_packet_size);
+s8 xhci_set_configuration(struct usb_device *udev, u32 config_value);
+s8 xhci_set_interface(struct usb_device *udev, u8 iface_number, u8 alt_setting);
 
-void xhci_dump_ep_ctx(const char *tag, struct usb_device *udev, UBYTE ep_index);
+void xhci_dump_ep_ctx(const char *tag, struct usb_device *udev, u8 ep_index);
 void xhci_dump_slot_ctx(const char *tag, struct usb_device *udev, BOOL in_ctx);
 
 #endif /* __XHCI_CONTEXT_H */

--- a/xhci.device/include/xhci/xhci-descriptors.h
+++ b/xhci.device/include/xhci/xhci-descriptors.h
@@ -2,7 +2,7 @@
 #define __XHCI_DESCRIPTORS_H__
 
 #include <devices/hcd_api.h>
-#include <compat.h>
+#include <emu_types.h>
 #include <xhci/ch9.h>
 
 struct usb_device;

--- a/xhci.device/include/xhci/xhci-descriptors.h
+++ b/xhci.device/include/xhci/xhci-descriptors.h
@@ -9,39 +9,39 @@
 
 struct usb_device;
 
-inline int xhci_ep_index_from_parts(UWORD endpoint, UWORD direction)
+inline u8 xhci_ep_index_from_parts(u16 endpoint, u16 direction)
 {
-    UBYTE ep = endpoint & 0x0F;
+    u8 ep = endpoint & 0x0F;
     if (ep == 0)
         return 0;
     BOOL dir_in = (direction == DIRECTION_IN);
-    return (ep << 1) - (dir_in ? 0 : 1);
+    return (u8)(((u32)ep << 1) - (u32)(dir_in ? 0 : 1));
 }
 
-inline static int xhci_address_to_ep_index(const struct usb_endpoint_descriptor *descriptor)
+inline static u8 xhci_address_to_ep_index(const struct usb_endpoint_descriptor *descriptor)
 {
-    int ep_num = usb_endpoint_num(descriptor);
+    u32 ep_num = usb_endpoint_num(descriptor);
     if (ep_num == 0)
         return 0;
-    return (ep_num << 1) - (usb_endpoint_dir_in(descriptor) ? 0 : 1);
+    return (u8)((ep_num << 1) - (u32)(usb_endpoint_dir_in(descriptor) ? 0 : 1));
 }
 
 struct usb_config *xhci_find_config(struct usb_device *udev, int config_value);
-struct usb_interface *xhci_find_interface(struct usb_config *cfg, unsigned int iface_number);
-struct usb_interface_altsetting *xhci_find_altsetting(struct usb_interface *iface, unsigned int alt_setting);
+struct usb_interface *xhci_find_interface(struct usb_config *cfg, u32 iface_number);
+struct usb_interface_altsetting *xhci_find_altsetting(struct usb_interface *iface, u8 alt_setting);
 
 struct usb_interface_altsetting *xhci_select_active_alt(struct usb_interface *iface);
 
-unsigned int compute_max_ep_flag(const struct usb_config *cfg);
-u32 xhci_collect_ep_mask(const struct usb_interface_altsetting *alt, unsigned int *max_flag);
-u32 xhci_collect_config_masks(const struct usb_config *cfg, unsigned int limit, unsigned int *max_flag);
+u32 compute_max_ep_flag(const struct usb_config *cfg);
+u32 xhci_collect_ep_mask(const struct usb_interface_altsetting *alt, u32 *max_flag);
+u32 xhci_collect_config_masks(const struct usb_config *cfg, u32 limit, u32 *max_flag);
 
-unsigned int xhci_get_ep_index(struct usb_endpoint_descriptor *desc);
-unsigned int xhci_get_endpoint_interval(struct usb_device *udev, struct usb_endpoint_descriptor *endpt_desc);
-u32 xhci_get_endpoint_mult(struct usb_device *udev, struct usb_endpoint_descriptor *endpt_desc, struct usb_ss_ep_comp_descriptor *ss_ep_comp_desc);
-u32 xhci_get_endpoint_max_burst(struct usb_device *udev, struct usb_endpoint_descriptor *endpt_desc, struct usb_ss_ep_comp_descriptor *ss_ep_comp_desc);
+u8 xhci_get_ep_index(struct usb_endpoint_descriptor *desc);
+u8 xhci_get_endpoint_interval(struct usb_device *udev, struct usb_endpoint_descriptor *endpt_desc);
+u8 xhci_get_endpoint_mult(struct usb_device *udev, struct usb_endpoint_descriptor *endpt_desc, struct usb_ss_ep_comp_descriptor *ss_ep_comp_desc);
+u8 xhci_get_endpoint_max_burst(struct usb_device *udev, struct usb_endpoint_descriptor *endpt_desc, struct usb_ss_ep_comp_descriptor *ss_ep_comp_desc);
 u32 xhci_get_max_esit_payload(struct usb_device *udev, struct usb_endpoint_descriptor *endpt_desc, struct usb_ss_ep_comp_descriptor *ss_ep_comp_desc);
 
-void xhci_dump_config(const char *tag, const struct usb_config *cfg, UBYTE addr);
+void xhci_dump_config(const char *tag, const struct usb_config *cfg, u16 addr);
 
 #endif /* __XHCI_DESCRIPTORS_H__ */

--- a/xhci.device/include/xhci/xhci-descriptors.h
+++ b/xhci.device/include/xhci/xhci-descriptors.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifndef __XHCI_DESCRIPTORS_H__
 #define __XHCI_DESCRIPTORS_H__
 

--- a/xhci.device/include/xhci/xhci-descriptors.h
+++ b/xhci.device/include/xhci/xhci-descriptors.h
@@ -2,7 +2,7 @@
 #define __XHCI_DESCRIPTORS_H__
 
 #include <devices/hcd_api.h>
-#include <emu_types.h>
+#include <types.h>
 #include <xhci/ch9.h>
 
 struct usb_device;

--- a/xhci.device/include/xhci/xhci-endpoint.h
+++ b/xhci.device/include/xhci/xhci-endpoint.h
@@ -21,15 +21,15 @@ enum ep_state
 struct usb_device;
 struct ep_context;
 
-BOOL xhci_ep_create_context(struct usb_device *udev, int ep_index, int max_packet_size, APTR memoryPool);
-void xhci_ep_destroy_contexts(struct usb_device *udev, BYTE reply_code);
-struct ep_context *xhci_ep_get_context_for_index(struct usb_device *udev, int ep_index);
+BOOL xhci_ep_create_context(struct usb_device *udev, u8 ep_index, u32 max_packet_size, APTR memoryPool);
+void xhci_ep_destroy_contexts(struct usb_device *udev, s8 reply_code);
+struct ep_context *xhci_ep_get_context_for_index(struct usb_device *udev, u8 ep_index);
 
-void xhci_ep_set_max_packet_size(struct ep_context *ep_ctx, int max_packet_size);
+void xhci_ep_set_max_packet_size(struct ep_context *ep_ctx, u32 max_packet_size);
 
 void xhci_ep_set_failed(struct ep_context *ep_ctx);
 void xhci_ep_set_idle(struct ep_context *ep_ctx);
-void xhci_ep_set_receiving(struct ep_context *ep_ctx, struct USBIORequest *req, dma_addr_t *trb_addrs, ULONG timeout_ms, unsigned int trb_count);
+void xhci_ep_set_receiving(struct ep_context *ep_ctx, struct USBIORequest *req, dma_addr_t *trb_addrs, u32 timeout_ms, u32 trb_count);
 void xhci_ep_set_receiving_control_short(struct ep_context *ep_ctx);
 void xhci_ep_set_resetting(struct ep_context *ep_ctx);
 void xhci_ep_set_aborting(struct ep_context *ep_ctx);
@@ -41,24 +41,24 @@ void xhci_ep_process_stop(struct ep_context *ep_ctx, dma_addr_t *deq_ptr);
 
 BOOL xhci_ep_is_expired(struct ep_context *ep_ctx);
 enum ep_state xhci_ep_get_state(struct ep_context *ep_ctx);
-int xhci_ep_get_ep_index(struct ep_context *ep_ctx);
-int xhci_ep_get_active_trb_count(struct ep_context *ep_ctx);
+u8 xhci_ep_get_ep_index(struct ep_context *ep_ctx);
+u32 xhci_ep_get_active_trb_count(struct ep_context *ep_ctx);
 struct xhci_ring *xhci_ep_get_ring(struct ep_context *ep_ctx);
 
 struct USBIORequest *xhci_ep_get_by_trb(struct ep_context *ep_ctx, dma_addr_t trb_addr);
 BOOL xhci_ep_has_request(struct ep_context *ep_ctx, struct USBIORequest *io);
 void xhci_ep_enqueue(struct ep_context *ep_ctx, struct USBIORequest *io);
-void xhci_ep_flush(struct ep_context *ep_ctx, BYTE reply_code);
+void xhci_ep_flush(struct ep_context *ep_ctx, s8 reply_code);
 
 /* RT ISO functions */
-BYTE xhci_ep_rt_iso_add_handler(struct ep_context *ep_ctx, struct USBIORequest *req);
-BYTE xhci_ep_rt_iso_rem_handler(struct ep_context *ep_ctx, struct USBIORequest *req);
+s8 xhci_ep_rt_iso_add_handler(struct ep_context *ep_ctx, struct USBIORequest *req);
+s8 xhci_ep_rt_iso_rem_handler(struct ep_context *ep_ctx, struct USBIORequest *req);
 
-BYTE xhci_ep_rt_iso_start(struct ep_context *ep_ctx);
-BYTE xhci_ep_rt_iso_stop(struct ep_context *ep_ctx, struct USBIORequest *req);
+s8 xhci_ep_rt_iso_start(struct ep_context *ep_ctx);
+s8 xhci_ep_rt_iso_stop(struct ep_context *ep_ctx, struct USBIORequest *req);
 
-void xhci_ep_rt_iso_in(struct ep_context *ep_ctx, struct USBIORequest *req, ULONG act_len);
-void xhci_ep_rt_iso_out(struct ep_context *ep_ctx, struct USBIORequest *req, ULONG act_len);
+void xhci_ep_rt_iso_in(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len);
+void xhci_ep_rt_iso_out(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len);
 
 void xhci_ep_schedule_rt_iso(struct ep_context *ep_ctx);
 

--- a/xhci.device/include/xhci/xhci-endpoint.h
+++ b/xhci.device/include/xhci/xhci-endpoint.h
@@ -21,12 +21,14 @@ enum ep_state
 struct usb_device;
 struct ep_context;
 
-BOOL xhci_ep_create_context(struct usb_device *udev, u8 ep_index, u32 max_packet_size, APTR memoryPool);
+BOOL xhci_ep_create_context(struct usb_device *udev, u8 ep_index, u32 max_packet_size, u8 max_burst, APTR memoryPool);
 void xhci_ep_set_rt_interval(struct ep_context *ep_ctx, u8 interval);
 void xhci_ep_destroy_contexts(struct usb_device *udev, s8 reply_code);
 struct ep_context *xhci_ep_get_context_for_index(struct usb_device *udev, u8 ep_index);
 
 void xhci_ep_set_max_packet_size(struct ep_context *ep_ctx, u32 max_packet_size);
+u32 xhci_ep_get_max_packet_size(struct ep_context *ep_ctx);
+u8 xhci_ep_get_max_burst(struct ep_context *ep_ctx);
 
 void xhci_ep_set_failed(struct ep_context *ep_ctx);
 void xhci_ep_set_idle(struct ep_context *ep_ctx);

--- a/xhci.device/include/xhci/xhci-endpoint.h
+++ b/xhci.device/include/xhci/xhci-endpoint.h
@@ -65,5 +65,7 @@ void xhci_ep_rt_iso_out(struct ep_context *ep_ctx, struct USBIORequest *req, u32
 
 void xhci_ep_schedule_rt_iso(struct ep_context *ep_ctx);
 
+/* Free a staging IN buffer back to the endpoint's per-endpoint slab. */
+void xhci_ep_free_rt_iso_buffer(struct ep_context *ep_ctx, APTR data_buffer);
 
 #endif /* __XHCI_ENDPOINT_H__ */

--- a/xhci.device/include/xhci/xhci-endpoint.h
+++ b/xhci.device/include/xhci/xhci-endpoint.h
@@ -22,6 +22,7 @@ struct usb_device;
 struct ep_context;
 
 BOOL xhci_ep_create_context(struct usb_device *udev, u8 ep_index, u32 max_packet_size, APTR memoryPool);
+void xhci_ep_set_rt_interval(struct ep_context *ep_ctx, u8 interval);
 void xhci_ep_destroy_contexts(struct usb_device *udev, s8 reply_code);
 struct ep_context *xhci_ep_get_context_for_index(struct usb_device *udev, u8 ep_index);
 
@@ -57,8 +58,8 @@ s8 xhci_ep_rt_iso_rem_handler(struct ep_context *ep_ctx, struct USBIORequest *re
 s8 xhci_ep_rt_iso_start(struct ep_context *ep_ctx);
 s8 xhci_ep_rt_iso_stop(struct ep_context *ep_ctx, struct USBIORequest *req);
 
-void xhci_ep_rt_iso_in(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len);
-void xhci_ep_rt_iso_out(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len);
+void xhci_ep_rt_iso_in(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len, u16 rt_frame);
+void xhci_ep_rt_iso_out(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len, u16 rt_frame);
 
 void xhci_ep_schedule_rt_iso(struct ep_context *ep_ctx);
 

--- a/xhci.device/include/xhci/xhci-endpoint.h
+++ b/xhci.device/include/xhci/xhci-endpoint.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifndef __XHCI_ENDPOINT_H__
 #define __XHCI_ENDPOINT_H__
 

--- a/xhci.device/include/xhci/xhci-events.h
+++ b/xhci.device/include/xhci/xhci-events.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifndef _XHCI_EVENTS_H_
 #define _XHCI_EVENTS_H_
 

--- a/xhci.device/include/xhci/xhci-ring.h
+++ b/xhci.device/include/xhci/xhci-ring.h
@@ -308,6 +308,7 @@ struct xhci_ring *xhci_ring_alloc(struct xhci_ctrl *ctrl, u32 num_segs,
 void xhci_ring_free(struct xhci_ctrl *ctrl, struct xhci_ring *ring);								  
 
 s8 xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell);
+BOOL xhci_ring_has_room(struct ep_context *ep_ctx, u32 needed_trbs);
 void xhci_ring_giveback(struct usb_device *udev, struct ep_context *ep_ctx);
 
 void xhci_ring_acknowledge_event(struct xhci_ctrl *ctrl);

--- a/xhci.device/include/xhci/xhci-ring.h
+++ b/xhci.device/include/xhci/xhci-ring.h
@@ -82,11 +82,10 @@ typedef enum
 	COMP_CMD_ABORT, /* 25 */
 	/* Stopped - transfer was terminated by a stop endpoint command */
 	COMP_STOP, /* 26 */
-	/* Same as COMP_EP_STOPPED, but the transferred length in the event
-	 * is invalid */
+	/* Same as COMP_STOP, but the transferred length in the event is invalid */
 	COMP_STOP_INVAL, /* 27*/
-	/* Control Abort Error - Debug Capability - control pipe aborted */
-	COMP_DBG_ABORT, /* 28 */
+	/* Same as COMP_STOP, but the transfer was stopped after Short Packet condition */
+	COMP_STOP_SHORT, /* 28 */
 	/* Max Exit Latency Too Large Error */
 	COMP_MEL_ERR, /* 29 */
 	/* TRB type 30 reserved */

--- a/xhci.device/include/xhci/xhci-ring.h
+++ b/xhci.device/include/xhci/xhci-ring.h
@@ -3,8 +3,8 @@
 
 #include <exec/types.h>
 #include <devices/hcd_api.h>
-#include <emu_bits.h>
-#include <emu_byteorder.h>
+#include <bits.h>
+#include <byteorder.h>
 
 struct xhci_transfer_event
 {
@@ -290,10 +290,10 @@ typedef enum
 
 #define TRB_TYPE_LINK(x) (((x) & TRB_TYPE_BITMASK) == TRB_TYPE(TRB_LINK))
 /* Above, but for __le32 types -- can avoid work by swapping constants: */
-#define TRB_TYPE_LINK_LE32(x) (((x) & LE32(TRB_TYPE_BITMASK)) == \
-							   LE32(TRB_TYPE(TRB_LINK)))
-#define TRB_TYPE_NOOP_LE32(x) (((x) & LE32(TRB_TYPE_BITMASK)) == \
-							   LE32(TRB_TYPE(TRB_TR_NOOP)))
+#define TRB_TYPE_LINK_LE32(x) (((x) & le32(TRB_TYPE_BITMASK)) == \
+							   le32(TRB_TYPE(TRB_LINK)))
+#define TRB_TYPE_NOOP_LE32(x) (((x) & le32(TRB_TYPE_BITMASK)) == \
+							   le32(TRB_TYPE(TRB_TR_NOOP)))
 
 struct xhci_ctrl;
 struct xhci_erst;

--- a/xhci.device/include/xhci/xhci-ring.h
+++ b/xhci.device/include/xhci/xhci-ring.h
@@ -3,7 +3,8 @@
 
 #include <exec/types.h>
 #include <devices/hcd_api.h>
-#include <compat.h>
+#include <emu_bits.h>
+#include <emu_byteorder.h>
 
 struct xhci_transfer_event
 {

--- a/xhci.device/include/xhci/xhci-ring.h
+++ b/xhci.device/include/xhci/xhci-ring.h
@@ -305,8 +305,10 @@ struct usb_device;
 struct ep_context;
 
 struct xhci_ring *xhci_ring_alloc(struct xhci_ctrl *ctrl, u32 num_segs,
-							  BOOL link_trbs, BOOL is_event_ring, u8 ep_index, u32 max_packet_size);
-void xhci_ring_free(struct xhci_ctrl *ctrl, struct xhci_ring *ring);								  
+							BOOL link_trbs, BOOL is_event_ring, u8 ep_index, u32 max_packet_size);
+void xhci_ring_free(struct xhci_ctrl *ctrl, struct xhci_ring *ring);
+
+BOOL xhci_ring_grow(struct xhci_ctrl *ctrl, struct xhci_ring *ring, u32 num_new_segs);
 
 s8 xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell);
 s8 xhci_ring_enqueue_td_at_frame(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell, u16 frame);

--- a/xhci.device/include/xhci/xhci-ring.h
+++ b/xhci.device/include/xhci/xhci-ring.h
@@ -19,13 +19,13 @@ struct xhci_transfer_event
 
 /* Transfer event TRB length bit mask */
 /* bits 0:23 */
-#define EVENT_TRB_LEN(p) ((p) & 0xffffff)
+#define EVENT_TRB_LEN(p) ((p) & 0xffffffU)
 
 /** Transfer Event bit fields **/
-#define TRB_TO_EP_ID(p) (((p) >> 16) & 0x1f)
+#define TRB_TO_EP_ID(p) (((p) >> 16) & 0x1fU)
 
 /* Completion Code - only applicable for some types of TRBs */
-#define COMP_CODE_MASK (0xff << 24)
+#define COMP_CODE_MASK (0xffU << 24)
 #define COMP_CODE_SHIFT (24)
 #define GET_COMP_CODE(p) (((p) & COMP_CODE_MASK) >> 24)
 
@@ -108,72 +108,72 @@ typedef enum
 /* flags bitmasks */
 /* bits 16:23 are the virtual function ID */
 /* bits 24:31 are the slot ID */
-#define TRB_TO_SLOT_ID(p) (((p) & (0xff << 24)) >> 24)
+#define TRB_TO_SLOT_ID(p) (((p) & (0xffU << 24)) >> 24)
 #define TRB_TO_SLOT_ID_SHIFT (24)
-#define TRB_TO_SLOT_ID_MASK (0xff << TRB_TO_SLOT_ID_SHIFT)
-#define SLOT_ID_FOR_TRB(p) (((p) & 0xff) << 24)
-#define SLOT_ID_FOR_TRB_MASK (0xff)
+#define TRB_TO_SLOT_ID_MASK (0xffU << TRB_TO_SLOT_ID_SHIFT)
+#define SLOT_ID_FOR_TRB(p) (((u32)(p) & 0xffU) << 24)
+#define SLOT_ID_FOR_TRB_MASK (0xffU)
 #define SLOT_ID_FOR_TRB_SHIFT (24)
 
 /* Stop Endpoint TRB - ep_index to endpoint ID for this TRB */
-#define TRB_TO_EP_INDEX(p) ((((p) & (0x1f << 16)) >> 16) - 1)
-#define TRB_TO_ENDPOINT(p) ((((p) & (0x1f << 16)) >> 17))
-#define EP_ID_FOR_TRB(p) ((((p) + 1) & 0x1f) << 16)
+#define TRB_TO_EP_INDEX(p) (u8)((((p) & (0x1fU << 16)) >> 16) - 1U)
+#define TRB_TO_ENDPOINT(p) ((((p) & (0x1fU << 16)) >> 17))
+#define EP_ID_FOR_TRB(p) ((((u32)(p) + 1U) & 0x1fU) << 16)
 
-#define SUSPEND_PORT_FOR_TRB(p) (((p) & 1) << 23)
-#define TRB_TO_SUSPEND_PORT(p) (((p) & (1 << 23)) >> 23)
+#define SUSPEND_PORT_FOR_TRB(p) (((u32)(p) & 1U) << 23)
+#define TRB_TO_SUSPEND_PORT(p) (((p) & BIT(23)) >> 23)
 #define LAST_EP_INDEX 30
 
 /* Set TR Dequeue Pointer command TRB fields */
-#define TRB_TO_STREAM_ID(p) ((((p) & (0xffff << 16)) >> 16))
-#define STREAM_ID_FOR_TRB(p) ((((p)) & 0xffff) << 16)
+#define TRB_TO_STREAM_ID(p) ((((p) & (0xffffU << 16)) >> 16))
+#define STREAM_ID_FOR_TRB(p) (((u32)(p) & 0xffffU) << 16)
 
 /* Port Status Change Event TRB fields */
 /* Port ID - bits 31:24 */
-#define GET_PORT_ID(p) (((p) & (0xff << 24)) >> 24)
+#define GET_PORT_ID(p) (((p) & (0xffU << 24)) >> 24)
 #define PORT_ID_SHIFT (24)
-#define PORT_ID_MASK (0xff << PORT_ID_SHIFT)
+#define PORT_ID_MASK (0xffU << PORT_ID_SHIFT)
 
 /* Normal TRB fields */
 /* transfer_len bitmasks - bits 0:16 */
 #define TRB_LEN(p) ((p) & 0x1ffff)
 /* TD Size, packets remaining in this TD, bits 21:17 (5 bits, so max 31) */
-#define TRB_TD_SIZE(p) (min((p), (u32)31) << 17)
+#define TRB_TD_SIZE(p) (((p) > 31U ? 31U : (u32)(p)) << 17)
 /* Interrupter Target - which MSI-X vector to target the completion event at */
-#define TRB_INTR_TARGET(p) (((p) & 0x3ff) << 22)
+#define TRB_INTR_TARGET(p) (((p) & 0x3ffU) << 22)
 #define GET_INTR_TARGET(p) (((p) >> 22) & 0x3ff)
 #define TRB_TBC(p) (((p) & 0x3) << 7)
 #define TRB_TLBPC(p) (((p) & 0xf) << 16)
 
 /* Cycle bit - indicates TRB ownership by HC or HCD */
-#define TRB_CYCLE (1 << 0)
+#define TRB_CYCLE BIT(0)
 /*
  * Force next event data TRB to be evaluated before task switch.
  * Used to pass OS data back after a TD completes.
  */
-#define TRB_ENT (1 << 1)
+#define TRB_ENT BIT(1)
 /* Interrupt on short packet */
-#define TRB_ISP (1 << 2)
+#define TRB_ISP BIT(2)
 /* Set PCIe no snoop attribute */
-#define TRB_NO_SNOOP (1 << 3)
+#define TRB_NO_SNOOP BIT(3)
 /* Chain multiple TRBs into a TD */
-#define TRB_CHAIN (1 << 4)
+#define TRB_CHAIN BIT(4)
 /* Interrupt on completion */
-#define TRB_IOC (1 << 5)
+#define TRB_IOC BIT(5)
 /* The buffer pointer contains immediate data */
-#define TRB_IDT (1 << 6)
+#define TRB_IDT BIT(6)
 
 /* Block Event Interrupt */
-#define TRB_BEI (1 << 9)
+#define TRB_BEI BIT(9)
 
 /* Control transfer TRB specific fields */
-#define TRB_DIR_IN (1 << 16)
-#define TRB_TX_TYPE(p) ((p) << 16)
+#define TRB_DIR_IN BIT(16)
+#define TRB_TX_TYPE(p) ((u32)(p) << 16)
 #define TRB_DATA_OUT 2
 #define TRB_DATA_IN 3
 
 /* Isochronous TRB specific fields */
-#define TRB_SIA (1 << 31)
+#define TRB_SIA BIT(31)
 
 struct xhci_link_trb
 {
@@ -184,7 +184,7 @@ struct xhci_link_trb
 };
 
 /* control bitfields */
-#define LINK_TOGGLE (0x1 << 1)
+#define LINK_TOGGLE BIT(1)
 
 /* Command completion event TRB */
 struct xhci_event_cmd
@@ -209,8 +209,8 @@ union xhci_trb
 };
 
 /* TRB bit mask */
-#define TRB_TYPE_BITMASK (0xfc00)
-#define TRB_TYPE(p) ((p) << 10)
+#define TRB_TYPE_BITMASK (0xfc00U)
+#define TRB_TYPE(p) ((u32)(p) << 10)
 #define TRB_FIELD_TO_TYPE(p) (((p) & TRB_TYPE_BITMASK) >> 10)
 
 /* TRB type IDs */
@@ -303,11 +303,11 @@ struct xhci_intr_reg;
 struct usb_device;
 struct ep_context;
 
-struct xhci_ring *xhci_ring_alloc(struct xhci_ctrl *ctrl, unsigned int num_segs,
-								  BOOL link_trbs, BOOL is_event_ring, int ep_index, int max_packet_size);
+struct xhci_ring *xhci_ring_alloc(struct xhci_ctrl *ctrl, u32 num_segs,
+							  BOOL link_trbs, BOOL is_event_ring, u8 ep_index, u32 max_packet_size);
 void xhci_ring_free(struct xhci_ctrl *ctrl, struct xhci_ring *ring);								  
 
-int xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, unsigned int timeout_ms, BOOL defer_doorbell);
+s8 xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell);
 void xhci_ring_giveback(struct usb_device *udev, struct ep_context *ep_ctx);
 
 void xhci_ring_acknowledge_event(struct xhci_ctrl *ctrl);
@@ -316,11 +316,11 @@ union xhci_trb *xhci_ring_get_event_trb(struct xhci_ring *ring);
 u32 xhci_ring_get_new_dequeue_ptr(struct xhci_ring *ring);
 u32 xhci_ring_get_deq_ptr_for_trb(dma_addr_t trb_addr);
 
-int xhci_ring_get_max_packet_size(struct xhci_ring *ring);
-void xhci_ring_set_max_packet_size(struct xhci_ring *ring, int max_packet_size);
-void xhci_ring_patch_trbs_to_noop(dma_addr_t *trb_addrs, UWORD trb_count, UWORD start_index);
+u32 xhci_ring_get_max_packet_size(struct xhci_ring *ring);
+void xhci_ring_set_max_packet_size(struct xhci_ring *ring, u32 max_packet_size);
+void xhci_ring_patch_trbs_to_noop(dma_addr_t *trb_addrs, u32 trb_count, u32 start_index);
 
-dma_addr_t xhci_ring_enqueue_command(struct xhci_ring *ring, u64 address, u32 slot_id, u32 ep_index, trb_type cmd);
+dma_addr_t xhci_ring_enqueue_command(struct xhci_ring *ring, u64 address, u32 slot_id, u8 ep_index, trb_type cmd);
 void xhci_ring_setup_erst(struct xhci_ring *ring, struct xhci_erst *erst, struct xhci_intr_reg *ir_set);
 
 #endif /* __XHCI_RING_H */

--- a/xhci.device/include/xhci/xhci-ring.h
+++ b/xhci.device/include/xhci/xhci-ring.h
@@ -173,6 +173,8 @@ typedef enum
 #define TRB_DATA_IN 3
 
 /* Isochronous TRB specific fields */
+#define TRB_FRAME_ID(p) (((u32)(p) & 0x7ffU) << 20)
+#define GET_TRB_FRAME_ID(p) ((u16)(((p) >> 20) & 0x7ffU))
 #define TRB_SIA BIT(31)
 
 struct xhci_link_trb
@@ -308,6 +310,7 @@ struct xhci_ring *xhci_ring_alloc(struct xhci_ctrl *ctrl, u32 num_segs,
 void xhci_ring_free(struct xhci_ctrl *ctrl, struct xhci_ring *ring);								  
 
 s8 xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell);
+s8 xhci_ring_enqueue_td_at_frame(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell, u16 frame);
 BOOL xhci_ring_has_room(struct ep_context *ep_ctx, u32 needed_trbs);
 void xhci_ring_giveback(struct usb_device *udev, struct ep_context *ep_ctx);
 

--- a/xhci.device/include/xhci/xhci-ring.h
+++ b/xhci.device/include/xhci/xhci-ring.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifndef __XHCI_RING_H
 #define __XHCI_RING_H
 

--- a/xhci.device/include/xhci/xhci-root-hub.h
+++ b/xhci.device/include/xhci/xhci-root-hub.h
@@ -7,18 +7,18 @@
 
 struct xhci_root_hub;
 
-typedef void (*io_reply_data_fn)(struct usb_device *udev, struct USBIORequest *io, int err, ULONG actual);
+typedef void (*io_reply_data_fn)(struct usb_device *udev, struct USBIORequest *io, s8 err, ULONG actual);
 
 struct xhci_root_hub *xhci_roothub_create(struct usb_device *udev,
                                          io_reply_data_fn io_reply_data);
 void xhci_roothub_destroy(struct xhci_root_hub *rh);
 
 void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct USBIORequest *req);
-int xhci_roothub_submit_int_request(struct xhci_root_hub *rh, struct USBIORequest *req);
+s8 xhci_roothub_submit_int_request(struct xhci_root_hub *rh, struct USBIORequest *req);
 void xhci_roothub_complete_int_request(struct xhci_root_hub *rh);
 void xhci_roothub_abort_int_request(struct xhci_root_hub *rh);
 
-unsigned int xhci_roothub_get_address(struct xhci_root_hub *rh);
-UBYTE xhci_roothub_get_num_ports(struct xhci_root_hub *rh);
+u16 xhci_roothub_get_address(struct xhci_root_hub *rh);
+u8 xhci_roothub_get_num_ports(struct xhci_root_hub *rh);
 
 #endif

--- a/xhci.device/include/xhci/xhci-root-hub.h
+++ b/xhci.device/include/xhci/xhci-root-hub.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifndef __XHCI_ROOT_HUB_H
 #define __XHCI_ROOT_HUB_H
 

--- a/xhci.device/include/xhci/xhci-td.h
+++ b/xhci.device/include/xhci/xhci-td.h
@@ -19,12 +19,12 @@ struct xhci_ctrl;
 struct xhci_ring;
 
 TransferDescriptorList* xhci_td_create_list(struct xhci_ctrl *ctrl);
-void xhci_td_destroy_list(TransferDescriptorList *td_list, UBYTE error_code);
+void xhci_td_destroy_list(TransferDescriptorList *td_list, s8 error_code);
 
 BOOL xhci_td_is_empty(TransferDescriptorList *td_list);
 BOOL xhci_td_is_expired(TransferDescriptorList *td_list);
-ULONG xhci_td_get_queued_trb_count(TransferDescriptorList *td_list);
-ULONG xhci_td_get_queued_td_count(TransferDescriptorList *td_list);
+u32 xhci_td_get_queued_trb_count(TransferDescriptorList *td_list);
+u32 xhci_td_get_queued_td_count(TransferDescriptorList *td_list);
 BOOL xhci_td_has_request(TransferDescriptorList *td_list, struct USBIORequest *io_req);
 void xhci_td_patch_recovery(TransferDescriptorList *td_list,
     struct xhci_ring *ring,
@@ -34,14 +34,14 @@ void xhci_td_patch_recovery(TransferDescriptorList *td_list,
 
 BOOL xhci_td_add(TransferDescriptorList *td_list,
     struct USBIORequest *io_req,
-    ULONG timeout_ms,
+    u32 timeout_ms,
     BOOL is_rt_iso,
     dma_addr_t *trb_addresses,
-    ULONG trb_count);
+    u32 trb_count);
 
 struct USBIORequest *xhci_td_get_by_trb(TransferDescriptorList *td_list, dma_addr_t trb_addr);
 
 void xhci_td_abort_req(struct USBIORequest *io);
-void xhci_td_fail_all(TransferDescriptorList *td_list, BYTE io_Error);
+void xhci_td_fail_all(TransferDescriptorList *td_list, s8 io_Error);
 
 #endif

--- a/xhci.device/include/xhci/xhci-td.h
+++ b/xhci.device/include/xhci/xhci-td.h
@@ -17,11 +17,12 @@ typedef struct IOReqNode {
 typedef struct TransferDescriptorList TransferDescriptorList;
 struct xhci_ctrl;
 struct xhci_ring;
+struct ep_context;
 
 void xhci_td_slab_init(struct xhci_ctrl *ctrl);
 void xhci_td_slab_destroy(struct xhci_ctrl *ctrl);
 
-TransferDescriptorList* xhci_td_create_list(struct xhci_ctrl *ctrl);
+TransferDescriptorList* xhci_td_create_list(struct xhci_ctrl *ctrl, struct ep_context *ep_ctx);
 void xhci_td_destroy_list(TransferDescriptorList *td_list, s8 error_code);
 
 BOOL xhci_td_is_empty(TransferDescriptorList *td_list);

--- a/xhci.device/include/xhci/xhci-td.h
+++ b/xhci.device/include/xhci/xhci-td.h
@@ -3,7 +3,6 @@
 
 #include <exec/types.h>
 #include <devices/hcd_api.h>
-#include <compat.h>
 #include <minlist.h>
 
 typedef struct MinList IOReqList;

--- a/xhci.device/include/xhci/xhci-td.h
+++ b/xhci.device/include/xhci/xhci-td.h
@@ -18,6 +18,9 @@ typedef struct TransferDescriptorList TransferDescriptorList;
 struct xhci_ctrl;
 struct xhci_ring;
 
+void xhci_td_slab_init(struct xhci_ctrl *ctrl);
+void xhci_td_slab_destroy(struct xhci_ctrl *ctrl);
+
 TransferDescriptorList* xhci_td_create_list(struct xhci_ctrl *ctrl);
 void xhci_td_destroy_list(TransferDescriptorList *td_list, s8 error_code);
 

--- a/xhci.device/include/xhci/xhci-td.h
+++ b/xhci.device/include/xhci/xhci-td.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifndef __XHCI_TD_H
 #define __XHCI_TD_H
 

--- a/xhci.device/include/xhci/xhci-udev.h
+++ b/xhci.device/include/xhci/xhci-udev.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0+ */
+/* SPDX-License-Identifier: GPL-2.0-only */
 /*
  * (C) Copyright 2001
  * Denis Peter, MPL AG Switzerland

--- a/xhci.device/include/xhci/xhci-udev.h
+++ b/xhci.device/include/xhci/xhci-udev.h
@@ -120,8 +120,18 @@ struct usb_hub_descriptor {
 #define REQ_INTERNAL 0x1       /* Internal request, free instead of reply */
 #define REQ_ENQUEUED 0x2       /* Request was already enqueued to EP */
 #define REQ_ON_RING 0x4        /* Request is currently on the transfer ring */
-#define REQ_DMA_MAPPED 0x8     /* Request data buffer is DMA mapped */
+#define REQ_DMA_MAPPED 0x8      /* Request data buffer is DMA mapped */
 #define REQ_HUB_DESC_FETCH 0x10 /* Internal hub descriptor fetch before CONFIG_EP */
+#define REQ_RT_ISO_CLONE 0x40   /* Cloned IO req for RT ISO; pool_free instead of ReplyMsg */
+#define REQ_RT_IN_BUF_SLABBED 0x80 /* RT ISO IN data_buffer came from iso_in_staging_slab */
+
+/* bounce class — which bounce slab the bounce buffer came from (0 = dma_alloc fallback) */
+#define REQ_BOUNCE_CLASS_SHIFT 8
+#define REQ_BOUNCE_CLASS_MASK  (0x7U << REQ_BOUNCE_CLASS_SHIFT)
+#define REQ_BOUNCE_CLASS_NONE  0
+#define REQ_BOUNCE_CLASS_SMALL 1
+#define REQ_BOUNCE_CLASS_MED   2
+#define REQ_BOUNCE_CLASS_LARGE 3
 
 enum slot_state {
 	USB_DEV_SLOT_STATE_DISABLED = 0,

--- a/xhci.device/include/xhci/xhci-udev.h
+++ b/xhci.device/include/xhci/xhci-udev.h
@@ -94,22 +94,22 @@ enum {
 
 /* Hub descriptor */
 struct usb_hub_descriptor {
-	u8  bLength;
-	u8  bDescriptorType;
-	u8  bNbrPorts;
-	u16 wHubCharacteristics;
-	u8  bPwrOn2PwrGood;
-	u8  bHubContrCurrent;
+	__le8  bLength;
+	__le8  bDescriptorType;
+	__le8  bNbrPorts;
+	__le16 wHubCharacteristics;
+	__le8  bPwrOn2PwrGood;
+	__le8  bHubContrCurrent;
 	/* 2.0 and 3.0 hubs differ here */
 	union {
 		struct {
 			/* add 1 bit for hub status change; round to bytes */
-			u8 DeviceRemovable[(USB_MAXCHILDREN + 1 + 7) / 8];
-			u8 PortPowerCtrlMask[(USB_MAXCHILDREN + 1 + 7) / 8];
+			__le8 DeviceRemovable[(USB_MAXCHILDREN + 1 + 7) / 8];
+			__le8 PortPowerCtrlMask[(USB_MAXCHILDREN + 1 + 7) / 8];
 		} __attribute__ ((packed)) hs;
 
 		struct {
-			u8 bHubHdrDecLat;
+			__le8 bHubHdrDecLat;
 			__le16 wHubDelay;
 			__le16 DeviceRemovable;
 		} __attribute__ ((packed)) ss;
@@ -145,9 +145,9 @@ enum slot_state {
  * a struct usb_device since it is not a device.
  */
 struct usb_device {
-	unsigned int	virtual_address;			/* Device address as seen by the driver user */
-	unsigned int    xhci_address;				/* Device address as seen by xHCI */
-	unsigned int	slot_id;		/* Slot ID for xHCI */
+	u16	virtual_address;			/* Device address as seen by the driver user */
+	u8    xhci_address;				/* Device address as seen by xHCI */
+	u8	slot_id;		/* Slot ID for xHCI */
 	enum usb_device_speed speed;	/* full/low/high */
 	enum slot_state  slot_state;	/* current slot state */
 
@@ -167,10 +167,10 @@ struct usb_device {
 
 	/* Split routing data */
 	struct usb_device *parent;    /* Parent hub device, NULL for root */
-	unsigned int parent_port;     /* Parent hub downstream port (all speeds) */
-	unsigned int route;           /* xHCI route string nibble-packed */
+	u8 parent_port;               /* Parent hub downstream port (all speeds) */
+	u32 route;                    /* xHCI route string nibble-packed */
 	u8 route_depth;
-	unsigned int tt_think_time;   /* Hub TT think time encoding (0-3 -> 8/16/24/32 bit times) */
+	u8 tt_think_time;             /* Hub TT think time encoding (0-3 -> 8/16/24/32 bit times) */
 
 	/* Requests state data */
 	struct ep_context *ep_context[USB_MAX_ENDPOINT_CONTEXTS];
@@ -194,23 +194,23 @@ struct XHCIUnit;
 struct xhci_ctrl;
 
 /* Access udev */
-struct usb_device *xhci_udev_alloc(struct xhci_ctrl *ctrl, UWORD virtual_address);
-struct usb_device *xhci_udev_get(struct XHCIUnit *unit, UWORD virtual_address);
+struct usb_device *xhci_udev_alloc(struct xhci_ctrl *ctrl, u16 virtual_address);
+struct usb_device *xhci_udev_get(struct XHCIUnit *unit, u16 virtual_address);
 void xhci_udev_free(struct usb_device *udev);
 
 /* Dispatch */
-int xhci_udev_send_ctrl(struct usb_device *udev, struct USBIORequest *io);
-int xhci_udev_send(struct USBIORequest *req);
+s8 xhci_udev_send_ctrl(struct usb_device *udev, struct USBIORequest *io);
+s8 xhci_udev_send(struct USBIORequest *req);
 
 /* Track replies */
-void xhci_udev_io_reply_failed(struct xhci_ctrl *ctrl, struct USBIORequest *io, int err);
-void xhci_udev_io_reply_data(struct usb_device *udev, struct USBIORequest *io, int err, ULONG actual);
+void xhci_udev_io_reply_failed(struct xhci_ctrl *ctrl, struct USBIORequest *io, s8 err);
+void xhci_udev_io_reply_data(struct usb_device *udev, struct USBIORequest *io, s8 err, u32 actual);
 
 /* Send commands to device */
-void xhci_udev_clear_feature_halt(struct usb_device *udev, ULONG ep_index);
-void xhci_udev_clear_tt_buffer(struct usb_device *udev, ULONG ep_index, int ep_type);
+void xhci_udev_clear_feature_halt(struct usb_device *udev, u8 ep_index);
+void xhci_udev_clear_tt_buffer(struct usb_device *udev, u8 ep_index, int ep_type);
 
 /* Descriptor access */
-int xhci_ep_type_for_index(struct usb_device *udev, u32 ep_index);
+s32 xhci_ep_type_for_index(struct usb_device *udev, u8 ep_index);
 
 #endif /* __XHCI_UDEV_H__ */

--- a/xhci.device/include/xhci/xhci-udev.h
+++ b/xhci.device/include/xhci/xhci-udev.h
@@ -18,8 +18,8 @@
  * The EHCI spec says that we must align to at least 32 bytes.  However,
  * some platforms require larger alignment.
  */
-#if ARCH_DMA_MINALIGN > 32
-#define USB_DMA_MINALIGN	ARCH_DMA_MINALIGN
+#if DMA_ALIGN_MIN > 32
+#define USB_DMA_MINALIGN	DMA_ALIGN_MIN
 #else
 #define USB_DMA_MINALIGN	32
 #endif
@@ -40,7 +40,7 @@
 struct usb_interface_altsetting {
 	struct usb_interface_descriptor desc;
 
-	__u8 no_of_ep;
+	u8 no_of_ep;
 
 	struct usb_endpoint_descriptor ep_desc[USB_MAXENDPOINTS];
 	struct usb_ss_ep_comp_descriptor ss_ep_comp_desc[USB_MAXENDPOINTS];
@@ -48,8 +48,8 @@ struct usb_interface_altsetting {
 
 /* Interface */
 struct usb_interface {
-	__u8 interface_number;
-	__u8 num_altsetting;
+	u8 interface_number;
+	u8 num_altsetting;
 	struct usb_interface_altsetting *active_altsetting;
 
 	struct usb_interface_altsetting altsetting[USB_ALTSETTINGALLOC];
@@ -60,7 +60,7 @@ struct usb_config {
 	struct MinNode node;
 	struct usb_config_descriptor desc;
 
-	__u8	no_of_if;	/* number of interfaces */
+	u8	no_of_if;	/* number of interfaces */
 	struct usb_interface if_desc[USB_MAXINTERFACES];
 };
 
@@ -94,22 +94,22 @@ enum {
 
 /* Hub descriptor */
 struct usb_hub_descriptor {
-	__u8  bLength;
-	__u8  bDescriptorType;
-	__u8  bNbrPorts;
-	__u16 wHubCharacteristics;
-	__u8  bPwrOn2PwrGood;
-	__u8  bHubContrCurrent;
+	u8  bLength;
+	u8  bDescriptorType;
+	u8  bNbrPorts;
+	u16 wHubCharacteristics;
+	u8  bPwrOn2PwrGood;
+	u8  bHubContrCurrent;
 	/* 2.0 and 3.0 hubs differ here */
 	union {
 		struct {
 			/* add 1 bit for hub status change; round to bytes */
-			__u8 DeviceRemovable[(USB_MAXCHILDREN + 1 + 7) / 8];
-			__u8 PortPowerCtrlMask[(USB_MAXCHILDREN + 1 + 7) / 8];
+			u8 DeviceRemovable[(USB_MAXCHILDREN + 1 + 7) / 8];
+			u8 PortPowerCtrlMask[(USB_MAXCHILDREN + 1 + 7) / 8];
 		} __attribute__ ((packed)) hs;
 
 		struct {
-			__u8 bHubHdrDecLat;
+			u8 bHubHdrDecLat;
 			__le16 wHubDelay;
 			__le16 DeviceRemovable;
 		} __attribute__ ((packed)) ss;

--- a/xhci.device/include/xhci/xhci-udev.h
+++ b/xhci.device/include/xhci/xhci-udev.h
@@ -123,7 +123,6 @@ struct usb_hub_descriptor {
 #define REQ_DMA_MAPPED 0x8      /* Request data buffer is DMA mapped */
 #define REQ_HUB_DESC_FETCH 0x10 /* Internal hub descriptor fetch before CONFIG_EP */
 #define REQ_RT_ISO_CLONE 0x40   /* Cloned IO req for RT ISO; pool_free instead of ReplyMsg */
-#define REQ_RT_IN_BUF_SLABBED 0x80 /* RT ISO IN data_buffer came from iso_in_staging_slab */
 
 /* bounce class — which bounce slab the bounce buffer came from (0 = dma_alloc fallback) */
 #define REQ_BOUNCE_CLASS_SHIFT 8

--- a/xhci.device/include/xhci/xhci.h
+++ b/xhci.device/include/xhci/xhci.h
@@ -19,10 +19,13 @@
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
 #endif
 
-#include <compat.h>
+#include <emu_bits.h>
+#include <emu_iomem.h>
 #include <pci_types.h>
 #include <devices/hcd_api.h>
 #include <xhci/xhci-udev.h>
@@ -703,6 +706,7 @@ struct xhci_ctrl
 	u16 hci_version;
 
 	APTR memoryPool;
+	struct Library *utilityBase;
 	struct pci_device *pci_dev;
 	struct usb_device *devices_by_virtual_address[USB_MAX_ADDRESS + 1];
 	struct usb_device *devices_by_slot_id[MAX_HC_SLOTS];

--- a/xhci.device/include/xhci/xhci.h
+++ b/xhci.device/include/xhci/xhci.h
@@ -26,6 +26,7 @@
 
 #include <bits.h>
 #include <iomem.h>
+#include <slab.h>
 #include <devices/hcd_api.h>
 #include <xhci/xhci-udev.h>
 
@@ -707,6 +708,23 @@ struct xhci_ctrl
 	u16 hci_version;
 
 	APTR memoryPool;
+#define XHCI_TD_SMALL_TRBS         8                       /* trb_addr_slab covers up to this many TRBs */
+#define XHCI_BOUNCE_SMALL_SIZE     256                     /* covers RT ISO 192 + tiny ctrl/desc */
+#define XHCI_BOUNCE_SMALL_CAP      256
+#define XHCI_BOUNCE_MED_SIZE       (32 * 1024)             /* covers ≤32KiB bulk reads */
+#define XHCI_BOUNCE_MED_CAP        8
+#define XHCI_BOUNCE_LARGE_SIZE     (2 * 1024 * 1024)       /* mass storage 2MB transfers */
+#define XHCI_BOUNCE_LARGE_CAP      2                       /* Poseidon 1 bulk/EP */
+#define XHCI_ISO_CLONE_CAP         64                      /* RT ISO clone IO requests */
+#define XHCI_ISO_IN_STAGING_SIZE   2048                    /* covers up to 24-bit/192kHz audio */
+#define XHCI_ISO_IN_STAGING_CAP    64
+	struct slab_cache td_slab;            /* one struct xhci_td per slot */
+	struct slab_cache trb_addr_slab;      /* XHCI_TD_SMALL_TRBS * sizeof(dma_addr_t) per slot */
+	struct slab_cache bounce_small;       /* XHCI_BOUNCE_SMALL_SIZE bytes per slot */
+	struct slab_cache bounce_med;         /* XHCI_BOUNCE_MED_SIZE bytes per slot */
+	struct slab_cache bounce_large;       /* XHCI_BOUNCE_LARGE_SIZE bytes per slot */
+	struct slab_cache iso_clone_slab;     /* sizeof(struct USBIORequest) per slot */
+	struct slab_cache iso_in_staging_slab;/* XHCI_ISO_IN_STAGING_SIZE bytes per slot */
 	struct Library *utilityBase;
 	struct pci_dev *pci_dev;
 	BOOL msi_enabled; /* TRUE after EnableMSI + AddIntServer succeed */

--- a/xhci.device/include/xhci/xhci.h
+++ b/xhci.device/include/xhci/xhci.h
@@ -149,6 +149,14 @@ struct xhci_hccr
 #define HCC_LTC(p) ((p) & BIT(6))
 /* true: no secondary Stream ID Support */
 #define HCC_NSS(p) ((p) & BIT(7))
+/* true: HC supports Parse All Event Data */
+#define HCC_PAE(p) ((p) & BIT(8))
+/* true: HC supports Stopped - Short Packet Capability */
+#define HCC_SPC(p) ((p) & BIT(9))
+/* true: HC supports Stopped EDTLA Capability */
+#define HCC_SEC(p) ((p) & BIT(10))
+/* true: HC supports Configure Frame ID Capability */
+#define HCC_CFC(p) ((p) & BIT(11))
 /* Max size for Primary Stream Arrays - 2^(n+1), where n is bits 12:15 */
 #define HCC_MAX_PSA(p) (1 << ((((p) >> 12) & 0xf) + 1))
 /* Extended Capabilities pointer from PCI base - section 5.3.6 */
@@ -611,8 +619,8 @@ static inline void xhci_writeq(__le64 volatile *regs, const u64 val)
 #define XHCI_EXT_CAPS_PM 3
 #define XHCI_EXT_CAPS_VIRT 4
 #define XHCI_EXT_CAPS_MSI 5
-/* IDs 6-9 reserved */
-#define XHCI_EXT_CAPS_LOCAL_MEMORY 9
+#define XHCI_EXT_CAPS_LOCAL_MEMORY 6
+/* IDs 7-9 reserved */
 #define XHCI_EXT_CAPS_DEBUG 10
 #define XHCI_EXT_CAPS_MSIX 17
 

--- a/xhci.device/include/xhci/xhci.h
+++ b/xhci.device/include/xhci/xhci.h
@@ -24,8 +24,8 @@
 #include <proto/exec.h>
 #endif
 
-#include <emu_bits.h>
-#include <emu_iomem.h>
+#include <bits.h>
+#include <iomem.h>
 #include <pci_types.h>
 #include <devices/hcd_api.h>
 #include <xhci/xhci-udev.h>
@@ -578,20 +578,20 @@ struct xhci_scratchpad
  */
 static inline u64 xhci_readq(__le64 volatile *regs)
 {
-	__u32 *ptr = (__u32 *)regs;
-	u64 val_lo = readl(ptr);
-	u64 val_hi = readl(ptr + 1);
+	u32 *ptr = (u32 *)regs;
+	u64 val_lo = mmio_read32(ptr);
+	u64 val_hi = mmio_read32(ptr + 1);
 	return val_lo + (val_hi << 32);
 }
 
 static inline void xhci_writeq(__le64 volatile *regs, const u64 val)
 {
-	__u32 *ptr = (__u32 *)regs;
-	u32 val_lo = lower_32_bits(val);
+	u32 *ptr = (u32 *)regs;
+	u32 val_lo = u64_lo32(val);
 	/* FIXME */
-	u32 val_hi = upper_32_bits(val);
-	writel(val_lo, ptr);
-	writel(val_hi, ptr + 1);
+	u32 val_hi = u64_hi32(val);
+	mmio_write32(val_lo, ptr);
+	mmio_write32(val_hi, ptr + 1);
 }
 
 /*************************************************************
@@ -696,7 +696,7 @@ struct xhci_ctrl
 	struct xhci_hcor *hcor;
 	struct xhci_doorbell_array *dba;
 	struct xhci_run_regs *run_regs;
-	struct xhci_device_context_array *dcbaa __attribute__((aligned(ARCH_DMA_MINALIGN)));
+	struct xhci_device_context_array *dcbaa __attribute__((aligned(DMA_ALIGN_MIN)));
 	struct xhci_ring *event_ring;
 	struct xhci_ring *cmd_ring;
 	struct xhci_intr_reg *ir_set;

--- a/xhci.device/include/xhci/xhci.h
+++ b/xhci.device/include/xhci/xhci.h
@@ -26,9 +26,10 @@
 
 #include <bits.h>
 #include <iomem.h>
-#include <pci_types.h>
 #include <devices/hcd_api.h>
 #include <xhci/xhci-udev.h>
+
+struct pci_dev;
 
 #define XHCI_ALIGNMENT 64
 /* Generic timeout for XHCI events */
@@ -637,11 +638,11 @@ struct xhci_protocol_caps
 	u8 protocol_slot_type;
 
 	u8 max_hub_depth;
-	BOOL usb3_lsecc; /* Link Soft Error Count Capability */
+	BOOL usb3_lsecc;		  /* Link Soft Error Count Capability */
 	BOOL usb2_integrated_hub; /* Integrated Hub Implemented */
-	BOOL usb2_hs_only; /* High-Speed Only Capability */
-	BOOL usb2_hw_lpm; /* Hardware LPM Capability */
-	BOOL usb2_besl_lpm; /* BESL LPM Capability */
+	BOOL usb2_hs_only;		  /* High-Speed Only Capability */
+	BOOL usb2_hw_lpm;		  /* Hardware LPM Capability */
+	BOOL usb2_besl_lpm;		  /* BESL LPM Capability */
 };
 
 /* Offset +00h */
@@ -652,12 +653,12 @@ struct xhci_protocol_caps
 #define XHCI_PROTOCOL_CAP_PORT_OFFSET(p) (((p) >> 0) & 0xff)
 #define XHCI_PROTOCOL_CAP_PORT_COUNT(p) (((p) >> 8) & 0xff)
 #define XHCI_PROTOCOL_CAP_USB3_LSECC(p) (((p) >> 24) & 0x1) // Link Soft Error Count Capability
-#define XHCI_PROTOCOL_CAP_USB3_MHD(p) (((p) >> 25) & 0x7) // Maximum Hub Depth
-#define XHCI_PROTOCOL_CAP_USB2_HSO(p) (((p) >> 17) & 0x1) // High-Speed Only Capability
-#define XHCI_PROTOCOL_CAP_USB2_IHI(p) (((p) >> 18) & 0x1) // Integrated Hub Implemented
-#define XHCI_PROTOCOL_CAP_USB2_HLC(p) (((p) >> 19) & 0x1) // Hardware LPM Capability
-#define XHCI_PROTOCOL_CAP_USB2_BLC(p) (((p) >> 20) & 0x1) // BESL LPM Capability
-#define XHCI_PROTOCOL_CAP_USB2_MHD(p) (((p) >> 25) & 0x7) // Maximum Hub Depth
+#define XHCI_PROTOCOL_CAP_USB3_MHD(p) (((p) >> 25) & 0x7)	// Maximum Hub Depth
+#define XHCI_PROTOCOL_CAP_USB2_HSO(p) (((p) >> 17) & 0x1)	// High-Speed Only Capability
+#define XHCI_PROTOCOL_CAP_USB2_IHI(p) (((p) >> 18) & 0x1)	// Integrated Hub Implemented
+#define XHCI_PROTOCOL_CAP_USB2_HLC(p) (((p) >> 19) & 0x1)	// Hardware LPM Capability
+#define XHCI_PROTOCOL_CAP_USB2_BLC(p) (((p) >> 20) & 0x1)	// BESL LPM Capability
+#define XHCI_PROTOCOL_CAP_USB2_MHD(p) (((p) >> 25) & 0x7)	// Maximum Hub Depth
 #define XHCI_PROTOCOL_CAP_SPEED_ID_COUNT(p) ((u8)(((p) >> 28) & 0xf))
 
 /* Offset +0Ch */
@@ -707,7 +708,8 @@ struct xhci_ctrl
 
 	APTR memoryPool;
 	struct Library *utilityBase;
-	struct pci_device *pci_dev;
+	struct pci_dev *pci_dev;
+	BOOL msi_enabled; /* TRUE after EnableMSI + AddIntServer succeed */
 	struct usb_device *devices_by_virtual_address[USB_MAX_ADDRESS + 1];
 	struct usb_device *devices_by_slot_id[MAX_HC_SLOTS];
 
@@ -716,7 +718,7 @@ struct xhci_ctrl
 	enum usb_device_speed pending_parent_speed;
 
 	struct MinList pending_commands; /* list of pending commands */
-	BOOL cmd_abort_pending;          /* TRUE while CA bit is asserted; doorbell suppressed */
+	BOOL cmd_abort_pending;			 /* TRUE while CA bit is asserted; doorbell suppressed */
 };
 
 inline void xhci_flush_cache(void *addr, u32 len)

--- a/xhci.device/include/xhci/xhci.h
+++ b/xhci.device/include/xhci/xhci.h
@@ -563,9 +563,7 @@ struct xhci_scratchpad
 /*
  * Each segment table entry is 4*32bits long.  1K seems like an ok size:
  * (1K bytes * 8bytes/bit) / (4*32 bits) = 64 segment entries in the table,
- * meaning 64 ring segments.
- * Initial allocated size of the ERST, in number of entries */
-#define ERST_NUM_SEGS 1
+ * meaning 64 ring segments. */
 /* Initial number of event segment rings allocated */
 #define ERST_ENTRIES 1
 /* Initial allocated size of the ERST, in number of entries */
@@ -724,16 +722,13 @@ struct xhci_ctrl
 #define XHCI_BOUNCE_MED_CAP        8
 #define XHCI_BOUNCE_LARGE_SIZE     (2 * 1024 * 1024)       /* mass storage 2MB transfers */
 #define XHCI_BOUNCE_LARGE_CAP      2                       /* Poseidon 1 bulk/EP */
-#define XHCI_ISO_CLONE_CAP         64                      /* RT ISO clone IO requests */
-#define XHCI_ISO_IN_STAGING_SIZE   2048                    /* covers up to 24-bit/192kHz audio */
-#define XHCI_ISO_IN_STAGING_CAP    64
+#define XHCI_ISO_CLONE_CAP         320                     /* 32 ms RT ISO target at 1 kHz ESIT plus headroom */
 	struct slab_cache td_slab;            /* one struct xhci_td per slot */
 	struct slab_cache trb_addr_slab;      /* XHCI_TD_SMALL_TRBS * sizeof(dma_addr_t) per slot */
 	struct slab_cache bounce_small;       /* XHCI_BOUNCE_SMALL_SIZE bytes per slot */
 	struct slab_cache bounce_med;         /* XHCI_BOUNCE_MED_SIZE bytes per slot */
 	struct slab_cache bounce_large;       /* XHCI_BOUNCE_LARGE_SIZE bytes per slot */
 	struct slab_cache iso_clone_slab;     /* sizeof(struct USBIORequest) per slot */
-	struct slab_cache iso_in_staging_slab;/* XHCI_ISO_IN_STAGING_SIZE bytes per slot */
 	struct Library *utilityBase;
 	struct pci_dev *pci_dev;
 	BOOL msi_enabled; /* TRUE after EnableMSI + AddIntServer succeed */

--- a/xhci.device/include/xhci/xhci.h
+++ b/xhci.device/include/xhci/xhci.h
@@ -714,6 +714,7 @@ struct xhci_ctrl
 	struct xhci_scratchpad *scratchpad;
 	struct xhci_root_hub *root_hub;
 	u16 hci_version;
+	BOOL cfc_supported; /* HCC_CFC: per-TRB Frame ID is reliable */
 
 	APTR memoryPool;
 #define XHCI_TD_SMALL_TRBS         8                       /* trb_addr_slab covers up to this many TRBs */

--- a/xhci.device/include/xhci/xhci.h
+++ b/xhci.device/include/xhci/xhci.h
@@ -525,14 +525,14 @@ struct xhci_device_context_array
  * since the command ring is 64-byte aligned.
  * It must also be greater than 16.
  */
-#define TRBS_PER_SEGMENT 64
+#define TRBS_PER_SEGMENT 256
 /* Allow two commands + a link TRB, along with any reserved command TRBs */
 #define MAX_RSVD_CMD_TRBS (TRBS_PER_SEGMENT - 3)
 #define SEGMENT_SIZE (TRBS_PER_SEGMENT * 16)
 /* SEGMENT_SHIFT should be log2(SEGMENT_SIZE).
  * Change this if you change TRBS_PER_SEGMENT!
  */
-#define SEGMENT_SHIFT 10
+#define SEGMENT_SHIFT 12
 /* TRB buffer pointers can't cross 64KB boundaries */
 #define TRB_MAX_BUFF_SHIFT 16
 #define TRB_MAX_BUFF_SIZE (1 << TRB_MAX_BUFF_SHIFT)
@@ -560,14 +560,6 @@ struct xhci_scratchpad
 	u64 *sp_array;
 };
 
-/*
- * Each segment table entry is 4*32bits long.  1K seems like an ok size:
- * (1K bytes * 8bytes/bit) / (4*32 bits) = 64 segment entries in the table,
- * meaning 64 ring segments. */
-/* Initial number of event segment rings allocated */
-#define ERST_ENTRIES 1
-/* Initial allocated size of the ERST, in number of entries */
-#define ERST_SIZE 64
 /* Poll every 60 seconds */
 #define POLL_TIMEOUT 60
 /* Stop endpoint command timeout (secs) for URB cancellation watchdog timer */

--- a/xhci.device/include/xhci/xhci.h
+++ b/xhci.device/include/xhci/xhci.h
@@ -50,18 +50,18 @@
  * connect status and port speed are also sticky - meaning they're in
  * the AUX well and they aren't changed by a hot, warm, or cold reset.
  */
-#define XHCI_PORT_RO ((1 << 0) | (1 << 3) | (0xf << 10) | (1 << 24) | (1 << 30))
+#define XHCI_PORT_RO (BIT(0) | BIT(3) | (0xf << 10) | BIT(24) | BIT(30))
 /*
  * These bits are RW; writing a 0 clears the bit, writing a 1 sets the bit:
  * bits 5:8, 9, 14:15, 25:27
  * link state, port power, port indicator state, "wake on" enable state
  */
-#define XHCI_PORT_RWS ((0xf << 5) | (1 << 9) | (0x3 << 14) | (0x7 << 25))
+#define XHCI_PORT_RWS ((0xf << 5) | BIT(9) | (0x3 << 14) | (0x7 << 25))
 /*
  * These bits are RW; writing a 1 sets the bit, writing a 0 has no effect:
  * bit 4 (port reset)
  */
-#define XHCI_PORT_RW1S ((1 << 4) | (1 << 31))
+#define XHCI_PORT_RW1S (BIT(4) | BIT(31))
 /*
  * These bits are RW; writing a 1 clears the bit, writing a 0 has no effect:
  * bits 1, 17, 18, 19, 20, 21, 22, 23
@@ -70,31 +70,31 @@
  * warm port reset changed (reserved zero for USB 2.0 ports),
  * over-current, reset, link state, and L1 change
  */
-#define XHCI_PORT_RW1CS ((1 << 1) | (0x7f << 17))
+#define XHCI_PORT_RW1CS (BIT(1) | (0x7f << 17))
 /*
  * Bit 16 is RW, and writing a '1' to it causes the link state control to be
  * latched in
  */
-#define XHCI_PORT_RW ((1 << 16))
+#define XHCI_PORT_RW BIT(16)
 /*
  * These bits are Reserved Zero (RsvdZ) and zero should be written to them:
  * bits 2, 24, 28:31
  */
-#define XHCI_PORT_RZ ((1 << 2) | (0x3 << 28))
+#define XHCI_PORT_RZ (BIT(2) | (0x3 << 28))
 
 /*
  * XHCI Register Space.
  */
 struct xhci_hccr
 {
-	uint32_t cr_capbase;
-	uint32_t cr_hcsparams1;
-	uint32_t cr_hcsparams2;
-	uint32_t cr_hcsparams3;
-	uint32_t cr_hccparams1;
-	uint32_t cr_dboff;
-	uint32_t cr_rtsoff;
-	uint32_t cr_hccparams2;
+	u32 cr_capbase;
+	u32 cr_hcsparams1;
+	u32 cr_hcsparams2;
+	u32 cr_hcsparams3;
+	u32 cr_hccparams1;
+	u32 cr_dboff;
+	u32 cr_rtsoff;
+	u32 cr_hccparams2;
 
 /* hc_capbase bitmasks */
 /* bits 7:0 - how long is the Capabilities register */
@@ -105,7 +105,7 @@ struct xhci_hccr
 /* HCSPARAMS1 - hcs_params1 - bitmasks */
 /* bits 0:7, Max Device Slots */
 #define HCS_MAX_SLOTS(p) (((p) >> 0) & 0xff)
-#define HCS_SLOTS_MASK 0xff
+#define HCS_SLOTS_MASK 0xffU
 /* bits 8:18, Max Interrupters */
 #define HCS_MAX_INTRS(p) (((p) >> 8) & 0x7ff)
 /* bits 24:31, Max Ports - max value is 0x7F = 127 ports */
@@ -130,23 +130,23 @@ struct xhci_hccr
 
 /* HCCPARAMS1 - hcc_params1 - bitmasks */
 /* true: HC can use 64-bit address pointers */
-#define HCC_64BIT_ADDR(p) ((p) & (1 << 0))
+#define HCC_64BIT_ADDR(p) ((p) & BIT(0))
 /* true: HC can do bandwidth negotiation */
-#define HCC_BANDWIDTH_NEG(p) ((p) & (1 << 1))
+#define HCC_BANDWIDTH_NEG(p) ((p) & BIT(1))
 /* true: HC uses 64-byte Device Context structures
  * FIXME 64-byte context structures aren't supported yet.
  */
-#define HCC_64BYTE_CONTEXT(p) ((p) & (1 << 2))
+#define HCC_64BYTE_CONTEXT(p) ((p) & BIT(2))
 /* true: HC has port power switches */
-#define HCC_PPC(p) ((p) & (1 << 3))
+#define HCC_PPC(p) ((p) & BIT(3))
 /* true: HC has port indicators */
-#define HCS_INDICATOR(p) ((p) & (1 << 4))
+#define HCS_INDICATOR(p) ((p) & BIT(4))
 /* true: HC has Light HC Reset Capability */
-#define HCC_LIGHT_RESET(p) ((p) & (1 << 5))
+#define HCC_LIGHT_RESET(p) ((p) & BIT(5))
 /* true: HC supports latency tolerance messaging */
-#define HCC_LTC(p) ((p) & (1 << 6))
+#define HCC_LTC(p) ((p) & BIT(6))
 /* true: no secondary Stream ID Support */
-#define HCC_NSS(p) ((p) & (1 << 7))
+#define HCC_NSS(p) ((p) & BIT(7))
 /* Max size for Primary Stream Arrays - 2^(n+1), where n is bits 12:15 */
 #define HCC_MAX_PSA(p) (1 << ((((p) >> 12) & 0xf) + 1))
 /* Extended Capabilities pointer from PCI base - section 5.3.6 */
@@ -154,53 +154,53 @@ struct xhci_hccr
 
 /* HCCPARAMS2 - hcc_params2 - bitmasks */
 /* U3 Entry Capability */
-#define HCC_U3C(p) ((p) & (1 << 0))
+#define HCC_U3C(p) ((p) & BIT(0))
 /* Configure Endpoint Command Max Exit Latency Too Large Capability (CMC) */
-#define HCC_CMC(p) ((p) & (1 << 1))
+#define HCC_CMC(p) ((p) & BIT(1))
 /* Force Save Context Capability (FSC) */
-#define HCC_FSC(p) ((p) & (1 << 2))
+#define HCC_FSC(p) ((p) & BIT(2))
 /* Compliance Transition Capability (CTC) */
-#define HCC_CTC(p) ((p) & (1 << 3))
+#define HCC_CTC(p) ((p) & BIT(3))
 /* Large ESIT Payload Capability (LEC) */
-#define HCC_LEC(p) ((p) & (1 << 4))
+#define HCC_LEC(p) ((p) & BIT(4))
 /* Configuration Information Capability (CIC) */
-#define HCC_CIC(p) ((p) & (1 << 5))
+#define HCC_CIC(p) ((p) & BIT(5))
 /* Extended TBC Capability (ETC) */
-#define HCC_ETC(p) ((p) & (1 << 6))
+#define HCC_ETC(p) ((p) & BIT(6))
 /* Extended TBC TRB Status Capability (ETC_TSC) */
-#define HCC_ETC_TSC(p) ((p) & (1 << 7))
+#define HCC_ETC_TSC(p) ((p) & BIT(7))
 /* Get/Set Extended Property Capability (GSC) */
-#define HCC_GSC(p) ((p) & (1 << 8))
+#define HCC_GSC(p) ((p) & BIT(8))
 /* Virtualization Based Trusted I/O Capability (VTC) */
-#define HCC_VTC(p) ((p) & (1 << 9))
+#define HCC_VTC(p) ((p) & BIT(9))
 
 /* db_off bitmask - bits 0:1 reserved */
-#define DBOFF_MASK (~0x3)
+#define DBOFF_MASK (~0x3U)
 
 /* run_regs_off bitmask - bits 0:4 reserved */
-#define RTSOFF_MASK (~0x1f)
+#define RTSOFF_MASK (~0x1fU)
 };
 
 struct xhci_hcor_port_regs
 {
-	volatile uint32_t or_portsc;
-	volatile uint32_t or_portpmsc;
-	volatile uint32_t or_portli;
-	volatile uint32_t reserved_3;
+	volatile u32 or_portsc;
+	volatile u32 or_portpmsc;
+	volatile u32 or_portli;
+	volatile u32 reserved_3;
 };
 
 struct xhci_hcor
 {
-	volatile uint32_t or_usbcmd;
-	volatile uint32_t or_usbsts;
-	volatile uint32_t or_pagesize;
-	volatile uint32_t reserved_0[2];
-	volatile uint32_t or_dnctrl;
-	volatile uint64_t or_crcr;
-	volatile uint32_t reserved_1[4];
-	volatile uint64_t or_dcbaap;
-	volatile uint32_t or_config;
-	volatile uint32_t reserved_2[241];
+	volatile u32 or_usbcmd;
+	volatile u32 or_usbsts;
+	volatile u32 or_pagesize;
+	volatile u32 reserved_0[2];
+	volatile u32 or_dnctrl;
+	volatile u64 or_crcr;
+	volatile u32 reserved_1[4];
+	volatile u64 or_dcbaap;
+	volatile u32 or_config;
+	volatile u32 reserved_2[241];
 	struct xhci_hcor_port_regs portregs[MAX_HC_PORTS];
 };
 
@@ -211,17 +211,17 @@ struct xhci_hcor
  * PCI config regs).  HC does NOT drive a USB reset on the downstream ports.
  * The xHCI driver must reinitialize the xHC after setting this bit.
  */
-#define CMD_RESET_USB (1 << 1)
+#define CMD_RESET_USB BIT(1)
 /* Event Interrupt Enable - a '1' allows interrupts from the host controller */
 #define CMD_EIE XHCI_CMD_EIE
 /* Host System Error Interrupt Enable - get out-of-band signal for HC errors */
 #define CMD_HSEIE XHCI_CMD_HSEIE
 /* bits 4:6 are reserved (and should be preserved on writes). */
 /* light reset (port status stays unchanged) - reset completed when this is 0 */
-#define CMD_LRESET (1 << 7)
+#define CMD_LRESET BIT(7)
 /* host controller save/restore state. */
-#define CMD_CSS (1 << 8)
-#define CMD_CRS (1 << 9)
+#define CMD_CSS BIT(8)
+#define CMD_CRS BIT(9)
 /* Enable Wrap Event - '1' means xHC generates an event when MFINDEX wraps. */
 #define CMD_EWE XHCI_CMD_EWE
 /* MFINDEX power management - '1' means xHC can stop MFINDEX counter if all root
@@ -229,29 +229,29 @@ struct xhci_hcor
  * '0' means the xHC can power it off if all ports are in the disconnect,
  * disabled, or powered-off state.
  */
-#define CMD_PM_INDEX (1 << 11)
+#define CMD_PM_INDEX BIT(11)
 /* bits 12:31 are reserved (and should be preserved on writes). */
 
 /* USBSTS - USB status - status bitmasks */
 /* HC not running - set to 1 when run/stop bit is cleared. */
-#define STS_HALT (1 << 0)
+#define STS_HALT BIT(0)
 /* serious error, e.g. PCI parity error.  The HC will clear the run/stop bit. */
-#define STS_FATAL (1 << 2)
+#define STS_FATAL BIT(2)
 /* event interrupt - clear this prior to clearing any IP flags in IR set*/
-#define STS_EINT (1 << 3)
+#define STS_EINT BIT(3)
 /* port change detect */
-#define STS_PORT (1 << 4)
+#define STS_PORT BIT(4)
 /* bits 5:7 reserved and zeroed */
 /* save state status - '1' means xHC is saving state */
-#define STS_SAVE (1 << 8)
+#define STS_SAVE BIT(8)
 /* restore state status - '1' means xHC is restoring state */
-#define STS_RESTORE (1 << 9)
+#define STS_RESTORE BIT(9)
 /* true: save or restore error */
-#define STS_SRE (1 << 10)
+#define STS_SRE BIT(10)
 /* true: Controller Not Ready to accept doorbell or op reg writes after reset */
 #define STS_CNR XHCI_STS_CNR
 /* true: internal Host Controller Error - SW needs to reset and reinitialize */
-#define STS_HCE (1 << 12)
+#define STS_HCE BIT(12)
 /* bits 13:31 reserved and should be preserved */
 
 /*
@@ -269,11 +269,11 @@ struct xhci_hcor
 /* CRCR - Command Ring Control Register - cmd_ring bitmasks */
 /* bit 0 is the command ring cycle state */
 /* stop ring operation after completion of the currently executing command */
-#define CMD_RING_PAUSE (1 << 1)
+#define CMD_RING_PAUSE BIT(1)
 /* stop ring immediately - abort the currently executing command */
-#define CMD_RING_ABORT (1 << 2)
+#define CMD_RING_ABORT BIT(2)
 /* true: command ring is running */
-#define CMD_RING_RUNNING (1 << 3)
+#define CMD_RING_RUNNING BIT(3)
 /* bits 4:5 reserved and should be preserved */
 #define CMD_RING_RSVD_BITS (3 << 4)
 #define CMD_RING_ADDR_MASK (CMD_RING_PAUSE | CMD_RING_ABORT | CMD_RING_RUNNING | CMD_RING_RSVD_BITS)
@@ -285,34 +285,34 @@ struct xhci_hcor
 
 /* PORTSC - Port Status and Control Register - port_status_base bitmasks */
 /* true: device connected */
-#define PORT_CONNECT (1 << 0)
+#define PORT_CONNECT BIT(0)
 /* true: port enabled */
-#define PORT_PE (1 << 1)
+#define PORT_PE BIT(1)
 /* bit 2 reserved and zeroed */
 /* true: port has an over-current condition */
-#define PORT_OC (1 << 3)
+#define PORT_OC BIT(3)
 /* true: port reset signaling asserted */
-#define PORT_RESET (1 << 4)
+#define PORT_RESET BIT(4)
 /* Port Link State - bits 5:8
  * A read gives the current link PM state of the port,
  * a write with Link State Write Strobe set sets the link state.
  */
-#define PORT_PLS_MASK (0xf << 5)
-#define XDEV_U0 (0x0 << 5)
-#define XDEV_U1 (0x1 << 5)
-#define XDEV_U2 (0x2 << 5)
-#define XDEV_U3 (0x3 << 5)
-#define XDEV_DISABLED (0x4 << 5)
-#define XDEV_RXDETECT (0x5 << 5)
-#define XDEV_INACTIVE (0x6 << 5)
-#define XDEV_POLLING (0x7 << 5)
-#define XDEV_RECOVERY (0x8 << 5)
-#define XDEV_HOTRESET (0x9 << 5)
-#define XDEV_COMPLIANCE (0xa << 5)
-#define XDEV_TESTMODE (0xb << 5)
-#define XDEV_RESUME (0xf << 5)
+#define PORT_PLS_MASK (0xfu << 5)
+#define XDEV_U0 (0x0u << 5)
+#define XDEV_U1 (0x1u << 5)
+#define XDEV_U2 (0x2u << 5)
+#define XDEV_U3 (0x3u << 5)
+#define XDEV_DISABLED (0x4u << 5)
+#define XDEV_RXDETECT (0x5u << 5)
+#define XDEV_INACTIVE (0x6u << 5)
+#define XDEV_POLLING (0x7u << 5)
+#define XDEV_RECOVERY (0x8u << 5)
+#define XDEV_HOTRESET (0x9u << 5)
+#define XDEV_COMPLIANCE (0xau << 5)
+#define XDEV_TESTMODE (0xbu << 5)
+#define XDEV_RESUME (0xfu << 5)
 /* true: port has power (see HCC_PPC) */
-#define PORT_POWER (1 << 9)
+#define PORT_POWER BIT(9)
 /* bits 10:13 indicate device speed:
  * 0 - undefined speed - port hasn't be initialized by a reset yet
  * 1 - full speed
@@ -338,25 +338,25 @@ struct xhci_hcor
 #define SLOT_SPEED_SS (XDEV_SS << 10)
 /* Port Indicator Control */
 #define PORT_LED_OFF (0 << 14)
-#define PORT_LED_AMBER (1 << 14)
+#define PORT_LED_AMBER BIT(14)
 #define PORT_LED_GREEN (2 << 14)
 #define PORT_LED_MASK (3 << 14)
 /* Port Link State Write Strobe - set this when changing link state */
-#define PORT_LINK_STROBE (1 << 16)
+#define PORT_LINK_STROBE BIT(16)
 /* true: connect status change */
-#define PORT_CSC (1 << 17)
+#define PORT_CSC BIT(17)
 /* true: port enable change */
-#define PORT_PEC (1 << 18)
+#define PORT_PEC BIT(18)
 /* true: warm reset for a USB 3.0 device is done.  A "hot" reset puts the port
  * into an enabled state, and the device into the default state.  A "warm" reset
  * also resets the link, forcing the device through the link training sequence.
  * SW can also look at the Port Reset register to see when warm reset is done.
  */
-#define PORT_WRC (1 << 19)
+#define PORT_WRC BIT(19)
 /* true: over-current change */
-#define PORT_OCC (1 << 20)
+#define PORT_OCC BIT(20)
 /* true: reset change - 1 to 0 transition of PORT_RESET */
-#define PORT_RC (1 << 21)
+#define PORT_RC BIT(21)
 /* port link status change - set on some port link state transitions:
  *  Transition				Reason
  *  --------------------------------------------------------------------------
@@ -370,21 +370,21 @@ struct xhci_hcor
  *  - U0 to disabled		L1 entry error with USB 2.1 device
  *  - Any state to inactive	Error on USB 3.0 port
  */
-#define PORT_PLC (1 << 22)
+#define PORT_PLC BIT(22)
 /* port configure error change - port failed to configure its link partner */
-#define PORT_CEC (1 << 23)
+#define PORT_CEC BIT(23)
 /* bit 24 reserved */
 /* wake on connect (enable) */
-#define PORT_WKCONN_E (1 << 25)
+#define PORT_WKCONN_E BIT(25)
 /* wake on disconnect (enable) */
-#define PORT_WKDISC_E (1 << 26)
+#define PORT_WKDISC_E BIT(26)
 /* wake on over-current (enable) */
-#define PORT_WKOC_E (1 << 27)
+#define PORT_WKOC_E BIT(27)
 /* bits 28:29 reserved */
 /* true: device is removable - for USB 3.0 roothub emulation */
-#define PORT_DEV_REMOVE (1 << 30)
+#define PORT_DEV_REMOVE BIT(30)
 /* Initiate a warm port reset - complete when PORT_WRC is '1' */
-#define PORT_WR (1 << 31)
+#define PORT_WR BIT(31)
 
 /* We mark duplicate entries with -1 */
 #define DUPLICATE_ENTRY ((u8)(-1))
@@ -395,18 +395,18 @@ struct xhci_hcor
  */
 #define PORT_U1_TIMEOUT(p) ((p) & 0xff)
 /* Inactivity timer value for transitions into U2 */
-#define PORT_U2_TIMEOUT(p) (((p) & 0xff) << 8)
-#define PORT_FLA (1 << 16)
+#define PORT_U2_TIMEOUT(p) (u32)(((p) & 0xff) << 8)
+#define PORT_FLA BIT(16)
 /* Bits 24:31 for port testing */
 
 /* USB2 Protocol PORTSPMSC */
 #define PORT_L1S_MASK 7
 #define PORT_L1S_SUCCESS 1
-#define PORT_RWE (1 << 3)
+#define PORT_RWE BIT(3)
 #define PORT_HIRD(p) (((p) & 0xf) << 4)
 #define PORT_HIRD_MASK (0xf << 4)
 #define PORT_L1DS(p) (((p) & 0xff) << 8)
-#define PORT_HLE (1 << 16)
+#define PORT_HLE BIT(16)
 
 /**
 * struct xhci_intr_reg - Interrupt Register Set
@@ -442,31 +442,31 @@ struct xhci_intr_reg
 /* THIS IS BUGGY - FIXME - IP IS WRITE 1 TO CLEAR */
 #define ER_IRQ_CLEAR(p) ((p) & 0xfffffffe)
 #define ER_IRQ_ENABLE(p) ((ER_IRQ_CLEAR(p)) | 0x2)
-#define ER_IRQ_DISABLE(p) ((ER_IRQ_CLEAR(p)) & ~(0x2))
+#define ER_IRQ_DISABLE(p) ((ER_IRQ_CLEAR(p)) & ~(0x2U))
 
 /* irq_control bitmasks */
 /* Minimum interval between interrupts (in 250ns intervals).  The interval
  * between interrupts will be longer if there are no events on the event ring.
  * Default is 4000 (1 ms).
  */
-#define ER_IRQ_INTERVAL_MASK (0xffff)
+#define ER_IRQ_INTERVAL_MASK (0xffffU)
 /* Counter used to count down the time to the next interrupt - HW use only */
-#define ER_IRQ_COUNTER_MASK (0xffff << 16)
+#define ER_IRQ_COUNTER_MASK (0xffffU << 16)
 
 /* erst_size bitmasks */
 /* Preserve bits 16:31 of erst_size */
-#define ERST_SIZE_MASK (0xffff << 16)
+#define ERST_SIZE_MASK (0xffffU << 16)
 
 /* erst_dequeue bitmasks */
 /* Dequeue ERST Segment Index (DESI) - Segment number (or alias)
  * where the current dequeue pointer lies.  This is an optional HW hint.
  */
-#define ERST_DESI_MASK (0x7)
+#define ERST_DESI_MASK (0x7U)
 /* Event Handler Busy (EHB) - is the event ring scheduled to be serviced by
  * a work queue (or delayed service routine)?
  */
-#define ERST_EHB (1 << 3)
-#define ERST_PTR_MASK (0xf)
+#define ERST_EHB BIT(3)
+#define ERST_PTR_MASK (0xfU)
 
 /**
  * struct xhci_run_regs
@@ -539,9 +539,9 @@ struct xhci_erst_entry
 struct xhci_erst
 {
 	struct xhci_erst_entry *entries;
-	unsigned int num_entries;
+	u32 num_entries;
 	/* Num entries the ERST can contain */
-	unsigned int erst_size;
+	u32 erst_size;
 };
 
 struct xhci_scratchpad
@@ -618,8 +618,8 @@ static inline void xhci_writeq(__le64 volatile *regs, const u64 val)
 /* Add this offset, plus the value of xECP in HCCPARAMS to the base address */
 #define XHCI_LEGACY_SUPPORT_OFFSET (0x00)
 /* USB Legacy Support Capability - section 7.1.1 */
-#define XHCI_HC_BIOS_OWNED (1 << 16)
-#define XHCI_HC_OS_OWNED (1 << 24)
+#define XHCI_HC_BIOS_OWNED BIT(16)
+#define XHCI_HC_OS_OWNED BIT(24)
 /* USB Legacy Support Control and Status Register  - section 7.1.2 */
 /* Add this offset, plus the value of xECP in HCCPARAMS to the base address */
 #define XHCI_LEGACY_CONTROL_OFFSET (0x04)
@@ -646,7 +646,7 @@ struct xhci_protocol_caps
 
 /* Offset +00h */
 #define XHCI_PROTOCOL_CAP_MINOR_REV(p) (((p) >> 16) & 0xff)
-#define XHCI_PROTOCOL_CAP_MAJOR_REV(p) (((p) >> 24) & 0xff)
+#define XHCI_PROTOCOL_CAP_MAJOR_REV(p) ((u8)(((p) >> 24) & 0xff))
 
 /* Offset +08h */
 #define XHCI_PROTOCOL_CAP_PORT_OFFSET(p) (((p) >> 0) & 0xff)
@@ -658,37 +658,37 @@ struct xhci_protocol_caps
 #define XHCI_PROTOCOL_CAP_USB2_HLC(p) (((p) >> 19) & 0x1) // Hardware LPM Capability
 #define XHCI_PROTOCOL_CAP_USB2_BLC(p) (((p) >> 20) & 0x1) // BESL LPM Capability
 #define XHCI_PROTOCOL_CAP_USB2_MHD(p) (((p) >> 25) & 0x7) // Maximum Hub Depth
-#define XHCI_PROTOCOL_CAP_SPEED_ID_COUNT(p) (((p) >> 28) & 0xf)
+#define XHCI_PROTOCOL_CAP_SPEED_ID_COUNT(p) ((u8)(((p) >> 28) & 0xf))
 
 /* Offset +0Ch */
-#define XHCI_PROTOCOL_CAP_SLOT_TYPE(p) (((p) >> 0) & 0xf)
+#define XHCI_PROTOCOL_CAP_SLOT_TYPE(p) ((u8)(((p) >> 0) & 0xf))
 
 /* Capability Register */
 /* bits 7:0 - how long is the Capabilities register */
 #define XHCI_HC_LENGTH(p) (((p) >> 00) & 0x00ff)
 
 /* USB 2.0 xHCI 0.96 L1C capability - section 7.2.2.1.3.2 */
-#define XHCI_L1C (1 << 16)
+#define XHCI_L1C BIT(16)
 
 /* USB 2.0 xHCI 1.0 hardware LMP capability - section 7.2.2.1.3.2 */
-#define XHCI_HLC (1 << 19)
+#define XHCI_HLC BIT(19)
 
 /* End of extended capability definitions */
 
 /* command register values to disable interrupts and halt the HC */
 /* start/stop HC execution - do not write unless HC is halted*/
-#define XHCI_CMD_RUN (1 << 0)
+#define XHCI_CMD_RUN BIT(0)
 /* Event Interrupt Enable - get irq when EINT bit is set in USBSTS register */
-#define XHCI_CMD_EIE (1 << 2)
+#define XHCI_CMD_EIE BIT(2)
 /* Host System Error Interrupt Enable - get irq when HSEIE bit set in USBSTS */
-#define XHCI_CMD_HSEIE (1 << 3)
+#define XHCI_CMD_HSEIE BIT(3)
 /* Enable Wrap Event - '1' means xHC generates an event when MFINDEX wraps. */
-#define XHCI_CMD_EWE (1 << 10)
+#define XHCI_CMD_EWE BIT(10)
 
 #define XHCI_IRQS (XHCI_CMD_EIE | XHCI_CMD_HSEIE | XHCI_CMD_EWE)
 
 /* true: Controller Not Ready to accept doorbell or op reg writes after reset */
-#define XHCI_STS_CNR (1 << 11)
+#define XHCI_STS_CNR BIT(11)
 
 struct xhci_ctrl
 {
@@ -712,27 +712,27 @@ struct xhci_ctrl
 	struct usb_device *devices_by_slot_id[MAX_HC_SLOTS];
 
 	struct usb_device *pending_parent; /* parent hub pending for next default-address child */
-	unsigned int pending_parent_port;
+	u8 pending_parent_port;
 	enum usb_device_speed pending_parent_speed;
 
 	struct MinList pending_commands; /* list of pending commands */
 	BOOL cmd_abort_pending;          /* TRUE while CA bit is asserted; doorbell suppressed */
 };
 
-inline void xhci_flush_cache(APTR addr, ULONG len)
+inline void xhci_flush_cache(void *addr, u32 len)
 {
-	CachePreDMA(addr, &len, 0);
+	CachePreDMA((APTR)addr, &len, 0);
 }
 
-inline void xhci_inval_cache(APTR addr, ULONG len)
+inline void xhci_inval_cache(void *addr, u32 len)
 {
-	CachePostDMA(addr, &len, 0);
+	CachePostDMA((APTR)addr, &len, 0);
 }
 
-void *xhci_malloc(struct xhci_ctrl *ctrl, unsigned int size);
+void *xhci_malloc(struct xhci_ctrl *ctrl, u32 size);
 
 u32 *xhci_find_next_capability(struct xhci_ctrl *ctrl, u32 cap_id, u32 *init_offset);
-struct xhci_protocol_caps xhci_get_protocol_caps(u32* base_address);
+struct xhci_protocol_caps xhci_get_protocol_caps(u32 *base_address);
 
 /**
  * xhci_deregister() - Unregister an XHCI controller
@@ -740,7 +740,7 @@ struct xhci_protocol_caps xhci_get_protocol_caps(u32* base_address);
  * @dev:	Controller device
  * Return: 0 if registered, -ve on error
  */
-int xhci_deregister(struct xhci_ctrl *ctrl);
+void xhci_deregister(struct xhci_ctrl *ctrl);
 
 /**
  * xhci_register() - Register a new XHCI controller
@@ -750,7 +750,7 @@ int xhci_deregister(struct xhci_ctrl *ctrl);
  * @hcor:	Not sure what this means
  * Return: 0 if registered, -ve on error
  */
-int xhci_register(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr,
+s32 xhci_register(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr,
 				  struct xhci_hcor *hcor);
 
 #endif /* HOST_XHCI_H_ */

--- a/xhci.device/include/xhci/xhci.h
+++ b/xhci.device/include/xhci/xhci.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-2.0+ */
+/* SPDX-License-Identifier: GPL-2.0-only */
 /*
  * USB HOST XHCI Controller
  *

--- a/xhci.device/src/device.c
+++ b/xhci.device/src/device.c
@@ -115,7 +115,7 @@ APTR initFunction(struct XHCIDevice *base asm("d0"), ULONG segList asm("a0"), st
     GIC400_Base = OpenLibrary((CONST_STRPTR) "gic400.library", 0);
     if (GIC400_Base == NULL)
     {
-        Kprintf("[genet] %s: Failed to open gic400.library\n", __func__);
+        Kprintf("[xhci] %s: Failed to open gic400.library\n", __func__);
         return NULL;
     }
 

--- a/xhci.device/src/device.c
+++ b/xhci.device/src/device.c
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
+#include <clib/bcmpcie_protos.h>
 #else
 #define __NOLIBBASE__
 #define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
+#define BCMPCIE_BASE_NAME pcielibBase
+#include <proto/bcmpcie.h>
 #endif
 
 #include <exec/types.h>
@@ -15,6 +18,8 @@
 #include <dos/dosextens.h>
 
 #include <devices/hcd_api.h>
+
+#include <libraries/openpci.h>
 
 #include <device.h>
 #include <config.h>
@@ -94,8 +99,58 @@ static const APTR funcTable[] = {
     (APTR)abortIO,
     (APTR)-1};
 
+/*
+ * Try to open a PCIe library that supports the BCM2711 controller.
+ *
+ * Preference order:
+ *   1. bcmpcie.library v1
+ *   2. openpci.library — may be a renamed bcmpcie.library for compatibility
+ *
+ * In both cases pci_bus() must return BCM2711PCIeBus (0x80); any other
+ * result means the library is not our BCM2711 implementation.
+ *
+ * Returns 0 on success, -1 if no suitable library / hardware found.
+ */
+s32 xhci_open_pcie_library(struct XHCIDevice *base)
+{
+    if (base->pcieBase != NULL)
+        return 0; /* already open */
+
+    static const char * const libNames[] = { "bcmpcie.library", "openpci.library" };
+    static const ULONG libVersions[] = { 1, 0 };
+
+    for (int i = 0; i < 2; i++)
+    {
+        struct Library *pcielibBase = OpenLibrary((CONST_STRPTR)libNames[i], libVersions[i]);
+        if (pcielibBase == NULL)
+            continue;
+
+        UWORD flags = pci_bus();
+        if (flags & BCM2711PCIeBus)
+        {
+            base->pcieBase = pcielibBase;
+            Kprintf("[xhci] %s: %s opened, bus flags=0x%04lx\n",
+                    __func__, libNames[i], (ULONG)flags);
+            return 0;
+        }
+
+        Kprintf("[xhci] %s: %s bus flags=0x%04lx, BCM2711PCIeBus not set\n",
+                __func__, libNames[i], (ULONG)flags);
+        CloseLibrary(pcielibBase);
+    }
+
+    Kprintf("[xhci] %s: no BCM2711 PCIe library found\n", __func__);
+    return -1;
+}
+
 static void xhci_close_libraries(struct XHCIDevice *base)
 {
+    if (base->pcieBase != NULL)
+    {
+        CloseLibrary(base->pcieBase);
+        base->pcieBase = NULL;
+    }
+
     if (base->gic400Base != NULL)
     {
         CloseLibrary(base->gic400Base);
@@ -143,6 +198,7 @@ APTR initFunction(struct XHCIDevice *base asm("d0"), ULONG segList asm("a0"), st
     _NewMinList(&base->units);
     base->utilityBase = NULL;
     base->gic400Base = NULL;
+    base->pcieBase = NULL;
 
     return base;
 }

--- a/xhci.device/src/device.c
+++ b/xhci.device/src/device.c
@@ -25,7 +25,8 @@
     Put the function at the very beginning of the file in order to avoid
     unexpected results when user executes the device by mistake
 */
-int __attribute__((used, no_reorder)) doNotExecute()
+int doNotExecute(void);
+int __attribute__((used, no_reorder)) doNotExecute(void)
 {
     return -1;
 }
@@ -108,7 +109,7 @@ static void xhci_close_libraries(struct XHCIDevice *base)
     }
 }
 
-static int xhci_open_libraries(struct XHCIDevice *base)
+static s32 xhci_open_libraries(struct XHCIDevice *base)
 {
     if (base->utilityBase != NULL && base->gic400Base != NULL)
         return 0;
@@ -156,7 +157,7 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
 
     if (io->req.io_Message.mn_Length < sizeof(struct IOStdReq))
     {
-        Kprintf("[xhci] %s: Invalid request length %ld\n", __func__, io->req.io_Message.mn_Length);
+        Kprintf("[xhci] %s: Invalid request length %lu\n", __func__, (ULONG)io->req.io_Message.mn_Length);
         io->req.io_Error = IOERR_OPENFAIL;
         return;
     }
@@ -207,14 +208,14 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
         return;
     }
 
-    int result = UnitOpen(unit, unitNumber, flags);
+    int result = UnitOpen(unit, unitNumber, (LONG)flags);
 
     if (result == ERR_NO_ERROR)
     {
         Kprintf("[xhci] %s: Unit opened successfully\n", __func__);
         io->req.io_Unit = (struct Unit *)unit;
         base->device.dd_Library.lib_OpenCnt++;
-        base->device.dd_Library.lib_Flags &= ~LIBF_DELEXP;
+        base->device.dd_Library.lib_Flags &= (UBYTE)~LIBF_DELEXP;
         io->req.io_Message.mn_Node.ln_Type = NT_REPLYMSG;
     }
     else
@@ -279,7 +280,7 @@ ULONG expungeLib(struct XHCIDevice *base asm("a6"))
         Permit();
 
         /* Calculate size of device base and deallocate memory */
-        ULONG size = base->device.dd_Library.lib_NegSize + base->device.dd_Library.lib_PosSize;
+        ULONG size = (ULONG)(base->device.dd_Library.lib_NegSize + base->device.dd_Library.lib_PosSize);
         APTR pointer = (APTR)((ULONG)base - base->device.dd_Library.lib_NegSize);
         FreeMem(pointer, size);
 

--- a/xhci.device/src/device.c
+++ b/xhci.device/src/device.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #else

--- a/xhci.device/src/device.c
+++ b/xhci.device/src/device.c
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0+
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
-#include <clib/utility_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
-#include <proto/utility.h>
 #endif
 
 #include <exec/types.h>
@@ -93,31 +93,55 @@ static const APTR funcTable[] = {
     (APTR)abortIO,
     (APTR)-1};
 
-struct ExecBase *SysBase;
-struct Library *UtilityBase = NULL;
-struct Library *GIC400_Base = NULL;
+static void xhci_close_libraries(struct XHCIDevice *base)
+{
+    if (base->gic400Base != NULL)
+    {
+        CloseLibrary(base->gic400Base);
+        base->gic400Base = NULL;
+    }
+
+    if (base->utilityBase != NULL)
+    {
+        CloseLibrary(base->utilityBase);
+        base->utilityBase = NULL;
+    }
+}
+
+static int xhci_open_libraries(struct XHCIDevice *base)
+{
+    if (base->utilityBase != NULL && base->gic400Base != NULL)
+        return 0;
+
+    xhci_close_libraries(base);
+
+    base->utilityBase = OpenLibrary((CONST_STRPTR) "utility.library", LIB_MIN_VERSION);
+    if (base->utilityBase == NULL)
+    {
+        Kprintf("[xhci] %s: Failed to open utility.library\n", __func__);
+        return -1;
+    }
+
+    base->gic400Base = OpenLibrary((CONST_STRPTR) "gic400.library", 0);
+    if (base->gic400Base == NULL)
+    {
+        Kprintf("[xhci] %s: Failed to open gic400.library\n", __func__);
+        xhci_close_libraries(base);
+        return -1;
+    }
+
+    return 0;
+}
 
 APTR initFunction(struct XHCIDevice *base asm("d0"), ULONG segList asm("a0"), struct ExecBase *_SysBase asm("a6"))
 {
-    SysBase = _SysBase;
+    (void)_SysBase;
     Kprintf("[xhci] %s: Initializing device\n", __func__);
     base->segList = segList;
     base->device.dd_Library.lib_Revision = DEVICE_REVISION;
     _NewMinList(&base->units);
-
-    UtilityBase = OpenLibrary((CONST_STRPTR)"utility.library", LIB_MIN_VERSION);
-    if (UtilityBase == NULL)
-    {
-        Kprintf("[xhci] %s: Failed to open utility.library\n", __func__);
-        return NULL;
-    }
-
-    GIC400_Base = OpenLibrary((CONST_STRPTR) "gic400.library", 0);
-    if (GIC400_Base == NULL)
-    {
-        Kprintf("[xhci] %s: Failed to open gic400.library\n", __func__);
-        return NULL;
-    }
+    base->utilityBase = NULL;
+    base->gic400Base = NULL;
 
     return base;
 }
@@ -125,6 +149,9 @@ APTR initFunction(struct XHCIDevice *base asm("d0"), ULONG segList asm("a0"), st
 void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
              ULONG flags asm("d1"), struct XHCIDevice *base asm("a6"))
 {
+    BOOL firstOpen = FALSE;
+    BOOL createdUnit = FALSE;
+
     Kprintf("[xhci] %s: Opening device with unit number %ld and flags %lx\n", __func__, unitNumber, flags);
 
     if (io->req.io_Message.mn_Length < sizeof(struct IOStdReq))
@@ -136,7 +163,7 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
 
     // Seek through the list of units to find the one with the requested unit number
     struct XHCIUnit *unit = NULL;
-    for(struct MinNode *node = base->units.mlh_Head; node->mln_Succ != NULL; node = node->mln_Succ)
+    for (struct MinNode *node = base->units.mlh_Head; node->mln_Succ != NULL; node = node->mln_Succ)
     {
         struct XHCIUnit *currentUnit = (struct XHCIUnit *)node;
         if (currentUnit->unitNumber == unitNumber)
@@ -156,13 +183,27 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
             io->req.io_Error = IOERR_OPENFAIL;
             return;
         }
+        unit->device = base;
         AddTailMinList(&base->units, (struct MinNode *)unit);
+        createdUnit = TRUE;
     }
 
     if (unit->unit.unit_OpenCnt > 0)
     {
         Kprintf("[xhci] %s: Unit is already open, we only support exclusive access\n", __func__);
         io->req.io_Error = IOERR_UNITBUSY;
+        return;
+    }
+
+    firstOpen = (base->device.dd_Library.lib_OpenCnt == 0);
+    if (firstOpen && xhci_open_libraries(base) != 0)
+    {
+        io->req.io_Error = IOERR_OPENFAIL;
+        if (createdUnit)
+        {
+            RemoveMinNode((struct MinNode *)unit);
+            FreeMem(unit, sizeof(struct XHCIUnit));
+        }
         return;
     }
 
@@ -181,9 +222,11 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
         Kprintf("[xhci] %s: Failed to open unit, error code %ld\n", __func__, result);
         io->req.io_Error = IOERR_OPENFAIL;
 
-        // Remove the failed unit from the list and free its memory
         RemoveMinNode((struct MinNode *)unit);
         FreeMem(unit, sizeof(struct XHCIUnit));
+
+        if (firstOpen)
+            xhci_close_libraries(base);
     }
 
     /* In contrast to normal library there is no need to return anything */
@@ -207,6 +250,7 @@ ULONG closeLib(struct USBIORequest *io asm("a1"), struct XHCIDevice *base asm("a
 
     if (base->device.dd_Library.lib_OpenCnt == 0)
     {
+        xhci_close_libraries(base);
         if (base->device.dd_Library.lib_Flags & LIBF_DELEXP)
         {
             return expungeLib(base);
@@ -227,18 +271,6 @@ ULONG expungeLib(struct XHCIDevice *base asm("a6"))
     }
     else
     {
-        if (UtilityBase != NULL)
-        {
-            CloseLibrary(UtilityBase);
-            UtilityBase = NULL;
-        }
-
-        if (GIC400_Base != NULL)
-        {
-            CloseLibrary(GIC400_Base);
-            GIC400_Base = NULL;
-        }
-
         ULONG segList = base->segList;
 
         /* Remove yourself from list of devices */

--- a/xhci.device/src/device.c
+++ b/xhci.device/src/device.c
@@ -99,48 +99,26 @@ static const APTR funcTable[] = {
     (APTR)abortIO,
     (APTR)-1};
 
-/*
- * Try to open a PCIe library that supports the BCM2711 controller.
- *
- * Preference order:
- *   1. bcmpcie.library v1
- *   2. openpci.library — may be a renamed bcmpcie.library for compatibility
- *
- * In both cases pci_bus() must return BCM2711PCIeBus (0x80); any other
- * result means the library is not our BCM2711 implementation.
- *
- * Returns 0 on success, -1 if no suitable library / hardware found.
- */
 s32 xhci_open_pcie_library(struct XHCIDevice *base)
 {
-    if (base->pcieBase != NULL)
-        return 0; /* already open */
-
-    static const char * const libNames[] = { "bcmpcie.library", "openpci.library" };
-    static const ULONG libVersions[] = { 1, 0 };
-
-    for (int i = 0; i < 2; i++)
+    base->pcieBase = OpenLibrary((CONST_STRPTR) "bcmpcie.library", 1);
+    if (base->pcieBase == NULL)
     {
-        struct Library *pcielibBase = OpenLibrary((CONST_STRPTR)libNames[i], libVersions[i]);
-        if (pcielibBase == NULL)
-            continue;
-
-        UWORD flags = pci_bus();
-        if (flags & BCM2711PCIeBus)
-        {
-            base->pcieBase = pcielibBase;
-            Kprintf("[xhci] %s: %s opened, bus flags=0x%04lx\n",
-                    __func__, libNames[i], (ULONG)flags);
-            return 0;
-        }
-
-        Kprintf("[xhci] %s: %s bus flags=0x%04lx, BCM2711PCIeBus not set\n",
-                __func__, libNames[i], (ULONG)flags);
-        CloseLibrary(pcielibBase);
+        Kprintf("[xhci] %s: Failed to open %s\n", __func__, "bcmpcie.library");
+        return -1;
     }
 
-    Kprintf("[xhci] %s: no BCM2711 PCIe library found\n", __func__);
-    return -1;
+    struct Library *pcielibBase = base->pcieBase;
+    UWORD flags = pci_bus();
+    if (!(flags & BCM2711PCIeBus))
+    {
+        Kprintf("[xhci] %s: %s bus flags=0x%04lx, BCM2711PCIeBus not set\n", __func__, "bcmpcie.library", (ULONG)flags);
+        CloseLibrary(pcielibBase);
+        base->pcieBase = NULL;
+        return -1;
+    }
+
+    return 0;
 }
 
 static void xhci_close_libraries(struct XHCIDevice *base)

--- a/xhci.device/src/device.c
+++ b/xhci.device/src/device.c
@@ -170,7 +170,7 @@ static s32 xhci_open_libraries(struct XHCIDevice *base)
 APTR initFunction(struct XHCIDevice *base asm("d0"), ULONG segList asm("a0"), struct ExecBase *_SysBase asm("a6"))
 {
     (void)_SysBase;
-    Kprintf("[xhci] %s: Initializing device\n", __func__);
+    KprintfH("[xhci] %s: Initializing device\n", __func__);
     base->segList = segList;
     base->device.dd_Library.lib_Revision = DEVICE_REVISION;
     _NewMinList(&base->units);
@@ -187,7 +187,7 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
     BOOL firstOpen = FALSE;
     BOOL createdUnit = FALSE;
 
-    Kprintf("[xhci] %s: Opening device with unit number %ld and flags %lx\n", __func__, unitNumber, flags);
+    KprintfH("[xhci] %s: Opening device with unit number %ld and flags %lx\n", __func__, unitNumber, flags);
 
     if (io->req.io_Message.mn_Length < sizeof(struct IOStdReq))
     {
@@ -210,7 +210,7 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
 
     if (unit == NULL)
     {
-        Kprintf("[xhci] %s: Allocating unit structure\n", __func__);
+        KprintfH("[xhci] %s: Allocating unit structure\n", __func__);
         unit = AllocMem(sizeof(struct XHCIUnit), MEMF_FAST | MEMF_PUBLIC | MEMF_CLEAR);
         if (unit == NULL)
         {
@@ -225,7 +225,7 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
 
     if (unit->unit.unit_OpenCnt > 0)
     {
-        Kprintf("[xhci] %s: Unit is already open, we only support exclusive access\n", __func__);
+        KprintfH("[xhci] %s: Unit is already open, we only support exclusive access\n", __func__);
         io->req.io_Error = IOERR_UNITBUSY;
         return;
     }
@@ -246,7 +246,7 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
 
     if (result == ERR_NO_ERROR)
     {
-        Kprintf("[xhci] %s: Unit opened successfully\n", __func__);
+        KprintfH("[xhci] %s: Unit opened successfully\n", __func__);
         io->req.io_Unit = (struct Unit *)unit;
         base->device.dd_Library.lib_OpenCnt++;
         base->device.dd_Library.lib_Flags &= (UBYTE)~LIBF_DELEXP;
@@ -271,12 +271,12 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
 ULONG closeLib(struct USBIORequest *io asm("a1"), struct XHCIDevice *base asm("a6"))
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    Kprintf("[xhci] %s: Closing device\n", __func__);
+    KprintfH("[xhci] %s: Closing device\n", __func__);
 
     int result = UnitClose(unit);
     if (result == 0) // last user of Unit disappeared
     {
-        Kprintf("[xhci] %s: Unit closed successfully, freeing resources\n", __func__);
+        KprintfH("[xhci] %s: Unit closed successfully, freeing resources\n", __func__);
         RemoveMinNode((struct MinNode *)unit);
         FreeMem(unit, sizeof(struct XHCIUnit));
     }
@@ -297,10 +297,10 @@ ULONG closeLib(struct USBIORequest *io asm("a1"), struct XHCIDevice *base asm("a
 
 ULONG expungeLib(struct XHCIDevice *base asm("a6"))
 {
-    Kprintf("[xhci] %s: Expunging device\n", __func__);
+    KprintfH("[xhci] %s: Expunging device\n", __func__);
     if (base->device.dd_Library.lib_OpenCnt > 0)
     {
-        Kprintf("[xhci] %s: Device is still open, cannot expunge\n", __func__);
+        KprintfH("[xhci] %s: Device is still open, cannot expunge\n", __func__);
         base->device.dd_Library.lib_Flags |= LIBF_DELEXP;
         return 0;
     }

--- a/xhci.device/src/device_abortio.c
+++ b/xhci.device/src/device_abortio.c
@@ -2,11 +2,14 @@
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
 #endif
 
 #include <device.h>
 #include <debug.h>
+#include <emu_memory.h>
 #include <devices/hcd_api.h>
 #include <xhci/xhci-udev.h>
 

--- a/xhci.device/src/device_abortio.c
+++ b/xhci.device/src/device_abortio.c
@@ -9,7 +9,7 @@
 
 #include <device.h>
 #include <debug.h>
-#include <emu_memory.h>
+#include <memory.h>
 #include <devices/hcd_api.h>
 #include <xhci/xhci-udev.h>
 
@@ -18,11 +18,10 @@ static LONG post_abort_request(struct XHCIUnit *unit, struct USBIORequest *io)
     if (!unit || !unit->memoryPool)
         return -1;
 
-    struct USBIORequest *abort_req = AllocVecPooled(unit->memoryPool, sizeof(*abort_req));
+    struct USBIORequest *abort_req = pool_zalloc(unit->memoryPool, sizeof(*abort_req));
     if (!abort_req)
         return -1;
 
-    _memset(abort_req, 0, sizeof(*abort_req));
     abort_req->req.io_Message.mn_Length = sizeof(*abort_req);
     abort_req->req.io_Unit = io->req.io_Unit;
     abort_req->req.io_Command = CMD_INTERNAL_ABORT_REQUEST;

--- a/xhci.device/src/device_abortio.c
+++ b/xhci.device/src/device_abortio.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #else

--- a/xhci.device/src/device_beginio.c
+++ b/xhci.device/src/device_beginio.c
@@ -2,6 +2,8 @@
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
 #endif
 

--- a/xhci.device/src/device_beginio.c
+++ b/xhci.device/src/device_beginio.c
@@ -16,6 +16,6 @@ void beginIO(struct USBIORequest *io asm("a1"), struct XHCIDevice *base asm("a6"
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
 
     io->req.io_Error = ERR_NO_ERROR;
-    io->req.io_Flags &= ~IOF_QUICK;
+    io->req.io_Flags &= (UBYTE)~IOF_QUICK;
     PutMsg(&unit->unit.unit_MsgPort, (struct Message *)io);
 }

--- a/xhci.device/src/device_beginio.c
+++ b/xhci.device/src/device_beginio.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #else

--- a/xhci.device/src/device_end.c
+++ b/xhci.device/src/device_end.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 #include <exec/types.h>
 
 const UBYTE endOfCode = 0;

--- a/xhci.device/src/irq.c
+++ b/xhci.device/src/irq.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #include <clib/gic400_protos.h>

--- a/xhci.device/src/irq.c
+++ b/xhci.device/src/irq.c
@@ -113,11 +113,11 @@ void xhci_int_rearm(struct XHCIUnit *unit)
 	xhci_irq_enable_runtime(ctrl);
 }
 
-static int xhci_intx_enable(struct XHCIUnit *unit)
+static s32 xhci_intx_enable(struct XHCIUnit *unit)
 {
 	Kprintf("[xhci] %s: enabling INTx\n", __func__);
 	// UBYTE irq_line_cfg;
-	// dm_pci_read_config8(unit->xhci_ctrl->pci_dev, PCI_INTERRUPT_LINE, &irq_line_cfg);
+	// pci_read_config8(unit->xhci_ctrl->pci_dev, PCI_INTERRUPT_LINE, &irq_line_cfg);
 	// if (irq_line_cfg == 0 || irq_line_cfg == 0xff)
 	// {
 	// 	Kprintf("[xhci] %s: controller reports no legacy INTx line (value=0x%02lx)\n", __func__, (ULONG)irq_line_cfg);
@@ -125,12 +125,12 @@ static int xhci_intx_enable(struct XHCIUnit *unit)
 	// }
 
 	// unit->irq_line = irq_line_cfg + 32;
-	unit->irq_line = unit->xhci_ctrl->pci_dev->irq + 32;
+	unit->irq_line = (u32)(unit->xhci_ctrl->pci_dev->irq + 32);
 
-	int ret = AddIntServerEx((ULONG)unit->irq_line, 0, FALSE, &unit->irq_isr);
+	s32 ret = AddIntServerEx((ULONG)unit->irq_line, 0, FALSE, &unit->irq_isr);
 	if (ret < 0)
 	{
-		Kprintf("[xhci] %s: AddIntServerEx failed for IRQ %ld (ret=%ld)\n", __func__, unit->irq_line, (LONG)ret);
+		Kprintf("[xhci] %s: AddIntServerEx failed for IRQ %lu (ret=%ld)\n", __func__, (ULONG)unit->irq_line, (LONG)ret);
 		return ret;
 	}
 
@@ -142,7 +142,7 @@ static int xhci_intx_enable(struct XHCIUnit *unit)
 	return 0;
 }
 
-static int xhci_msi_enable(struct XHCIUnit *unit)
+static s32 xhci_msi_enable(struct XHCIUnit *unit)
 {
 	Kprintf("[xhci] %s: enabling MSI\n", __func__);
 	if (unit->xhci_ctrl->pci_dev->msi.enabled)
@@ -157,9 +157,9 @@ static int xhci_msi_enable(struct XHCIUnit *unit)
 		return xhci_intx_enable(unit);
 	}
 
-	unit->irq_line = unit->xhci_ctrl->pci_dev->msi.irq + 32;
+	unit->irq_line = (u32)(unit->xhci_ctrl->pci_dev->msi.irq + 32);
 
-	int ret = add_int_server(unit->xhci_ctrl->pci_dev, &unit->irq_isr);
+	s32 ret = add_int_server(unit->xhci_ctrl->pci_dev, &unit->irq_isr);
 	if (ret < 0)
 	{
 		Kprintf("[xhci] %s: add_int_server failed (ret=%ld)\n", __func__, (LONG)ret);
@@ -169,11 +169,11 @@ static int xhci_msi_enable(struct XHCIUnit *unit)
 	return 0;
 }
 
-int xhci_int_enable(struct XHCIUnit *unit)
+s32 xhci_int_enable(struct XHCIUnit *unit)
 {
 	xhci_setup_isr(unit);
 
-	int result = 0;
+	s32 result = 0;
 	if (!unit->xhci_ctrl->pci_dev)
 		result = AddIntServerEx((ULONG)unit->irq_line, 0, FALSE, &unit->irq_isr);
 	else if (DEVICE_USE_MSI)

--- a/xhci.device/src/irq.c
+++ b/xhci.device/src/irq.c
@@ -2,18 +2,21 @@
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #include <clib/gic400_protos.h>
+#include <clib/bcmpcie_protos.h>
 #else
 #define __NOLIBBASE__
 #define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
 #define GIC400_BASE_NAME unit->device->gic400Base
 #include <proto/gic400.h>
+#define BCMPCIE_BASE_NAME pcielibBase
+#include <proto/bcmpcie.h>
 #endif
 
 #include <iomem.h>
 #include <config.h>
 #include <debug.h>
-#include <pci.h>
+#include <libraries/openpci.h>
 #include <xhci/xhci.h>
 #include <xhci/xhci-events.h>
 #include <device.h>
@@ -49,6 +52,7 @@ static ULONG xhci_int_isr(struct ExecBase *execBase asm("a6"), struct XHCIUnit *
 	(void)vector;
 
 	struct xhci_ctrl *ctrl = unit->xhci_ctrl;
+	struct Library *pcielibBase = unit->device->pcieBase;
 	ULONG status = mmio_read32(&ctrl->hcor->or_usbsts) & XHCI_IRQ_ACK_MASK;
 
 	if (!status)
@@ -62,13 +66,16 @@ static ULONG xhci_int_isr(struct ExecBase *execBase asm("a6"), struct XHCIUnit *
 	mmio_write32(status & XHCI_IRQ_ACK_MASK, &ctrl->hcor->or_usbsts);
 	xhci_irq_disable_runtime(ctrl);
 
-	if (unit->xhci_ctrl->pci_dev->msi.enabled)
+	if (ctrl->pci_dev)
 	{
-		pci_msi_mask_irq(unit->xhci_ctrl->pci_dev, unit->xhci_ctrl->pci_dev->msi.irq);
-	}
-	else if (!pci_check_and_set_intx_mask(ctrl->pci_dev, TRUE))
-	{
-		KprintfH("[xhci] %s: failed to mask INTx line\n", __func__);
+		if (ctrl->msi_enabled)
+		{
+			MaskMSI(ctrl->pci_dev);
+		}
+		else if (!CheckSetINTxMask(ctrl->pci_dev, TRUE))
+		{
+			KprintfH("[xhci] %s: failed to mask INTx line\n", __func__);
+		}
 	}
 
 	Signal(unit->task, 1UL << unit->irq_signal);
@@ -99,12 +106,13 @@ static inline void xhci_irq_stop(struct xhci_ctrl *ctrl)
 void xhci_int_rearm(struct XHCIUnit *unit)
 {
 	struct xhci_ctrl *ctrl = unit->xhci_ctrl;
+	struct Library *pcielibBase = unit->device->pcieBase;
 
-	if (ctrl->pci_dev && ctrl->pci_dev->msi.enabled)
+	if (ctrl->pci_dev && ctrl->msi_enabled)
 	{
-		pci_msi_unmask_irq(ctrl->pci_dev, ctrl->pci_dev->msi.irq);
+		UnmaskMSI(ctrl->pci_dev);
 	}
-	else if (ctrl->pci_dev && !pci_check_and_set_intx_mask(ctrl->pci_dev, FALSE))
+	else if (ctrl->pci_dev && !CheckSetINTxMask(ctrl->pci_dev, FALSE))
 	{
 		Signal(unit->task, 1UL << unit->irq_signal);
 		return;
@@ -113,57 +121,25 @@ void xhci_int_rearm(struct XHCIUnit *unit)
 	xhci_irq_enable_runtime(ctrl);
 }
 
-static s32 xhci_intx_enable(struct XHCIUnit *unit)
+static s32 xhci_pci_int_enable(struct XHCIUnit *unit)
 {
-	Kprintf("[xhci] %s: enabling INTx\n", __func__);
-	// UBYTE irq_line_cfg;
-	// pci_read_config8(unit->xhci_ctrl->pci_dev, PCI_INTERRUPT_LINE, &irq_line_cfg);
-	// if (irq_line_cfg == 0 || irq_line_cfg == 0xff)
-	// {
-	// 	Kprintf("[xhci] %s: controller reports no legacy INTx line (value=0x%02lx)\n", __func__, (ULONG)irq_line_cfg);
-	// 	return -ENODEV;
-	// }
-
-	// unit->irq_line = irq_line_cfg + 32;
-	unit->irq_line = (u32)(unit->xhci_ctrl->pci_dev->irq + 32);
-
-	s32 ret = AddIntServerEx((ULONG)unit->irq_line, 0, FALSE, &unit->irq_isr);
-	if (ret < 0)
-	{
-		Kprintf("[xhci] %s: AddIntServerEx failed for IRQ %lu (ret=%ld)\n", __func__, (ULONG)unit->irq_line, (LONG)ret);
-		return ret;
-	}
-
 	struct xhci_ctrl *ctrl = unit->xhci_ctrl;
+	struct Library *pcielibBase = unit->device->pcieBase;
 
-	pci_intx(ctrl->pci_dev, TRUE);
-	pci_check_and_set_intx_mask(ctrl->pci_dev, FALSE);
-
-	return 0;
-}
-
-static s32 xhci_msi_enable(struct XHCIUnit *unit)
-{
-	Kprintf("[xhci] %s: enabling MSI\n", __func__);
-	if (unit->xhci_ctrl->pci_dev->msi.enabled)
+	if (DEVICE_USE_MSI && EnableMSI(ctrl->pci_dev)!=0)
 	{
-		Kprintf("[xhci] %s: MSI already enabled\n", __func__);
-		return 0;
+		Kprintf("[xhci] %s: MSI not supported, falling back to INTx\n", __func__);
+	}
+	else
+	{
+		Kprintf("[xhci] %s: MSI enabled successfully\n", __func__);
+		ctrl->msi_enabled = TRUE;
 	}
 
-	if (pci_get_controller(unit->xhci_ctrl->pci_dev->bus)->msi.enabled == FALSE)
+	if (!pci_add_intserver(&unit->irq_isr, ctrl->pci_dev))
 	{
-		Kprintf("[xhci] %s: MSI not supported on this controller, falling back to INTx\n", __func__);
-		return xhci_intx_enable(unit);
-	}
-
-	unit->irq_line = (u32)(unit->xhci_ctrl->pci_dev->msi.irq + 32);
-
-	s32 ret = add_int_server(unit->xhci_ctrl->pci_dev, &unit->irq_isr);
-	if (ret < 0)
-	{
-		Kprintf("[xhci] %s: add_int_server failed (ret=%ld)\n", __func__, (LONG)ret);
-		return ret;
+		Kprintf("[xhci] %s: pci_add_intserver failed\n", __func__);
+		return -1;
 	}
 
 	return 0;
@@ -176,10 +152,8 @@ s32 xhci_int_enable(struct XHCIUnit *unit)
 	s32 result = 0;
 	if (!unit->xhci_ctrl->pci_dev)
 		result = AddIntServerEx((ULONG)unit->irq_line, 0, FALSE, &unit->irq_isr);
-	else if (DEVICE_USE_MSI)
-		result = xhci_msi_enable(unit);
 	else
-		result = xhci_intx_enable(unit);
+		result = xhci_pci_int_enable(unit);
 
 	xhci_irq_start(unit->xhci_ctrl);
 
@@ -191,19 +165,12 @@ void xhci_int_shutdown(struct XHCIUnit *unit)
 	if (!unit)
 		return;
 
+	struct Library *pcielibBase = unit->device->pcieBase;
+
 	xhci_irq_stop(unit->xhci_ctrl);
 
 	if (!unit->xhci_ctrl->pci_dev)
 		RemIntServerEx((ULONG)unit->irq_line, &unit->irq_isr);
-	else if (DEVICE_USE_MSI && unit->xhci_ctrl->pci_dev->msi.enabled)
-		rem_int_server(unit->xhci_ctrl->pci_dev);
 	else
-	{
-		if (!pci_check_and_set_intx_mask(unit->xhci_ctrl->pci_dev, FALSE))
-		{
-			Kprintf("[xhci] %s: failed to unmask INTx line during shutdown\n", __func__);
-		}
-
-		RemIntServerEx((ULONG)unit->irq_line, &unit->irq_isr);
-	}
+		pci_rem_intserver(&unit->irq_isr, unit->xhci_ctrl->pci_dev);
 }

--- a/xhci.device/src/irq.c
+++ b/xhci.device/src/irq.c
@@ -3,11 +3,14 @@
 #include <clib/exec_protos.h>
 #include <clib/gic400_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
+#define GIC400_BASE_NAME unit->device->gic400Base
 #include <proto/gic400.h>
 #endif
 
-#include <compat.h>
+#include <emu_iomem.h>
 #include <config.h>
 #include <debug.h>
 #include <pci.h>
@@ -40,9 +43,9 @@ static inline void xhci_irq_update_cmd(struct xhci_ctrl *ctrl, BOOL enable)
 	writel(cmd, &ctrl->hcor->or_usbcmd);
 }
 
-static ULONG xhci_int_isr(struct ExecBase *SysBase asm("a6"), struct XHCIUnit *unit asm("a1"), ULONG vector asm("d0"))
+static ULONG xhci_int_isr(struct ExecBase *execBase asm("a6"), struct XHCIUnit *unit asm("a1"), ULONG vector asm("d0"))
 {
-	(void)SysBase;
+	(void)execBase;
 	(void)vector;
 
 	struct xhci_ctrl *ctrl = unit->xhci_ctrl;

--- a/xhci.device/src/irq.c
+++ b/xhci.device/src/irq.c
@@ -10,7 +10,7 @@
 #include <proto/gic400.h>
 #endif
 
-#include <emu_iomem.h>
+#include <iomem.h>
 #include <config.h>
 #include <debug.h>
 #include <pci.h>
@@ -22,25 +22,25 @@
 
 static inline void xhci_irq_disable_runtime(struct xhci_ctrl *ctrl)
 {
-	u32 iman = readl(&ctrl->ir_set->irq_pending);
-	writel(ER_IRQ_DISABLE(iman) | ER_IRQ_PENDING(iman), &ctrl->ir_set->irq_pending);
+	u32 iman = mmio_read32(&ctrl->ir_set->irq_pending);
+	mmio_write32(ER_IRQ_DISABLE(iman) | ER_IRQ_PENDING(iman), &ctrl->ir_set->irq_pending);
 }
 
 static inline void xhci_irq_enable_runtime(struct xhci_ctrl *ctrl)
 {
-	u32 iman = readl(&ctrl->ir_set->irq_pending);
-	writel(ER_IRQ_ENABLE(iman) | ER_IRQ_PENDING(iman), &ctrl->ir_set->irq_pending);
+	u32 iman = mmio_read32(&ctrl->ir_set->irq_pending);
+	mmio_write32(ER_IRQ_ENABLE(iman) | ER_IRQ_PENDING(iman), &ctrl->ir_set->irq_pending);
 }
 
 static inline void xhci_irq_update_cmd(struct xhci_ctrl *ctrl, BOOL enable)
 {
 	KprintfH("[xhci] %s: %s CMD_EIE | CMD_HSEIE\n", __func__, enable ? "enabling" : "disabling");
-	u32 cmd = readl(&ctrl->hcor->or_usbcmd);
+	u32 cmd = mmio_read32(&ctrl->hcor->or_usbcmd);
 	if (enable)
 		cmd |= (CMD_EIE | CMD_HSEIE);
 	else
 		cmd &= ~(CMD_EIE | CMD_HSEIE);
-	writel(cmd, &ctrl->hcor->or_usbcmd);
+	mmio_write32(cmd, &ctrl->hcor->or_usbcmd);
 }
 
 static ULONG xhci_int_isr(struct ExecBase *execBase asm("a6"), struct XHCIUnit *unit asm("a1"), ULONG vector asm("d0"))
@@ -49,7 +49,7 @@ static ULONG xhci_int_isr(struct ExecBase *execBase asm("a6"), struct XHCIUnit *
 	(void)vector;
 
 	struct xhci_ctrl *ctrl = unit->xhci_ctrl;
-	ULONG status = readl(&ctrl->hcor->or_usbsts) & XHCI_IRQ_ACK_MASK;
+	ULONG status = mmio_read32(&ctrl->hcor->or_usbsts) & XHCI_IRQ_ACK_MASK;
 
 	if (!status)
 		return 0;
@@ -59,7 +59,7 @@ static ULONG xhci_int_isr(struct ExecBase *execBase asm("a6"), struct XHCIUnit *
 		Kprintf("[xhci] %s: fatal status interrupt (USBSTS=0x%08lx)\n", __func__, status);
 	}
 
-	writel(status & XHCI_IRQ_ACK_MASK, &ctrl->hcor->or_usbsts);
+	mmio_write32(status & XHCI_IRQ_ACK_MASK, &ctrl->hcor->or_usbsts);
 	xhci_irq_disable_runtime(ctrl);
 
 	if (unit->xhci_ctrl->pci_dev->msi.enabled)

--- a/xhci.device/src/unit.c
+++ b/xhci.device/src/unit.c
@@ -9,11 +9,11 @@
 
 #include <exec/execbase.h>
 #include <exec/types.h>
-#include <emu_errors.h>
-#include <emu_iomem.h>
-#include <emu_string.h>
-#include <emu_timing.h>
-#include <emu_types.h>
+#include <errors.h>
+#include <iomem.h>
+#include <strutil.h>
+#include <timing.h>
+#include <types.h>
 
 #include <debug.h>
 #include <device.h>
@@ -76,9 +76,9 @@ static int unit_init_onboard_xhci(struct XHCIUnit *unit,
 	*hccr = (struct xhci_hccr *)base;
 	Kprintf("[bcm-xhci] %s: init mapped hccr %lx\n", __func__, *hccr);
 
-	*hcor = (struct xhci_hcor *)((uintptr_t)*hccr + HC_LENGTH(readl(&(*hccr)->cr_capbase)));
+	*hcor = (struct xhci_hcor *)((uintptr_t)*hccr + HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 	Kprintf("[bcm-xhci] %s: init hccr %lx and hcor %lx hc_length %ld\n",
-			__func__, *hccr, *hcor, (u32)HC_LENGTH(readl(&(*hccr)->cr_capbase)));
+			__func__, *hccr, *hcor, (u32)HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
 	return 0;
 }
@@ -203,10 +203,10 @@ static int pcie_xhci_init(struct pci_device *dev, struct xhci_hccr **hccr,
 	Kprintf("[xhci] %s: init mapped hccr %lx\n", __func__, *hccr);
 
 	*hcor = (struct xhci_hcor *)((uintptr_t)*hccr +
-								 HC_LENGTH(readl(&(*hccr)->cr_capbase)));
+							 HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
 	Kprintf("[xhci] %s: init hccr %lx and hcor %lx hc_length %ld\n",
-			__func__, *hccr, *hcor, (u32)HC_LENGTH(readl(&(*hccr)->cr_capbase)));
+			__func__, *hccr, *hcor, (u32)HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
 	/* enable busmaster */
 	u32 cmd;

--- a/xhci.device/src/unit.c
+++ b/xhci.device/src/unit.c
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-only
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
+#include <clib/bcmpcie_protos.h>
 #else
 #define __NOLIBBASE__
 #define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
+#define BCMPCIE_BASE_NAME pcielibBase
+#include <proto/bcmpcie.h>
 #endif
 
 #include <exec/execbase.h>
@@ -23,8 +26,8 @@
 #include <devtree.h>
 
 #include <devices/hcd_api.h>
-#include <pci_types.h>
-#include <pci.h>
+#include <libraries/pci_constants.h>
+#include <libraries/openpci.h>
 #include <xhci/xhci.h>
 #include <config.h>
 
@@ -47,7 +50,7 @@ static s32 unit_init_onboard_xhci(struct XHCIUnit *unit,
 	}
 
 	CONST_STRPTR status = DT_GetPropValue(DT_FindProperty(key, (CONST_STRPTR) "status"));
-	if (status != NULL && _Stricmp(status, (CONST_STRPTR)"disabled") == 0)
+	if (status != NULL && _Stricmp(status, (CONST_STRPTR) "disabled") == 0)
 	{
 		Kprintf("[bcm-xhci] %s: Node %s is disabled\n", __func__, "/scb/xhci");
 		DT_CloseKey(key);
@@ -83,105 +86,28 @@ static s32 unit_init_onboard_xhci(struct XHCIUnit *unit,
 	return 0;
 }
 
-/*
- * Initialize and enumerate the PCIe bus
- */
-static s32 pcie_init(struct XHCIDevice *device)
+static BOOL pcie_xhci_is_supported(struct Library *pcielibBase, struct pci_dev *pd)
 {
-	if (device->pcie != NULL)
-		return 0;
-
-	device->pcie = AllocMem(sizeof(struct pci_controller), MEMF_CLEAR | MEMF_PUBLIC);
-	if (!device->pcie)
-	{
-		Kprintf("[pcie] %s: Failed to allocate memory for PCIe controller\n", __func__);
-		return -ENOMEM;
-	}
-	_NewMinList(&device->pcie->buses);
-
-	int ret = brcm_pcie_probe(device->pcie, /* bus number */ 0);
-	if (ret < 0)
-	{
-		Kprintf("[pcie] %s: brcm_pcie_probe failed: %ld\n", __func__, ret);
-		FreeMem(device->pcie, sizeof(*device->pcie));
-		device->pcie = NULL;
-		return -ENODEV;
-	}
-	Kprintf("[pcie] %s: brcm_pcie_probe succeeded\n", __func__);
-
-	struct pci_bus *root_bus = AllocMem(sizeof(*root_bus), MEMF_CLEAR);
-	if (!root_bus)
-	{
-		Kprintf("[pcie] %s: Failed to allocate memory for root bus\n", __func__);
-		return -ENOMEM;
-	}
-
-	_NewMinList(&root_bus->devices);
-	root_bus->controller = device->pcie;
-	root_bus->parent = NULL;
-	root_bus->pci_bridge = NULL;
-	CopyMem((APTR)"pcie0", root_bus->name, sizeof("pcie0"));
-	root_bus->bus_number = 0;
-	root_bus->bus_number_last_sub = 0;
-	AddTailMinList(&device->pcie->buses, (struct MinNode *)root_bus);
-
-	ret = pci_bind_bus_devices(root_bus);
-	if (ret)
-	{
-		Kprintf("[pcie] %s: pci_bind_bus_devices failed: %ld\n", __func__, ret);
-		FreeMem(root_bus, sizeof(*root_bus));
-		return -ENODEV;
-	}
-
-	ret = pci_auto_config_devices(root_bus);
-	if (ret < 0)
-	{
-		Kprintf("[pcie] %s: pci_auto_config_devices failed: %ld\n", __func__, ret);
-		FreeMem(root_bus, sizeof(*root_bus));
-		return -ENODEV;
-	}
-
-	return 0;
-}
-
-static s32 vl805_init(void)
-{
-	s32 ret = bcm2711_reload_vl805_firmware();
-	if (ret != 0)
-	{
-		Kprintf("[vl805] %s: Failed to load VL805 firmware: %ld\n", __func__, ret);
-		return -ENODEV;
-	}
-	/* It seems to take a while for the VL805 to start responding */
-	delay_us(1000);
-	return 0;
-}
-
-static BOOL pcie_xhci_is_supported(struct pci_device *dev)
-{
-	// Check some basic PCI device info
-	ULONG vendor_device;
-	UBYTE revision, prog_if, subclass, baseclass;
-	ULONG mcu_firmware;
-
-	pci_read_config32(dev, PCI_VENDOR_ID, &vendor_device);
-	pci_read_config8(dev, PCI_REVISION_ID, &revision);
-	pci_read_config8(dev, PCI_CLASS_PROG, &prog_if);
-	pci_read_config8(dev, PCI_CLASS_DEVICE, &subclass);
-	pci_read_config8(dev, PCI_CLASS_DEVICE + 1, &baseclass);
-	pci_read_config32(dev, 0x50, &mcu_firmware);
-
 	Kprintf("[pcie] %s: Device Info:\n", __func__);
-	Kprintf("[pcie] %s:   Vendor:Device = 0x%08lx\n", __func__, vendor_device);
-	Kprintf("[pcie] %s:   Class = %02lx:%02lx:%02lx (revision %02lx)\n", __func__, baseclass, subclass, prog_if, revision);
-	Kprintf("[pcie] %s:   MCU Firmware Version: 0x%08lx\n", __func__, mcu_firmware);
+	Kprintf("[pcie] %s:   Vendor:Device = 0x%04lx:%04lx\n", __func__,
+			(ULONG)pd->vendor, (ULONG)pd->device);
 
-	// Check if device is responding to config space
-	if (vendor_device == 0xFFFFFFFF)
+	/* Check if device is responding */
+	if (pd->vendor == 0xFFFFU && pd->device == 0xFFFFU)
 	{
 		Kprintf("[pcie] %s: Device not responding to config space reads!\n", __func__);
 		return FALSE;
 	}
+
+	UBYTE revision = pci_read_config_byte(PCI_REVISION_ID, pd);
+	UBYTE prog_if = pci_read_config_byte(PCI_CLASS_PROG, pd);
+	UBYTE subclass = pci_read_config_byte((UBYTE)PCI_CLASS_DEVICE, pd);
+	UBYTE baseclass = pci_read_config_byte((UBYTE)(PCI_CLASS_DEVICE + 1), pd);
+	ULONG mcu_firmware = pci_read_config_long((UBYTE)0x50, pd);
+
+	Kprintf("[pcie] %s:   Class = %02lx:%02lx:%02lx (revision %02lx)\n",
+			__func__, (ULONG)baseclass, (ULONG)subclass, (ULONG)prog_if, (ULONG)revision);
+	Kprintf("[pcie] %s:   MCU Firmware Version: 0x%08lx\n", __func__, mcu_firmware);
 
 	return TRUE;
 }
@@ -189,12 +115,10 @@ static BOOL pcie_xhci_is_supported(struct pci_device *dev)
 /*
  * Map BAR, get register pointers and enable bus mastering
  */
-static s32 pcie_xhci_init(struct pci_device *dev, struct xhci_hccr **hccr,
-						  struct xhci_hcor **hcor)
+static s32 pcie_xhci_init(struct Library *pcielibBase, struct pci_dev *pd,
+						  struct xhci_hccr **hccr, struct xhci_hcor **hcor)
 {
-	*hccr = (struct xhci_hccr *)pci_map_bar(dev,
-											   PCI_BASE_ADDRESS_0, 0, 0, PCI_REGION_TYPE,
-											   PCI_REGION_MEM);
+	*hccr = (struct xhci_hccr *)MapBAR(pd, 0, 0, 0, PCI_REGION_MEM);
 	if (!*hccr)
 	{
 		Kprintf("[xhci] %s: init cannot map PCI mem bar\n", __func__);
@@ -203,82 +127,62 @@ static s32 pcie_xhci_init(struct pci_device *dev, struct xhci_hccr **hccr,
 	Kprintf("[xhci] %s: init mapped hccr %lx\n", __func__, *hccr);
 
 	*hcor = (struct xhci_hcor *)((uintptr_t)*hccr +
-							 HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
+								 HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
 	Kprintf("[xhci] %s: init hccr %lx and hcor %lx hc_length %lu\n",
 			__func__, *hccr, *hcor, (ULONG)HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
-	/* enable busmaster */
-	u32 cmd;
-	pci_read_config32(dev, PCI_COMMAND, &cmd);
-	cmd |= PCI_COMMAND_MASTER;
-	pci_write_config32(dev, PCI_COMMAND, cmd);
+	pci_set_master(pd);
 	return 0;
 }
 
-static s32 unit_init_pcie_xhci(LONG unitNumber, struct pci_device **ret_xhci_dev,
+static s32 unit_init_pcie_xhci(LONG unitNumber, struct pci_dev **ret_pci_dev,
 							   struct xhci_hccr **ret_hccr,
 							   struct xhci_hcor **ret_hcor,
 							   struct XHCIDevice *device)
 {
-	struct pci_device *xhci_dev = NULL;
-	s32 result = pcie_init(device);
-	if (result != 0)
+	/* Lazily open the PCI library on first PCIe unit access */
+	if (xhci_open_pcie_library(device) != 0)
 	{
-		Kprintf("[xhci] %s: Failed to initialize PCIe: %ld\n", __func__, result);
-		return result;
-	}
-
-	/* -1 because unit 0 is always the OTG port and pci_find_class indexes from 0 */
-	pci_find_class(device->pcie, 0x0C0330, unitNumber - 1, &xhci_dev);
-	if (xhci_dev == NULL)
-	{
-		Kprintf("[xhci] %s: Failed to find XHCI PCI device\n", __func__);
+		Kprintf("[xhci] %s: No PCI library available for unit %ld\n", __func__, unitNumber);
 		return ERR_BAD_PARAMETERS;
 	}
 
-	if (xhci_dev->vendor == 0x1106 && xhci_dev->device == 0x3483)
+	struct Library *pcielibBase = device->pcieBase;
+
+	/* Find the (unitNumber)th PCIe xHCI controller (unit 0 is always onboard;
+	 * pcie.library handles bus init + VL805 firmware reload on first open). */
+	struct pci_dev *pd = NULL;
+	for (LONG i = 0; i < unitNumber; i++)
 	{
-		Kprintf("[xhci] %s: Found VL805 XHCI controller, loading firmware\n", __func__);
-		result = vl805_init();
-		if (result != 0)
-		{
-			Kprintf("[xhci] %s: Failed to load VL805 firmware: %ld\n", __func__, result);
-			/* continue, this may be other XHCI controller */
-		}
+		pd = pci_find_class(0x0C0330, pd);
+		if (!pd)
+			break;
+	}
+	if (!pd)
+	{
+		Kprintf("[xhci] %s: Failed to find XHCI PCI device (unit %ld)\n", __func__, unitNumber);
+		return ERR_BAD_PARAMETERS;
 	}
 
-	if (!pcie_xhci_is_supported(xhci_dev))
+	if (!pcie_xhci_is_supported(pcielibBase, pd))
 	{
 		Kprintf("[xhci] %s: Unsupported XHCI controller\n", __func__);
 		return ERR_BAD_PARAMETERS;
 	}
 
-	result = pcie_xhci_init(xhci_dev, ret_hccr, ret_hcor);
+	s32 result = pcie_xhci_init(pcielibBase, pd, ret_hccr, ret_hcor);
 	if (result != 0)
 	{
 		Kprintf("[xhci] %s: Failed to initialize XHCI PCI device: %ld\n", __func__, result);
 		return result;
 	}
 
-	*ret_xhci_dev = xhci_dev;
+	*ret_pci_dev = pd;
 	return 0;
 }
 
-static s32 unit_init_xhci_hw(struct XHCIUnit *unit, LONG unitNumber,
-							 struct pci_device **ret_xhci_dev,
-							 struct xhci_hccr **ret_hccr,
-							 struct xhci_hcor **ret_hcor)
-{
-	*ret_xhci_dev = NULL;
-
-	if (unitNumber == 0)
-		return unit_init_onboard_xhci(unit, ret_hccr, ret_hcor);
-
-	return unit_init_pcie_xhci(unitNumber, ret_xhci_dev, ret_hccr, ret_hcor, unit->device);
-}
-
-static s32 unit_attach_xhci(struct XHCIUnit *unit, struct pci_device *xhci_dev,
+static s32 unit_attach_xhci(struct XHCIUnit *unit, struct pci_dev *pci_dev,
 							struct xhci_hccr *hccr, struct xhci_hcor *hcor)
 {
 	struct xhci_ctrl *xhci_ctrl = AllocMem(sizeof(struct xhci_ctrl), MEMF_CLEAR | MEMF_PUBLIC);
@@ -289,7 +193,7 @@ static s32 unit_attach_xhci(struct XHCIUnit *unit, struct pci_device *xhci_dev,
 	}
 
 	xhci_ctrl->utilityBase = unit->device->utilityBase;
-	xhci_ctrl->pci_dev = xhci_dev;
+	xhci_ctrl->pci_dev = pci_dev;
 
 	s32 result = xhci_register(xhci_ctrl, hccr, hcor);
 	if (result)
@@ -349,12 +253,14 @@ s32 UnitOpen(struct XHCIUnit *unit, LONG unitNumber, LONG flags)
 
 	struct xhci_hccr *hccr;
 	struct xhci_hcor *hcor;
-	struct pci_device *xhci_dev = NULL;
-	s32 result = unit_init_xhci_hw(unit, unitNumber, &xhci_dev, &hccr, &hcor);
+	struct pci_dev *pci_dev = NULL;
+	s32 result = (unitNumber == 0)
+		? unit_init_onboard_xhci(unit, &hccr, &hcor)
+		: unit_init_pcie_xhci(unitNumber, &pci_dev, &hccr, &hcor, unit->device);
 	if (result != ERR_NO_ERROR)
 		goto err_del_pool;
 
-	result = unit_attach_xhci(unit, xhci_dev, hccr, hcor);
+	result = unit_attach_xhci(unit, pci_dev, hccr, hcor);
 	if (result != ERR_NO_ERROR)
 		goto err_del_pool;
 

--- a/xhci.device/src/unit.c
+++ b/xhci.device/src/unit.c
@@ -1,39 +1,43 @@
 // SPDX-License-Identifier: GPL-2.0+
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
-#include <clib/dos_protos.h>
-#include <clib/utility_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
-#include <proto/dos.h>
-#include <proto/utility.h>
 #endif
 
 #include <exec/execbase.h>
 #include <exec/types.h>
-#include <stdarg.h>
+#include <emu_errors.h>
+#include <emu_iomem.h>
+#include <emu_string.h>
+#include <emu_timing.h>
+#include <emu_types.h>
 
 #include <debug.h>
 #include <device.h>
-#include <compat.h>
 #include <minlist.h>
+
+#define __NOLIBBASE__
 #include <devtree.h>
 
-#include <msg.h>
 #include <devices/hcd_api.h>
 #include <pci_types.h>
 #include <pci.h>
 #include <xhci/xhci.h>
 #include <config.h>
 
-static struct pci_controller *pcie = NULL;
-extern struct MinList pci_bus_list;
-
 static int unit_init_onboard_xhci(struct XHCIUnit *unit,
 								  struct xhci_hccr **hccr,
 								  struct xhci_hcor **hcor)
 {
-	DT_Init();
+	APTR DeviceTreeBase = OpenResource((CONST_STRPTR) "devicetree.resource");
+	if (DeviceTreeBase == NULL)
+	{
+		Kprintf("[bcm-xhci] %s: Failed to open devicetree.resource\n", __func__);
+		return -1;
+	}
 
 	APTR key = DT_OpenKey((CONST_STRPTR) "/scb/xhci");
 	if (key == NULL)
@@ -43,7 +47,7 @@ static int unit_init_onboard_xhci(struct XHCIUnit *unit,
 	}
 
 	CONST_STRPTR status = DT_GetPropValue(DT_FindProperty(key, (CONST_STRPTR) "status"));
-	if (status && Stricmp((STRPTR)status, (STRPTR)"disabled") == 0)
+	if (status != NULL && _Stricmp(status, (CONST_STRPTR)"disabled") == 0)
 	{
 		Kprintf("[bcm-xhci] %s: Node %s is disabled\n", __func__, "/scb/xhci");
 		DT_CloseKey(key);
@@ -82,27 +86,28 @@ static int unit_init_onboard_xhci(struct XHCIUnit *unit,
 /*
  * Initialize and enumerate the PCIe bus
  */
-static int pcie_init(void)
+static int pcie_init(struct XHCIDevice *device)
 {
-	if (pcie != NULL)
+	if (device->pcie != NULL)
 		return 0;
 
-	pcie = AllocMem(sizeof(struct pci_controller), MEMF_CLEAR | MEMF_PUBLIC);
-	if (!pcie)
+	device->pcie = AllocMem(sizeof(struct pci_controller), MEMF_CLEAR | MEMF_PUBLIC);
+	if (!device->pcie)
 	{
 		Kprintf("[pcie] %s: Failed to allocate memory for PCIe controller\n", __func__);
 		return -ENOMEM;
 	}
+	_NewMinList(&device->pcie->buses);
 
-	int ret = brcm_pcie_probe(pcie, /* bus number */ 0);
+	int ret = brcm_pcie_probe(device->pcie, /* bus number */ 0);
 	if (ret < 0)
 	{
 		Kprintf("[pcie] %s: brcm_pcie_probe failed: %ld\n", __func__, ret);
+		FreeMem(device->pcie, sizeof(*device->pcie));
+		device->pcie = NULL;
 		return -ENODEV;
 	}
 	Kprintf("[pcie] %s: brcm_pcie_probe succeeded\n", __func__);
-
-	_NewMinList(&pci_bus_list);
 
 	struct pci_bus *root_bus = AllocMem(sizeof(*root_bus), MEMF_CLEAR);
 	if (!root_bus)
@@ -112,18 +117,19 @@ static int pcie_init(void)
 	}
 
 	_NewMinList(&root_bus->devices);
-	root_bus->controller = pcie;
+	root_bus->controller = device->pcie;
 	root_bus->parent = NULL;
 	root_bus->pci_bridge = NULL;
 	CopyMem((APTR)"pcie0", root_bus->name, sizeof("pcie0"));
 	root_bus->bus_number = 0;
 	root_bus->bus_number_last_sub = 0;
-	AddTailMinList(&pci_bus_list, (struct MinNode *)root_bus);
+	AddTailMinList(&device->pcie->buses, (struct MinNode *)root_bus);
 
 	ret = pci_bind_bus_devices(root_bus);
 	if (ret)
 	{
 		Kprintf("[pcie] %s: pci_bind_bus_devices failed: %ld\n", __func__, ret);
+		FreeMem(root_bus, sizeof(*root_bus));
 		return -ENODEV;
 	}
 
@@ -131,6 +137,7 @@ static int pcie_init(void)
 	if (ret < 0)
 	{
 		Kprintf("[pcie] %s: pci_auto_config_devices failed: %ld\n", __func__, ret);
+		FreeMem(root_bus, sizeof(*root_bus));
 		return -ENODEV;
 	}
 
@@ -139,7 +146,7 @@ static int pcie_init(void)
 
 static int vl805_init(void)
 {
-	int ret = bcm2711_notify_vl805_reset();
+	int ret = bcm2711_reload_vl805_firmware();
 	if (ret != 0)
 	{
 		Kprintf("[vl805] %s: Failed to load VL805 firmware: %ld\n", __func__, ret);
@@ -211,10 +218,11 @@ static int pcie_xhci_init(struct pci_device *dev, struct xhci_hccr **hccr,
 
 static int unit_init_pcie_xhci(LONG unitNumber, struct pci_device **ret_xhci_dev,
 							   struct xhci_hccr **ret_hccr,
-							   struct xhci_hcor **ret_hcor)
+							   struct xhci_hcor **ret_hcor,
+							   struct XHCIDevice *device)
 {
 	struct pci_device *xhci_dev = NULL;
-	int result = pcie_init();
+	int result = pcie_init(device);
 	if (result != 0)
 	{
 		Kprintf("[xhci] %s: Failed to initialize PCIe: %ld\n", __func__, result);
@@ -222,7 +230,7 @@ static int unit_init_pcie_xhci(LONG unitNumber, struct pci_device **ret_xhci_dev
 	}
 
 	/* -1 because unit 0 is always the OTG port and dm_pci_find_class indexes from 0 */
-	dm_pci_find_class(0x0C0330, unitNumber - 1, &xhci_dev);
+	dm_pci_find_class(device->pcie, 0x0C0330, unitNumber - 1, &xhci_dev);
 	if (xhci_dev == NULL)
 	{
 		Kprintf("[xhci] %s: Failed to find XHCI PCI device\n", __func__);
@@ -267,7 +275,7 @@ static int unit_init_xhci_hw(struct XHCIUnit *unit, LONG unitNumber,
 	if (unitNumber == 0)
 		return unit_init_onboard_xhci(unit, ret_hccr, ret_hcor);
 
-	return unit_init_pcie_xhci(unitNumber, ret_xhci_dev, ret_hccr, ret_hcor);
+	return unit_init_pcie_xhci(unitNumber, ret_xhci_dev, ret_hccr, ret_hcor, unit->device);
 }
 
 static int unit_attach_xhci(struct XHCIUnit *unit, struct pci_device *xhci_dev,
@@ -280,6 +288,7 @@ static int unit_attach_xhci(struct XHCIUnit *unit, struct pci_device *xhci_dev,
 		return ERR_ALLOC_ERROR;
 	}
 
+	xhci_ctrl->utilityBase = unit->device->utilityBase;
 	xhci_ctrl->pci_dev = xhci_dev;
 
 	int result = xhci_register(xhci_ctrl, hccr, hcor);

--- a/xhci.device/src/unit.c
+++ b/xhci.device/src/unit.c
@@ -89,14 +89,14 @@ static s32 unit_init_onboard_xhci(struct XHCIUnit *unit,
 
 static BOOL pcie_xhci_is_supported(struct Library *pcielibBase, struct pci_dev *pd)
 {
-	Kprintf("[pcie] %s: Device Info:\n", __func__);
-	Kprintf("[pcie] %s:   Vendor:Device = 0x%04lx:%04lx\n", __func__,
+	Kprintf("[xhci] %s: Device Info:\n", __func__);
+	Kprintf("[xhci] %s:   Vendor:Device = 0x%04lx:%04lx\n", __func__,
 			(ULONG)pd->vendor, (ULONG)pd->device);
 
 	/* Check if device is responding */
 	if (pd->vendor == 0xFFFFU && pd->device == 0xFFFFU)
 	{
-		Kprintf("[pcie] %s: Device not responding to config space reads!\n", __func__);
+		Kprintf("[xhci] %s: Device not responding to config space reads!\n", __func__);
 		return FALSE;
 	}
 
@@ -106,9 +106,9 @@ static BOOL pcie_xhci_is_supported(struct Library *pcielibBase, struct pci_dev *
 	UBYTE baseclass = pci_read_config_byte((UBYTE)(PCI_CLASS_DEVICE + 1), pd);
 	ULONG mcu_firmware = pci_read_config_long((UBYTE)0x50, pd);
 
-	Kprintf("[pcie] %s:   Class = %02lx:%02lx:%02lx (revision %02lx)\n",
+	Kprintf("[xhci] %s:   Class = %02lx:%02lx:%02lx (revision %02lx)\n",
 			__func__, (ULONG)baseclass, (ULONG)subclass, (ULONG)prog_if, (ULONG)revision);
-	Kprintf("[pcie] %s:   MCU Firmware Version: 0x%08lx\n", __func__, mcu_firmware);
+	Kprintf("[xhci] %s:   MCU Firmware Version: 0x%08lx\n", __func__, mcu_firmware);
 
 	return TRUE;
 }
@@ -125,12 +125,12 @@ static s32 pcie_xhci_init(struct Library *pcielibBase, struct pci_dev *pd,
 		Kprintf("[xhci] %s: BAR0 not mapped\n", __func__);
 		return -EIO;
 	}
-	Kprintf("[xhci] %s: init mapped hccr %lx\n", __func__, *hccr);
+	KprintfH("[xhci] %s: init mapped hccr %lx\n", __func__, *hccr);
 
 	*hcor = (struct xhci_hcor *)((uintptr_t)*hccr +
 								 HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
-	Kprintf("[xhci] %s: init hccr %lx and hcor %lx hc_length %lu\n",
+	KprintfH("[xhci] %s: init hccr %lx and hcor %lx hc_length %lu\n",
 			__func__, *hccr, *hcor, (ULONG)HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
 	pci_set_master(pd);
@@ -240,7 +240,7 @@ err_free_ctrl:
 
 s32 UnitOpen(struct XHCIUnit *unit, LONG unitNumber, LONG flags)
 {
-	Kprintf("[xhci] %s: Opening unit %ld with flags %lx\n", __func__, unitNumber, flags);
+	KprintfH("[xhci] %s: Opening unit %ld with flags %lx\n", __func__, unitNumber, flags);
 	if (unit->unit.unit_OpenCnt > 0)
 	{
 		unit->unit.unit_OpenCnt++;

--- a/xhci.device/src/unit.c
+++ b/xhci.device/src/unit.c
@@ -73,7 +73,6 @@ static s32 unit_init_onboard_xhci(struct XHCIUnit *unit,
 
 	unit->irq_line = (u32)DT_GetInterrupt(key, 0);
 	Kprintf("[bcm-xhci] %s: IRQ = %lu\n", __func__, (ULONG)unit->irq_line);
-	unit->irq_line += 32;
 
 	// We're done with the device tree
 	DT_CloseKey(key);

--- a/xhci.device/src/unit.c
+++ b/xhci.device/src/unit.c
@@ -118,10 +118,10 @@ static BOOL pcie_xhci_is_supported(struct Library *pcielibBase, struct pci_dev *
 static s32 pcie_xhci_init(struct Library *pcielibBase, struct pci_dev *pd,
 						  struct xhci_hccr **hccr, struct xhci_hcor **hcor)
 {
-	*hccr = (struct xhci_hccr *)MapBAR(pd, 0, 0, 0, PCI_REGION_MEM);
+	*hccr = (struct xhci_hccr *)pd->base_address[0];
 	if (!*hccr)
 	{
-		Kprintf("[xhci] %s: init cannot map PCI mem bar\n", __func__);
+		Kprintf("[xhci] %s: BAR0 not mapped\n", __func__);
 		return -EIO;
 	}
 	Kprintf("[xhci] %s: init mapped hccr %lx\n", __func__, *hccr);

--- a/xhci.device/src/unit.c
+++ b/xhci.device/src/unit.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #else

--- a/xhci.device/src/unit.c
+++ b/xhci.device/src/unit.c
@@ -19,7 +19,6 @@
 #include <minlist.h>
 #include <devtree.h>
 
-#include <mbox.h>
 #include <msg.h>
 #include <devices/hcd_api.h>
 #include <pci_types.h>
@@ -140,14 +139,7 @@ static int pcie_init(void)
 
 static int vl805_init(void)
 {
-	int ret = mbox_parse_devtree();
-	if (ret != 0)
-	{
-		Kprintf("[vl805] %s: mbox_parse_devtree failed: %ld\n", __func__, ret);
-		return -ENODEV;
-	}
-
-	ret = bcm2711_notify_vl805_reset();
+	int ret = bcm2711_notify_vl805_reset();
 	if (ret != 0)
 	{
 		Kprintf("[vl805] %s: Failed to load VL805 firmware: %ld\n", __func__, ret);

--- a/xhci.device/src/unit.c
+++ b/xhci.device/src/unit.c
@@ -28,6 +28,8 @@
 #include <devices/hcd_api.h>
 #include <libraries/pci_constants.h>
 #include <libraries/openpci.h>
+#include <libraries/pcitags.h>
+#include <utility/tagitem.h>
 #include <xhci/xhci.h>
 #include <config.h>
 
@@ -171,10 +173,17 @@ static s32 unit_init_pcie_xhci(LONG unitNumber, struct pci_dev **ret_pci_dev,
 		return ERR_BAD_PARAMETERS;
 	}
 
+	if (!SetBoardAttrs(pd, PRM_BoardOwner, (ULONG)FindTask(NULL), TAG_DONE))
+	{
+		Kprintf("[xhci] %s: PCI device already owned by another task\n", __func__);
+		return ERR_BAD_PARAMETERS;
+	}
+
 	s32 result = pcie_xhci_init(pcielibBase, pd, ret_hccr, ret_hcor);
 	if (result != 0)
 	{
 		Kprintf("[xhci] %s: Failed to initialize XHCI PCI device: %ld\n", __func__, result);
+		SetBoardAttrs(pd, PRM_BoardOwner, 0UL, TAG_DONE);
 		return result;
 	}
 
@@ -280,6 +289,9 @@ s32 UnitClose(struct XHCIUnit *unit)
 	if (unit->unit.unit_OpenCnt == 0)
 	{
 		Kprintf("[xhci] %s: Last opener closed, cleaning up unit\n", __func__);
+		struct Library *pcielibBase = unit->device->pcieBase;
+		if (pcielibBase && unit->xhci_ctrl->pci_dev)
+			SetBoardAttrs(unit->xhci_ctrl->pci_dev, PRM_BoardOwner, 0UL, TAG_DONE);
 		UnitTaskStop(unit);
 		xhci_int_shutdown(unit);
 		xhci_deregister(unit->xhci_ctrl);

--- a/xhci.device/src/unit.c
+++ b/xhci.device/src/unit.c
@@ -28,7 +28,7 @@
 #include <xhci/xhci.h>
 #include <config.h>
 
-static int unit_init_onboard_xhci(struct XHCIUnit *unit,
+static s32 unit_init_onboard_xhci(struct XHCIUnit *unit,
 								  struct xhci_hccr **hccr,
 								  struct xhci_hcor **hcor)
 {
@@ -66,8 +66,8 @@ static int unit_init_onboard_xhci(struct XHCIUnit *unit,
 
 	Kprintf("[bcm-xhci] %s: compatible: %s\n", __func__, compatible);
 
-	unit->irq_line = DT_GetInterrupt(key, 0);
-	Kprintf("[bcm-xhci] %s: IRQ = %ld\n", __func__, unit->irq_line);
+	unit->irq_line = (u32)DT_GetInterrupt(key, 0);
+	Kprintf("[bcm-xhci] %s: IRQ = %lu\n", __func__, (ULONG)unit->irq_line);
 	unit->irq_line += 32;
 
 	// We're done with the device tree
@@ -77,8 +77,8 @@ static int unit_init_onboard_xhci(struct XHCIUnit *unit,
 	Kprintf("[bcm-xhci] %s: init mapped hccr %lx\n", __func__, *hccr);
 
 	*hcor = (struct xhci_hcor *)((uintptr_t)*hccr + HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
-	Kprintf("[bcm-xhci] %s: init hccr %lx and hcor %lx hc_length %ld\n",
-			__func__, *hccr, *hcor, (u32)HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
+	Kprintf("[bcm-xhci] %s: init hccr %lx and hcor %lx hc_length %lu\n",
+			__func__, *hccr, *hcor, (ULONG)HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
 	return 0;
 }
@@ -86,7 +86,7 @@ static int unit_init_onboard_xhci(struct XHCIUnit *unit,
 /*
  * Initialize and enumerate the PCIe bus
  */
-static int pcie_init(struct XHCIDevice *device)
+static s32 pcie_init(struct XHCIDevice *device)
 {
 	if (device->pcie != NULL)
 		return 0;
@@ -144,9 +144,9 @@ static int pcie_init(struct XHCIDevice *device)
 	return 0;
 }
 
-static int vl805_init(void)
+static s32 vl805_init(void)
 {
-	int ret = bcm2711_reload_vl805_firmware();
+	s32 ret = bcm2711_reload_vl805_firmware();
 	if (ret != 0)
 	{
 		Kprintf("[vl805] %s: Failed to load VL805 firmware: %ld\n", __func__, ret);
@@ -164,12 +164,12 @@ static BOOL pcie_xhci_is_supported(struct pci_device *dev)
 	UBYTE revision, prog_if, subclass, baseclass;
 	ULONG mcu_firmware;
 
-	dm_pci_read_config32(dev, PCI_VENDOR_ID, &vendor_device);
-	dm_pci_read_config8(dev, PCI_REVISION_ID, &revision);
-	dm_pci_read_config8(dev, PCI_CLASS_PROG, &prog_if);
-	dm_pci_read_config8(dev, PCI_CLASS_DEVICE, &subclass);
-	dm_pci_read_config8(dev, PCI_CLASS_DEVICE + 1, &baseclass);
-	dm_pci_read_config32(dev, 0x50, &mcu_firmware);
+	pci_read_config32(dev, PCI_VENDOR_ID, &vendor_device);
+	pci_read_config8(dev, PCI_REVISION_ID, &revision);
+	pci_read_config8(dev, PCI_CLASS_PROG, &prog_if);
+	pci_read_config8(dev, PCI_CLASS_DEVICE, &subclass);
+	pci_read_config8(dev, PCI_CLASS_DEVICE + 1, &baseclass);
+	pci_read_config32(dev, 0x50, &mcu_firmware);
 
 	Kprintf("[pcie] %s: Device Info:\n", __func__);
 	Kprintf("[pcie] %s:   Vendor:Device = 0x%08lx\n", __func__, vendor_device);
@@ -189,10 +189,10 @@ static BOOL pcie_xhci_is_supported(struct pci_device *dev)
 /*
  * Map BAR, get register pointers and enable bus mastering
  */
-static int pcie_xhci_init(struct pci_device *dev, struct xhci_hccr **hccr,
+static s32 pcie_xhci_init(struct pci_device *dev, struct xhci_hccr **hccr,
 						  struct xhci_hcor **hcor)
 {
-	*hccr = (struct xhci_hccr *)dm_pci_map_bar(dev,
+	*hccr = (struct xhci_hccr *)pci_map_bar(dev,
 											   PCI_BASE_ADDRESS_0, 0, 0, PCI_REGION_TYPE,
 											   PCI_REGION_MEM);
 	if (!*hccr)
@@ -205,32 +205,32 @@ static int pcie_xhci_init(struct pci_device *dev, struct xhci_hccr **hccr,
 	*hcor = (struct xhci_hcor *)((uintptr_t)*hccr +
 							 HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
-	Kprintf("[xhci] %s: init hccr %lx and hcor %lx hc_length %ld\n",
-			__func__, *hccr, *hcor, (u32)HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
+	Kprintf("[xhci] %s: init hccr %lx and hcor %lx hc_length %lu\n",
+			__func__, *hccr, *hcor, (ULONG)HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
 	/* enable busmaster */
 	u32 cmd;
-	dm_pci_read_config32(dev, PCI_COMMAND, &cmd);
+	pci_read_config32(dev, PCI_COMMAND, &cmd);
 	cmd |= PCI_COMMAND_MASTER;
-	dm_pci_write_config32(dev, PCI_COMMAND, cmd);
+	pci_write_config32(dev, PCI_COMMAND, cmd);
 	return 0;
 }
 
-static int unit_init_pcie_xhci(LONG unitNumber, struct pci_device **ret_xhci_dev,
+static s32 unit_init_pcie_xhci(LONG unitNumber, struct pci_device **ret_xhci_dev,
 							   struct xhci_hccr **ret_hccr,
 							   struct xhci_hcor **ret_hcor,
 							   struct XHCIDevice *device)
 {
 	struct pci_device *xhci_dev = NULL;
-	int result = pcie_init(device);
+	s32 result = pcie_init(device);
 	if (result != 0)
 	{
 		Kprintf("[xhci] %s: Failed to initialize PCIe: %ld\n", __func__, result);
 		return result;
 	}
 
-	/* -1 because unit 0 is always the OTG port and dm_pci_find_class indexes from 0 */
-	dm_pci_find_class(device->pcie, 0x0C0330, unitNumber - 1, &xhci_dev);
+	/* -1 because unit 0 is always the OTG port and pci_find_class indexes from 0 */
+	pci_find_class(device->pcie, 0x0C0330, unitNumber - 1, &xhci_dev);
 	if (xhci_dev == NULL)
 	{
 		Kprintf("[xhci] %s: Failed to find XHCI PCI device\n", __func__);
@@ -265,7 +265,7 @@ static int unit_init_pcie_xhci(LONG unitNumber, struct pci_device **ret_xhci_dev
 	return 0;
 }
 
-static int unit_init_xhci_hw(struct XHCIUnit *unit, LONG unitNumber,
+static s32 unit_init_xhci_hw(struct XHCIUnit *unit, LONG unitNumber,
 							 struct pci_device **ret_xhci_dev,
 							 struct xhci_hccr **ret_hccr,
 							 struct xhci_hcor **ret_hcor)
@@ -278,7 +278,7 @@ static int unit_init_xhci_hw(struct XHCIUnit *unit, LONG unitNumber,
 	return unit_init_pcie_xhci(unitNumber, ret_xhci_dev, ret_hccr, ret_hcor, unit->device);
 }
 
-static int unit_attach_xhci(struct XHCIUnit *unit, struct pci_device *xhci_dev,
+static s32 unit_attach_xhci(struct XHCIUnit *unit, struct pci_device *xhci_dev,
 							struct xhci_hccr *hccr, struct xhci_hcor *hcor)
 {
 	struct xhci_ctrl *xhci_ctrl = AllocMem(sizeof(struct xhci_ctrl), MEMF_CLEAR | MEMF_PUBLIC);
@@ -291,7 +291,7 @@ static int unit_attach_xhci(struct XHCIUnit *unit, struct pci_device *xhci_dev,
 	xhci_ctrl->utilityBase = unit->device->utilityBase;
 	xhci_ctrl->pci_dev = xhci_dev;
 
-	int result = xhci_register(xhci_ctrl, hccr, hcor);
+	s32 result = xhci_register(xhci_ctrl, hccr, hcor);
 	if (result)
 	{
 		Kprintf("[xhci] %s: xhci_register failed: %ld\n", __func__, result);
@@ -326,13 +326,13 @@ err_free_ctrl:
 	return result;
 }
 
-int UnitOpen(struct XHCIUnit *unit, LONG unitNumber, LONG flags)
+s32 UnitOpen(struct XHCIUnit *unit, LONG unitNumber, LONG flags)
 {
 	Kprintf("[xhci] %s: Opening unit %ld with flags %lx\n", __func__, unitNumber, flags);
 	if (unit->unit.unit_OpenCnt > 0)
 	{
 		unit->unit.unit_OpenCnt++;
-		Kprintf("[xhci] %s: Unit opened successfully, current open count: %ld\n", __func__, unit->unit.unit_OpenCnt);
+		Kprintf("[xhci] %s: Unit opened successfully, current open count: %lu\n", __func__, (ULONG)unit->unit.unit_OpenCnt);
 		return ERR_NO_ERROR;
 	}
 
@@ -350,7 +350,7 @@ int UnitOpen(struct XHCIUnit *unit, LONG unitNumber, LONG flags)
 	struct xhci_hccr *hccr;
 	struct xhci_hcor *hcor;
 	struct pci_device *xhci_dev = NULL;
-	int result = unit_init_xhci_hw(unit, unitNumber, &xhci_dev, &hccr, &hcor);
+	s32 result = unit_init_xhci_hw(unit, unitNumber, &xhci_dev, &hccr, &hcor);
 	if (result != ERR_NO_ERROR)
 		goto err_del_pool;
 
@@ -366,7 +366,7 @@ err_del_pool:
 	return result;
 }
 
-int UnitClose(struct XHCIUnit *unit)
+s32 UnitClose(struct XHCIUnit *unit)
 {
 	Kprintf("[xhci] %s: Closing unit %ld\n", __func__, unit->unitNumber);
 

--- a/xhci.device/src/unit_commands.c
+++ b/xhci.device/src/unit_commands.c
@@ -45,7 +45,7 @@ static const UWORD SupportedCommands[] = {
     NSCMD_DEVICEQUERY,
     0};
 
-static int Do_NSCMD_DEVICEQUERY(struct IOStdReq *io)
+static u32 Do_NSCMD_DEVICEQUERY(struct IOStdReq *io)
 {
     KprintfH("[xhci] %s: NSCMD_DEVICEQUERY\n", __func__);
     struct NSDeviceQueryResult *dq = io->io_Data;
@@ -82,7 +82,7 @@ static inline void flush_queued_unit_request(struct XHCIUnit *unit, struct USBIO
 /*
  * Abort all UHCMD_CONTROLXFER, UHCMD_ISOXFER, UHCMD_INTXFER and UHCMD_BULKXFER requests in progress or queued
  */
-static int Do_CMD_FLUSH(struct USBIORequest *io)
+static u32 Do_CMD_FLUSH(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     KprintfH("[xhci] %s: CMD_FLUSH\n", __func__);
@@ -97,13 +97,13 @@ static int Do_CMD_FLUSH(struct USBIORequest *io)
 
     xhci_roothub_abort_int_request(ctrl->root_hub);
 
-    for (unsigned int addr = 0; addr <= USB_MAX_ADDRESS; ++addr)
+    for (u32 addr = 0; addr <= USB_MAX_ADDRESS; ++addr)
     {
         struct usb_device *udev = ctrl->devices_by_virtual_address[addr];
         if (!udev || addr == xhci_roothub_get_address(ctrl->root_hub))
             continue;
 
-        for (unsigned int ep_index = 0; ep_index < USB_MAX_ENDPOINT_CONTEXTS; ++ep_index)
+        for (u8 ep_index = 0; ep_index < USB_MAX_ENDPOINT_CONTEXTS; ++ep_index)
         {
             struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
             if (ep_ctx)
@@ -121,14 +121,14 @@ static int Do_CMD_FLUSH(struct USBIORequest *io)
 static void uword_to_hex(UWORD value, UBYTE *buf)
 {
     static const char hex[] = "0123456789abcdef";
-    buf[0] = hex[(value >> 12) & 0xF];
-    buf[1] = hex[(value >> 8) & 0xF];
-    buf[2] = hex[(value >> 4) & 0xF];
-    buf[3] = hex[value & 0xF];
+    buf[0] = (UBYTE)hex[(value >> 12) & 0xF];
+    buf[1] = (UBYTE)hex[(value >> 8) & 0xF];
+    buf[2] = (UBYTE)hex[(value >> 4) & 0xF];
+    buf[3] = (UBYTE)hex[value & 0xF];
     buf[4] = '\0';
 }
 
-static inline int Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
+static inline u32 Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
 {
     KprintfH("[xhci] %s: CMD_DEVICE_QUERY\n", __func__);
 
@@ -141,7 +141,7 @@ static inline int Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
 
     struct TagItem *tag, *tagList = (struct TagItem *)io->data_buffer;
-    int filled = 0;
+    u32 filled = 0;
     KprintfH("[xhci] %s: Processing tag list at 0x%lx\n", __func__, tagList);
     while ((tag = NextTagItem(&tagList)))
     {
@@ -222,15 +222,15 @@ static inline int Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
 /*
  * reset USB bus
  */
-static inline int Do_CMD_DEVICE_RESET(struct USBIORequest *io)
+static inline u32 Do_CMD_DEVICE_RESET(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     Kprintf("[xhci] %s: CMD_DEVICE_RESET\n", __func__);
 
     /* Issue SET_FEATURE(RESET) on all root hub ports */
     struct xhci_ctrl *ctrl = unit->xhci_ctrl;
-    int maxp = xhci_roothub_get_num_ports(ctrl->root_hub);
-    for (int p = 1; p <= maxp; ++p)
+    const u8 maxp = xhci_roothub_get_num_ports(ctrl->root_hub);
+    for (u8 p = 1; p <= maxp; ++p)
     {
         struct USBIORequest req;
         mem_zero(&req, sizeof(req));
@@ -250,7 +250,7 @@ static inline int Do_CMD_DEVICE_RESET(struct USBIORequest *io)
     return COMMAND_PROCESSED;
 }
 
-static int Do_CMD_RESET(struct USBIORequest *io)
+static u32 Do_CMD_RESET(struct USBIORequest *io)
 {
     // struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     Kprintf("[xhci] %s: CMD_RESET\n", __func__);
@@ -261,14 +261,14 @@ static int Do_CMD_RESET(struct USBIORequest *io)
 /*
  * resume from sleep mode
  */
-static inline int Do_CMD_DEVICE_RESUME(struct USBIORequest *io)
+static inline u32 Do_CMD_DEVICE_RESUME(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     Kprintf("[xhci] %s: CMD_DEVICE_RESUME - resuming USB\n", __func__);
 
     struct xhci_ctrl *ctrl = unit->xhci_ctrl;
-    int maxp = xhci_roothub_get_num_ports(ctrl->root_hub);
-    for (int p = 1; p <= maxp; ++p)
+    const u8 maxp = xhci_roothub_get_num_ports(ctrl->root_hub);
+    for (u8 p = 1; p <= maxp; ++p)
     {
         struct USBIORequest req;
         mem_zero(&req, sizeof(req));
@@ -289,15 +289,15 @@ static inline int Do_CMD_DEVICE_RESUME(struct USBIORequest *io)
 /*
  * enter sleep mode
  */
-static inline int Do_CMD_STOP(struct USBIORequest *io)
+static inline u32 Do_CMD_STOP(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     Kprintf("[xhci] %s: CMD_STOP - suspending USB\n", __func__);
 
     // TODO check if there is a controller level suspend/resume
     struct xhci_ctrl *ctrl = unit->xhci_ctrl;
-    int maxp = xhci_roothub_get_num_ports(ctrl->root_hub);
-    for (int p = 1; p <= maxp; ++p)
+    const u8 maxp = xhci_roothub_get_num_ports(ctrl->root_hub);
+    for (u8 p = 1; p <= maxp; ++p)
     {
         struct USBIORequest req;
         mem_zero(&req, sizeof(req));
@@ -318,7 +318,7 @@ static inline int Do_CMD_STOP(struct USBIORequest *io)
 /*
  * enter operational state
  */
-static inline int Do_CMD_START(struct USBIORequest *io)
+static inline u32 Do_CMD_START(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     Kprintf("[xhci] %s: CMD_START - making USB operational\n", __func__);
@@ -326,8 +326,8 @@ static inline int Do_CMD_START(struct USBIORequest *io)
     // TODO should likely also resume and perhaps reset the ports
     /* Ensure port power is on for all ports */
     struct xhci_ctrl *ctrl = unit->xhci_ctrl;
-    int maxp = xhci_roothub_get_num_ports(ctrl->root_hub);
-    for (int p = 1; p <= maxp; ++p)
+    const u8 maxp = xhci_roothub_get_num_ports(ctrl->root_hub);
+    for (u8 p = 1; p <= maxp; ++p)
     {
         struct USBIORequest req;
         mem_zero(&req, sizeof(req));
@@ -348,7 +348,7 @@ static inline int Do_CMD_START(struct USBIORequest *io)
 /*
  * start a generic transfer
  */
-static inline int Do_CMD_XFER(struct USBIORequest *io)
+static inline u32 Do_CMD_XFER(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     struct xhci_ctrl *ctrl = unit ? unit->xhci_ctrl : NULL;
@@ -358,7 +358,7 @@ static inline int Do_CMD_XFER(struct USBIORequest *io)
         struct usb_device *udev = ctrl->devices_by_virtual_address[io->virtual_address];
         if (udev)
         {
-            int ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
+            u8 ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
             struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
             if (ep_ctx && xhci_ep_has_request(ep_ctx, io))
             {
@@ -372,10 +372,10 @@ static inline int Do_CMD_XFER(struct USBIORequest *io)
                  * This avoids queueing the same IORequest twice or replying the
                  * same message twice. It does not fix Poseidon's pending-count
                  * accounting for the duplicate send. */
-                KprintfH("[xhci] %s: ignoring duplicate hub resume re-send for tracked request %08lx state=%ld flags=%lx dflags=%lx\n",
+                KprintfH("[xhci] %s: ignoring duplicate hub resume re-send for tracked request %08lx state=%lu flags=%lx dflags=%lx\n",
                          __func__,
                          (ULONG)io,
-                         (LONG)xhci_ep_get_state(ep_ctx),
+                         (ULONG)xhci_ep_get_state(ep_ctx),
                          (ULONG)io->req.io_Flags,
                          (ULONG)io->driver_private_flags);
                 return COMMAND_SCHEDULED;
@@ -386,7 +386,7 @@ static inline int Do_CMD_XFER(struct USBIORequest *io)
     io->driver_private_flags = 0;
     io->driver_private_dma_address = NULL;
 
-    int result = xhci_udev_send(io);
+    s8 result = xhci_udev_send(io);
     if (result != ERR_NO_ERROR)
     {
         io->req.io_Error = result;
@@ -395,7 +395,7 @@ static inline int Do_CMD_XFER(struct USBIORequest *io)
     return COMMAND_SCHEDULED;
 }
 
-static inline int Do_CMD_INTERNAL_ABORT(struct USBIORequest *io)
+static inline u32 Do_CMD_INTERNAL_ABORT(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     struct xhci_ctrl *ctrl = unit->xhci_ctrl;
@@ -410,7 +410,7 @@ static inline int Do_CMD_INTERNAL_ABORT(struct USBIORequest *io)
     return COMMAND_PROCESSED;
 }
 
-static inline int Do_CMD_REGISTER_ISO_HANDLER(struct USBIORequest *io)
+static inline u32 Do_CMD_REGISTER_ISO_HANDLER(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     KprintfH("[xhci] %s: CMD_REGISTER_ISO_HANDLER\n", __func__);
@@ -423,13 +423,13 @@ static inline int Do_CMD_REGISTER_ISO_HANDLER(struct USBIORequest *io)
     if (!udev)
         goto badparams;
 
-    int ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
+    u8 ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
 
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
     if (!ep_ctx)
         goto badparams;
 
-    BYTE result = xhci_ep_rt_iso_add_handler(ep_ctx, io);
+    s8 result = xhci_ep_rt_iso_add_handler(ep_ctx, io);
 
     io->actual_length = 0;
     io->req.io_Error = result;
@@ -441,7 +441,7 @@ badparams:
     return COMMAND_PROCESSED;
 }
 
-static inline int Do_CMD_UNREGISTER_ISO_HANDLER(struct USBIORequest *io)
+static inline u32 Do_CMD_UNREGISTER_ISO_HANDLER(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     KprintfH("[xhci] %s: CMD_UNREGISTER_ISO_HANDLER\n", __func__);
@@ -453,13 +453,13 @@ static inline int Do_CMD_UNREGISTER_ISO_HANDLER(struct USBIORequest *io)
     if (!udev)
         goto badparams;
 
-    int ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
+    u8 ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
 
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
     if (!ep_ctx)
         goto badparams;
 
-    BYTE result = xhci_ep_rt_iso_rem_handler(ep_ctx, io);
+    s8 result = xhci_ep_rt_iso_rem_handler(ep_ctx, io);
     io->req.io_Error = result;
     return COMMAND_PROCESSED;
 
@@ -469,14 +469,14 @@ badparams:
     return COMMAND_PROCESSED;
 }
 
-static inline int Do_CMD_STARTRTISO(struct USBIORequest *io)
+static inline u32 Do_CMD_STARTRTISO(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     KprintfH("[xhci] %s: CMD_STOP_REALTIME_ISOCHRONOUS\n", __func__);
 
-    KprintfH("RT ISO start addr=%ld ep=%ld dir=%s frame=%lu len=%lu\n",
-             (LONG)io->virtual_address,
-             (LONG)(io->endpoint & 0x0F),
+    KprintfH("RT ISO start addr=%lu ep=%lu dir=%s frame=%lu len=%lu\n",
+             (ULONG)io->virtual_address,
+             (ULONG)(io->endpoint & 0x0F),
              (io->direction == DIRECTION_IN) ? "IN" : "OUT",
              (ULONG)io->usb_frame,
              (ULONG)io->data_buffer_length);
@@ -484,12 +484,12 @@ static inline int Do_CMD_STARTRTISO(struct USBIORequest *io)
     if (!udev)
         goto badparams;
 
-    int ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
+    u8 ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
     if (!ep_ctx)
         goto badparams;
 
-    BYTE result = xhci_ep_rt_iso_start(ep_ctx);
+    s8 result = xhci_ep_rt_iso_start(ep_ctx);
 
     io->actual_length = 0;
     io->req.io_Error = result;
@@ -501,23 +501,23 @@ badparams:
     return COMMAND_PROCESSED;
 }
 
-static inline int Do_CMD_STOPRTISO(struct USBIORequest *io)
+static inline u32 Do_CMD_STOPRTISO(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     KprintfH("[xhci] %s: CMD_STOP_REALTIME_ISOCHRONOUS\n", __func__);
 
-    KprintfH("RT ISO stop requested addr=%ld ep=%ld\n",
-             (LONG)io->virtual_address, (LONG)(io->endpoint & 0x0F));
+    KprintfH("RT ISO stop requested addr=%lu ep=%lu\n",
+             (ULONG)io->virtual_address, (ULONG)(io->endpoint & 0x0F));
     struct usb_device *udev = xhci_udev_get(unit, io->virtual_address);
     if (!udev)
         goto badparams;
 
-    int ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
+    u8 ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
     if (!ep_ctx)
         goto badparams;
 
-    BYTE result = xhci_ep_rt_iso_stop(ep_ctx, io);
+    s8 result = xhci_ep_rt_iso_stop(ep_ctx, io);
     io->req.io_Error = result;
     if (result != ERR_NO_ERROR)
     {
@@ -535,7 +535,7 @@ badparams:
 
 void ProcessCommand(struct USBIORequest *io)
 {
-    ULONG complete = COMMAND_SCHEDULED;
+    u32 complete = COMMAND_SCHEDULED;
 
     /*
         Only NSCMD_DEVICEQUERY can use standard sized request. All other must be of
@@ -613,7 +613,7 @@ void ProcessCommand(struct USBIORequest *io)
             break;
 
         default:
-            Kprintf("[xhci] %s: Unsupported command %ld\n", __func__, (LONG)io->req.io_Command);
+            Kprintf("[xhci] %s: Unsupported command %lu\n", __func__, (ULONG)io->req.io_Command);
             io->req.io_Error = IOERR_NOCMD;
             complete = COMMAND_PROCESSED;
             break;

--- a/xhci.device/src/unit_commands.c
+++ b/xhci.device/src/unit_commands.c
@@ -19,7 +19,7 @@
 #include <config.h>
 #include <device.h>
 #include <debug.h>
-#include <emu_memory.h>
+#include <memory.h>
 #include <xhci/usb_defs.h>
 #include <xhci/xhci.h>
 #include <xhci/xhci-root-hub.h>
@@ -71,7 +71,7 @@ static inline void flush_queued_unit_request(struct XHCIUnit *unit, struct USBIO
     if ((req->driver_private_flags & REQ_INTERNAL) && req->req.io_Command == CMD_INTERNAL_ABORT_REQUEST)
     {
         if (unit && unit->memoryPool)
-            FreeVecPooled(unit->memoryPool, req);
+            pool_free(unit->memoryPool, req);
         return;
     }
 
@@ -233,12 +233,12 @@ static inline int Do_CMD_DEVICE_RESET(struct USBIORequest *io)
     for (int p = 1; p <= maxp; ++p)
     {
         struct USBIORequest req;
-        _memset(&req, 0, sizeof(req));
+        mem_zero(&req, sizeof(req));
         req.setup.bmRequestType = USB_DIR_OUT | USB_RT_PORT; /* class=hub, recipient=other */
         req.setup.bRequest = USB_REQ_SET_FEATURE;
-        req.setup.wValue = LE16(USB_PORT_FEAT_RESET);
-        req.setup.wIndex = LE16(p);
-        req.setup.wLength = LE16(0);
+        req.setup.wValue = le16(USB_PORT_FEAT_RESET);
+        req.setup.wIndex = le16(p);
+        req.setup.wLength = le16(0);
         req.virtual_address = xhci_roothub_get_address(ctrl->root_hub);
 
         xhci_roothub_submit_ctrl_request(ctrl->root_hub, &req);
@@ -271,11 +271,11 @@ static inline int Do_CMD_DEVICE_RESUME(struct USBIORequest *io)
     for (int p = 1; p <= maxp; ++p)
     {
         struct USBIORequest req;
-        _memset(&req, 0, sizeof(req));
+        mem_zero(&req, sizeof(req));
         req.setup.bmRequestType = USB_DIR_OUT | USB_RT_PORT;
         req.setup.bRequest = USB_REQ_CLEAR_FEATURE;
-        req.setup.wValue = LE16(USB_PORT_FEAT_SUSPEND);
-        req.setup.wIndex = LE16(p);
+        req.setup.wValue = le16(USB_PORT_FEAT_SUSPEND);
+        req.setup.wIndex = le16(p);
         req.virtual_address = xhci_roothub_get_address(ctrl->root_hub);
 
         xhci_roothub_submit_ctrl_request(ctrl->root_hub, &req);
@@ -300,11 +300,11 @@ static inline int Do_CMD_STOP(struct USBIORequest *io)
     for (int p = 1; p <= maxp; ++p)
     {
         struct USBIORequest req;
-        _memset(&req, 0, sizeof(req));
+        mem_zero(&req, sizeof(req));
         req.setup.bmRequestType = USB_DIR_OUT | USB_RT_PORT;
         req.setup.bRequest = USB_REQ_SET_FEATURE;
-        req.setup.wValue = LE16(USB_PORT_FEAT_SUSPEND);
-        req.setup.wIndex = LE16(p);
+        req.setup.wValue = le16(USB_PORT_FEAT_SUSPEND);
+        req.setup.wIndex = le16(p);
         req.virtual_address = xhci_roothub_get_address(ctrl->root_hub);
 
         xhci_roothub_submit_ctrl_request(ctrl->root_hub, &req);
@@ -330,11 +330,11 @@ static inline int Do_CMD_START(struct USBIORequest *io)
     for (int p = 1; p <= maxp; ++p)
     {
         struct USBIORequest req;
-        _memset(&req, 0, sizeof(req));
+        mem_zero(&req, sizeof(req));
         req.setup.bmRequestType = USB_DIR_OUT | USB_RT_PORT;
         req.setup.bRequest = USB_REQ_SET_FEATURE;
-        req.setup.wValue = LE16(USB_PORT_FEAT_POWER);
-        req.setup.wIndex = LE16(p);
+        req.setup.wValue = le16(USB_PORT_FEAT_POWER);
+        req.setup.wIndex = le16(p);
         req.virtual_address = xhci_roothub_get_address(ctrl->root_hub);
 
         xhci_roothub_submit_ctrl_request(ctrl->root_hub, &req);
@@ -405,7 +405,7 @@ static inline int Do_CMD_INTERNAL_ABORT(struct USBIORequest *io)
         xhci_td_abort_req(orig_req);
 
     if (unit && unit->memoryPool)
-        FreeVecPooled(unit->memoryPool, io);
+        pool_free(unit->memoryPool, io);
 
     return COMMAND_PROCESSED;
 }

--- a/xhci.device/src/unit_commands.c
+++ b/xhci.device/src/unit_commands.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #include <clib/utility_protos.h>

--- a/xhci.device/src/unit_commands.c
+++ b/xhci.device/src/unit_commands.c
@@ -3,7 +3,10 @@
 #include <clib/exec_protos.h>
 #include <clib/utility_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
+#define UTILITY_BASE_NAME unit->device->utilityBase
 #include <proto/utility.h>
 #endif
 
@@ -16,6 +19,7 @@
 #include <config.h>
 #include <device.h>
 #include <debug.h>
+#include <emu_memory.h>
 #include <xhci/usb_defs.h>
 #include <xhci/xhci.h>
 #include <xhci/xhci-root-hub.h>
@@ -124,9 +128,6 @@ static void uword_to_hex(UWORD value, UBYTE *buf)
     buf[4] = '\0';
 }
 
-static char vendor_str[5];
-static char device_str[5];
-
 static inline int Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
 {
     KprintfH("[xhci] %s: CMD_DEVICE_QUERY\n", __func__);
@@ -160,8 +161,8 @@ static inline int Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
         case TAG_DEVICE_VENDOR:
             if (unit->xhci_ctrl->pci_dev)
             {
-                uword_to_hex(unit->xhci_ctrl->pci_dev->vendor, (UBYTE *)vendor_str);
-                *out = (ULONG)(APTR)vendor_str;
+                uword_to_hex(unit->xhci_ctrl->pci_dev->vendor, (UBYTE *)unit->vendor_str);
+                *out = (ULONG)(APTR)unit->vendor_str;
             }
             else
                 *out = (ULONG)(APTR) "Broadcom";
@@ -171,8 +172,8 @@ static inline int Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
         case TAG_DEVICE_PRODUCT:
             if (unit->xhci_ctrl->pci_dev)
             {
-                uword_to_hex(unit->xhci_ctrl->pci_dev->device, (UBYTE *)device_str);
-                *out = (ULONG)(APTR)device_str;
+                uword_to_hex(unit->xhci_ctrl->pci_dev->device, (UBYTE *)unit->device_str);
+                *out = (ULONG)(APTR)unit->device_str;
             }
             else
                 *out = (ULONG)(APTR) "OTG controller";

--- a/xhci.device/src/unit_commands.c
+++ b/xhci.device/src/unit_commands.c
@@ -473,7 +473,7 @@ badparams:
 static inline u32 Do_CMD_STARTRTISO(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    KprintfH("[xhci] %s: CMD_STOP_REALTIME_ISOCHRONOUS\n", __func__);
+    KprintfH("[xhci] %s: CMD_START_REALTIME_ISOCHRONOUS\n", __func__);
 
     KprintfH("RT ISO start addr=%lu ep=%lu dir=%s len=%lu\n",
              (ULONG)io->virtual_address,

--- a/xhci.device/src/unit_commands.c
+++ b/xhci.device/src/unit_commands.c
@@ -20,6 +20,7 @@
 #include <device.h>
 #include <debug.h>
 #include <memory.h>
+#include <libraries/openpci.h>
 #include <xhci/usb_defs.h>
 #include <xhci/xhci.h>
 #include <xhci/xhci-root-hub.h>

--- a/xhci.device/src/unit_commands.c
+++ b/xhci.device/src/unit_commands.c
@@ -226,7 +226,7 @@ static inline u32 Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
 static inline u32 Do_CMD_DEVICE_RESET(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    Kprintf("[xhci] %s: CMD_DEVICE_RESET\n", __func__);
+    KprintfH("[xhci] %s: CMD_DEVICE_RESET\n", __func__);
 
     /* Issue SET_FEATURE(RESET) on all root hub ports */
     struct xhci_ctrl *ctrl = unit->xhci_ctrl;
@@ -254,7 +254,7 @@ static inline u32 Do_CMD_DEVICE_RESET(struct USBIORequest *io)
 static u32 Do_CMD_RESET(struct USBIORequest *io)
 {
     // struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    Kprintf("[xhci] %s: CMD_RESET\n", __func__);
+    KprintfH("[xhci] %s: CMD_RESET\n", __func__);
     // TODO should reset entire controller...
     return Do_CMD_DEVICE_RESET(io);
 }
@@ -475,11 +475,10 @@ static inline u32 Do_CMD_STARTRTISO(struct USBIORequest *io)
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
     KprintfH("[xhci] %s: CMD_STOP_REALTIME_ISOCHRONOUS\n", __func__);
 
-    KprintfH("RT ISO start addr=%lu ep=%lu dir=%s frame=%lu len=%lu\n",
+    KprintfH("RT ISO start addr=%lu ep=%lu dir=%s len=%lu\n",
              (ULONG)io->virtual_address,
              (ULONG)(io->endpoint & 0x0F),
              (io->direction == DIRECTION_IN) ? "IN" : "OUT",
-             (ULONG)io->usb_frame,
              (ULONG)io->data_buffer_length);
     struct usb_device *udev = xhci_udev_get(unit, io->virtual_address);
     if (!udev)

--- a/xhci.device/src/unit_task.c
+++ b/xhci.device/src/unit_task.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #include <clib/timer_protos.h>

--- a/xhci.device/src/unit_task.c
+++ b/xhci.device/src/unit_task.c
@@ -3,13 +3,14 @@
 #include <clib/exec_protos.h>
 #include <clib/timer_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
 #include <proto/timer.h>
 #endif
 
 #include <dos/dos.h>
 
-#include <compat.h>
 #include <device.h>
 #include <minlist.h>
 #include <debug.h>

--- a/xhci.device/src/unit_task.c
+++ b/xhci.device/src/unit_task.c
@@ -106,9 +106,7 @@ static void UnitTask(struct XHCIUnit *unit, struct Task *parent)
         if (sigset & (1UL << microHZTimerPort->mp_SigBit))
         {
             if (CheckIO(&packetTimerReq->tr_node))
-            {
                 WaitIO(&packetTimerReq->tr_node);
-            }
 
             xhci_process_command_timeouts(unit->xhci_ctrl);
             xhci_process_event_timeouts(unit->xhci_ctrl);
@@ -197,19 +195,29 @@ s32 UnitTaskStart(struct XHCIUnit *unit)
         return ERR_HCI_ERROR;
     }
 
-    Wait(SIGBREAKF_CTRL_F);
+    ULONG sig = Wait(SIGBREAKF_CTRL_F | SIGBREAKF_CTRL_C);
+    if (sig & SIGBREAKF_CTRL_C)    {
+        Kprintf("[xhci] %s: xhci task failed to start\n", __func__);
+        FreeMem(ml, sizeof(struct MemList) + sizeof(struct MemEntry));
+        FreeMem(task, sizeof(struct Task));
+        FreeMem(&stack[0], STACK_SIZE);
+        return ERR_HCI_ERROR;
+    }
     Kprintf("[xhci] %s: xhci task started\n", __func__);
     return ERR_NO_ERROR;
 }
 
 void UnitTaskStop(struct XHCIUnit *unit)
 {
+    if (!unit->task)
+        return;
+
     Kprintf("[xhci] %s: xhci task stopping\n", __func__);
 
     struct MsgPort *timerPort = CreateMsgPort();
     struct timerequest *timerReq = CreateIORequest(timerPort, sizeof(struct timerequest));
 
-    if (timerPort != NULL && timerReq != NULL)
+    if (timerPort && timerReq)
     {
         BYTE result = OpenDevice((CONST_STRPTR) "timer.device", UNIT_VBLANK, (struct IORequest *)timerReq, LIB_MIN_VERSION);
         if (result != NULL)
@@ -220,19 +228,26 @@ void UnitTaskStop(struct XHCIUnit *unit)
     }
 
     Signal(unit->task, SIGBREAKF_CTRL_C);
-    do
+    while (unit->task != NULL)
     {
-        timerReq->tr_node.io_Command = TR_ADDREQUEST;
-        timerReq->tr_time.tv_secs = 0;
-        timerReq->tr_time.tv_micro = 250000;
-        DoIO(&timerReq->tr_node);
-    } while (unit->task != NULL);
+        if (timerPort && timerReq)
+        {
+            timerReq->tr_node.io_Command = TR_ADDREQUEST;
+            timerReq->tr_time.tv_secs = 0;
+            timerReq->tr_time.tv_micro = 250000;
+            DoIO(&timerReq->tr_node);
+        }
+    }
 
-    SetSignal(0UL, SIGBREAKF_CTRL_F);
+    SetSignal(0UL, SIGBREAKF_CTRL_F | SIGBREAKF_CTRL_C);
 
-    CloseDevice(&timerReq->tr_node);
-    DeleteIORequest(&timerReq->tr_node);
-    DeleteMsgPort(timerPort);
+    if (timerReq)
+    {
+        CloseDevice(&timerReq->tr_node);
+        DeleteIORequest(&timerReq->tr_node);
+    }
+    if (timerPort)
+        DeleteMsgPort(timerPort);
 
     Kprintf("[xhci] %s: xhci task stopped\n", __func__);
 }

--- a/xhci.device/src/unit_task.c
+++ b/xhci.device/src/unit_task.c
@@ -26,7 +26,13 @@ static void UnitTask(struct XHCIUnit *unit, struct Task *parent)
     // Initialize the built in msg port, we'll receive commands here
     _NewMinList((struct MinList *)&unit->unit.unit_MsgPort.mp_MsgList);
     unit->unit.unit_MsgPort.mp_SigTask = FindTask(NULL);
-    unit->unit.unit_MsgPort.mp_SigBit = AllocSignal(-1);
+    BYTE msg_sigbit = AllocSignal(-1);
+    if (msg_sigbit == -1)
+    {
+        Kprintf("[xhci] %s: Failed to allocate message signal\n", __func__);
+        goto free_signals;
+    }
+    unit->unit.unit_MsgPort.mp_SigBit = (UBYTE)msg_sigbit;
     unit->unit.unit_MsgPort.mp_Flags = PA_SIGNAL;
     unit->unit.unit_MsgPort.mp_Node.ln_Type = NT_MSGPORT;
 
@@ -47,14 +53,14 @@ static void UnitTask(struct XHCIUnit *unit, struct Task *parent)
         goto free_ports;
     }
 
-    UBYTE ret = OpenDevice((CONST_STRPTR)TIMERNAME, UNIT_MICROHZ, (struct IORequest *)packetTimerReq, LIB_MIN_VERSION);
+    LONG ret = OpenDevice((CONST_STRPTR)TIMERNAME, UNIT_MICROHZ, (struct IORequest *)packetTimerReq, LIB_MIN_VERSION);
     if (ret)
     {
         Kprintf("[xhci] %s: Failed to open timer device ret=%ld\n", __func__, ret);
         goto free_ports;
     }
 
-    const ULONG delay = UNIT_TASK_POLL_DELAY_MS * 1000;
+    const u32 delay = UNIT_TASK_POLL_DELAY_MS * 1000;
 
     // Set a timer... we need to pull on RX
     packetTimerReq->tr_node.io_Command = TR_ADDREQUEST;
@@ -128,13 +134,13 @@ free_ports:
     DeleteMsgPort(microHZTimerPort);
 free_signals:
     FreeSignal(unit->irq_signal);
-    FreeSignal(unit->unit.unit_MsgPort.mp_SigBit);
+    FreeSignal((BYTE)unit->unit.unit_MsgPort.mp_SigBit);
 
     Signal(parent, SIGBREAKF_CTRL_C);
     unit->task = NULL;
 }
 
-int UnitTaskStart(struct XHCIUnit *unit)
+s32 UnitTaskStart(struct XHCIUnit *unit)
 {
     Kprintf("[xhci] %s: xhci task starting\n", __func__);
 

--- a/xhci.device/src/unit_task.c
+++ b/xhci.device/src/unit_task.c
@@ -72,7 +72,7 @@ static void UnitTask(struct XHCIUnit *unit, struct Task *parent)
     /* Signal parent that Unit task is up and running now */
     Signal(parent, SIGBREAKF_CTRL_F);
 
-    Kprintf("[xhci] %s: Entering main unit task loop\n", __func__);
+    KprintfH("[xhci] %s: Entering main unit task loop\n", __func__);
 
     ULONG sigset;
     ULONG waitMask = (1UL << unit->unit.unit_MsgPort.mp_SigBit) |
@@ -120,7 +120,7 @@ static void UnitTask(struct XHCIUnit *unit, struct Task *parent)
 
         if (sigset & SIGBREAKF_CTRL_C)
         {
-            Kprintf("[xhci] %s: Received SIGBREAKF_CTRL_C, stopping xhci task\n", __func__);
+            KprintfH("[xhci] %s: Received SIGBREAKF_CTRL_C, stopping xhci task\n", __func__);
             AbortIO(&packetTimerReq->tr_node);
             WaitIO(&packetTimerReq->tr_node);
         }
@@ -140,7 +140,7 @@ free_signals:
 
 s32 UnitTaskStart(struct XHCIUnit *unit)
 {
-    Kprintf("[xhci] %s: xhci task starting\n", __func__);
+    KprintfH("[xhci] %s: xhci task starting\n", __func__);
 
     // Get all memory we need for the receiver task
     struct MemList *ml = AllocMem(sizeof(struct MemList) + sizeof(struct MemEntry), MEMF_PUBLIC | MEMF_CLEAR);
@@ -203,7 +203,7 @@ s32 UnitTaskStart(struct XHCIUnit *unit)
         FreeMem(&stack[0], STACK_SIZE);
         return ERR_HCI_ERROR;
     }
-    Kprintf("[xhci] %s: xhci task started\n", __func__);
+    KprintfH("[xhci] %s: xhci task started\n", __func__);
     return ERR_NO_ERROR;
 }
 
@@ -212,7 +212,7 @@ void UnitTaskStop(struct XHCIUnit *unit)
     if (!unit->task)
         return;
 
-    Kprintf("[xhci] %s: xhci task stopping\n", __func__);
+    KprintfH("[xhci] %s: xhci task stopping\n", __func__);
 
     struct MsgPort *timerPort = CreateMsgPort();
     struct timerequest *timerReq = CreateIORequest(timerPort, sizeof(struct timerequest));
@@ -249,5 +249,5 @@ void UnitTaskStop(struct XHCIUnit *unit)
     if (timerPort)
         DeleteMsgPort(timerPort);
 
-    Kprintf("[xhci] %s: xhci task stopped\n", __func__);
+    KprintfH("[xhci] %s: xhci task stopped\n", __func__);
 }

--- a/xhci.device/src/xhci/xhci-commands.c
+++ b/xhci.device/src/xhci/xhci-commands.c
@@ -34,20 +34,20 @@ struct pending_command
     struct MinNode node;
     dma_addr_t cmd_trb_dma;  /* value from queue_trb */
     struct usb_device *udev; /* for slot/endpoint checks */
-    u32 ep_index;            /* endpoint index encoded into the command */
+    u8 ep_index;            /* endpoint index encoded into the command */
     command_handler complete;
     struct USBIORequest *req; /* to continue control transfers */
     trb_type type;            /* command type */
     BOOL deadline_active;
-    ULONG deadline_us;
+    u32 deadline_us;
 };
 
 static const command_handler command_handlers[];
 
 #ifdef DEBUG_HIGH
-static ULONG xhci_pending_command_count(struct xhci_ctrl *ctrl)
+static u32 xhci_pending_command_count(struct xhci_ctrl *ctrl)
 {
-    ULONG count = 0;
+    u32 count = 0;
 
     for (struct MinNode *node = ctrl->pending_commands.mlh_Head; node->mln_Succ; node = node->mln_Succ)
         count++;
@@ -115,7 +115,7 @@ static void xhci_fail_timed_out_command(struct xhci_ctrl *ctrl, struct pending_c
     case TRB_ADDR_DEV:
         if (cmd->udev)
         {
-            Kprintf("Address Device timed out for slot %ld\n", (LONG)cmd->udev->slot_id);
+            Kprintf("Address Device timed out for slot %lu\n", (ULONG)cmd->udev->slot_id);
             xhci_dump_slot_ctx("[xhci-commands] timeout cleanup:", cmd->udev, TRUE);
             xhci_dump_slot_ctx("[xhci-commands] timeout cleanup:", cmd->udev, FALSE);
             xhci_disable_slot(cmd->udev);
@@ -154,7 +154,7 @@ static void xhci_fail_timed_out_command(struct xhci_ctrl *ctrl, struct pending_c
  * @param udev      Optional usb_device for slot/endpoint checks
  * Return: none
  */
-static void xhci_queue_command(struct xhci_ctrl *ctrl, dma_addr_t addr, u32 slot_id, u32 ep_index, trb_type cmd, struct USBIORequest *req, struct usb_device *udev)
+static void xhci_queue_command(struct xhci_ctrl *ctrl, dma_addr_t addr, u32 slot_id, u8 ep_index, trb_type cmd, struct USBIORequest *req, struct usb_device *udev)
 {
 
     dma_addr_t trb_dma = xhci_ring_enqueue_command(ctrl->cmd_ring, addr, slot_id, ep_index, cmd);
@@ -207,26 +207,26 @@ static void handle_reset_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd,
 {
     (void)ctrl;
     const u32 flags = le32(event->event_cmd.flags);
-    const ULONG slot_id = cmd->udev->slot_id;
-    const ULONG ep_index = cmd->ep_index;
+    const u32 slot_id = cmd->udev->slot_id;
+    const u8 ep_index = cmd->ep_index;
 
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(cmd->udev, ep_index);
     if (!ep_ctx)
     {
-        Kprintf("No ep context for addr %ld ep %ld\n", (LONG)cmd->udev->virtual_address, (LONG)ep_index);
+        Kprintf("No ep context for addr %lu ep %lu\n", (ULONG)cmd->udev->virtual_address, (ULONG)ep_index);
         return;
     }
 
     if (TRB_TO_SLOT_ID(flags) != slot_id)
     {
-        Kprintf("Expected a TRB for slot %ld, got %ld\n", slot_id, TRB_TO_SLOT_ID(flags));
+        Kprintf("Expected a TRB for slot %lu, got %lu\n", (ULONG)slot_id, (ULONG)TRB_TO_SLOT_ID(flags));
         xhci_ep_set_failed(ep_ctx);
         return;
     }
     struct xhci_ring *ring = xhci_ep_get_ring(ep_ctx);
     u32 deq_ptr = xhci_ring_get_new_dequeue_ptr(ring);
 
-    KprintfH("Reset EP %ld completed successfully\n", ep_index);
+    KprintfH("Reset EP %lu completed successfully\n", (ULONG)ep_index);
     xhci_set_deq_pointer(cmd->udev, ep_index, deq_ptr);
 }
 
@@ -234,37 +234,37 @@ static void handle_set_deq(struct xhci_ctrl *ctrl, struct pending_command *cmd, 
 {
     (void)ctrl;
     u32 flags = le32(event->event_cmd.flags);
-    ULONG slot_id = cmd->udev->slot_id;
-    ULONG ep_index = cmd->ep_index;
+    u32 slot_id = cmd->udev->slot_id;
+    u8 ep_index = cmd->ep_index;
     xhci_comp_code comp = GET_COMP_CODE(le32(event->event_cmd.status));
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(cmd->udev, ep_index);
     if (!ep_ctx)
     {
-        Kprintf("No ep context for addr %ld ep %ld\n", (LONG)cmd->udev->virtual_address, (LONG)ep_index);
+        Kprintf("No ep context for addr %lu ep %lu\n", (ULONG)cmd->udev->virtual_address, (ULONG)ep_index);
         return;
     }
 
     if (TRB_TO_SLOT_ID(flags) != slot_id || comp != COMP_SUCCESS)
     {
-        Kprintf("Expected a TRB for slot %ld with SUCCESS, got %ld with %ld\n",
-                slot_id,
-                TRB_TO_SLOT_ID(flags),
-                comp);
+        Kprintf("Expected a TRB for slot %lu with SUCCESS, got %lu with %lu\n",
+                (ULONG)slot_id,
+                (ULONG)TRB_TO_SLOT_ID(flags),
+                (ULONG)comp);
         xhci_ep_set_failed(ep_ctx);
         return;
     }
-    KprintfH("Set DEQ for EP %ld completed successfully, status code %ld (success=1)\n", ep_index, comp);
+    KprintfH("Set DEQ for EP %lu completed successfully, status code %lu (success=1)\n", (ULONG)ep_index, (ULONG)comp);
 
     if (xhci_ep_get_state(ep_ctx) == USB_DEV_EP_STATE_RESETTING)
     {
-        KprintfH("EP %ld was resetting, completing reset\n", ep_index);
+        KprintfH("EP %lu was resetting, completing reset\n", (ULONG)ep_index);
         /*
          * If this is due to e.g. STALL recovery, we need to sort out the device itself...:
          * issue ClearFeature(CLEAR_TT_BUFFER) to the hub if its control or bulk ep and dev is behind a TT
          * if not control ep,  issue ClearFeature(ENDPOINT_HALT) to the device.
          * We'll do that by pushing these to fron of the pending queue.
          */
-        int ep_type = xhci_ep_type_for_index(cmd->udev, ep_index);
+        s32 ep_type = xhci_ep_type_for_index(cmd->udev, ep_index);
 
         if (ep_index != 0 && ep_type != USB_ENDPOINT_XFER_CONTROL)
         {
@@ -291,30 +291,30 @@ static void handle_stop_ring(struct xhci_ctrl *ctrl, struct pending_command *cmd
     u32 flags = le32(event->event_cmd.flags);
     trb_type type = TRB_FIELD_TO_TYPE(flags);
     xhci_comp_code comp = GET_COMP_CODE(le32(event->event_cmd.status));
-    ULONG slot_id = cmd->udev->slot_id;
-    ULONG ep_index = cmd->ep_index;
+    u32 slot_id = cmd->udev->slot_id;
+    u8 ep_index = cmd->ep_index;
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(cmd->udev, ep_index);
     if (!ep_ctx)
     {
-        Kprintf("No ep context for addr %ld ep %ld\n", (LONG)cmd->udev->virtual_address, (LONG)ep_index);
+        Kprintf("No ep context for addr %lu ep %lu\n", (ULONG)cmd->udev->virtual_address, (ULONG)ep_index);
         return;
     }
 
     if (type != TRB_COMPLETION || TRB_TO_SLOT_ID(flags) != slot_id)
     {
-        Kprintf("Expected a TRB for slot %ld completion, got %ld with %ld\n", slot_id, TRB_TO_SLOT_ID(flags), comp);
+        Kprintf("Expected a TRB for slot %lu completion, got %lu with %lu\n", (ULONG)slot_id, (ULONG)TRB_TO_SLOT_ID(flags), (ULONG)comp);
         xhci_ep_set_failed(ep_ctx);
         return;
     }
 
     if (comp != COMP_SUCCESS && comp != COMP_CTX_STATE)
     {
-        Kprintf("Stop EP %ld failed with completion code %ld\n", (LONG)ep_index, (LONG)comp);
+        Kprintf("Stop EP %lu failed with completion code %lu\n", (ULONG)ep_index, (ULONG)comp);
         xhci_ep_set_failed(ep_ctx);
         return;
     }
 
-    KprintfH("Stopped EP %ld with completion code %ld\n", ep_index, comp);
+    KprintfH("Stopped EP %lu with completion code %lu\n", (ULONG)ep_index, (ULONG)comp);
 
     u32 deq_ptr = 0;
     xhci_ep_process_stop(ep_ctx, &deq_ptr);
@@ -341,13 +341,12 @@ static void handle_stop_ring(struct xhci_ctrl *ctrl, struct pending_command *cmd
 static void handle_config_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
     (void)ctrl;
+    xhci_comp_code comp = GET_COMP_CODE(le32(event->event_cmd.status));
 #ifdef DEBUG_HIGH
+    const u32 flags = le32(event->event_cmd.flags);
+    const u32 slot_id = TRB_TO_SLOT_ID(flags);
     trb_type type = cmd->type;
     const char *type_name = xhci_command_type_name(type);
-#endif
-    xhci_comp_code comp = GET_COMP_CODE(le32(event->event_cmd.status));
-
-#ifdef DEBUG_HIGH
     if (type == TRB_EVAL_CONTEXT && cmd->udev)
     {
         xhci_dump_slot_ctx("[xhci-commands] handle_config_ep:", cmd->udev, TRUE);
@@ -357,17 +356,17 @@ static void handle_config_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd
 
     if (comp != COMP_SUCCESS)
     {
-        KprintfH("ERROR: %s command for slot %ld returned completion code 0x%lx.\n", type_name, TRB_TO_SLOT_ID(le32(event->event_cmd.flags)), (ULONG)comp);
+        KprintfH("ERROR: %s command for slot %lu returned completion code 0x%lx.\n", type_name, (ULONG)slot_id, (ULONG)comp);
         return;
     }
 
-    KprintfH("%s command for slot %ld completed successfully\n", type_name, TRB_TO_SLOT_ID(le32(event->event_cmd.flags)));
+    KprintfH("%s command for slot %lu completed successfully\n", type_name, (ULONG)slot_id);
 
     cmd->udev->slot_state = USB_DEV_SLOT_STATE_CONFIGURED;
 
     if (cmd->req)
     {
-        unsigned int timeout = XHCI_TIMEOUT;
+        u32 timeout = XHCI_TIMEOUT;
         if (cmd->req->flags & DRIVER_FLAG_TIMEOUT_DEFINED)
             timeout = cmd->req->timeout;
 
@@ -377,8 +376,11 @@ static void handle_config_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd
 
 static void handle_enable_slot(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)le32(event->event_cmd.status), (ULONG)le32(event->event_cmd.flags));
-    if (GET_COMP_CODE(le32(event->event_cmd.status)) != COMP_SUCCESS)
+    const u32 status = le32(event->event_cmd.status);
+    const u32 flags = le32(event->event_cmd.flags);
+
+    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)flags);
+    if (GET_COMP_CODE(status) != COMP_SUCCESS)
     {
         Kprintf("ERROR: Enable Slot command failed.\n");
         xhci_udev_io_reply_failed(ctrl, cmd->req, ERR_HCI_ERROR);
@@ -386,18 +388,18 @@ static void handle_enable_slot(struct xhci_ctrl *ctrl, struct pending_command *c
     }
 
     struct usb_device *udev = cmd->udev;
-    int slot_id = TRB_TO_SLOT_ID(le32(event->event_cmd.flags));
+    const u32 slot_id = TRB_TO_SLOT_ID(flags);
 
-    udev->slot_id = slot_id;
+    udev->slot_id = slot_id & 0xffU;
     udev->slot_state = USB_DEV_SLOT_STATE_ENABLED;
     ctrl->devices_by_slot_id[slot_id] = udev;
-    KprintfH("assigned slot_id=%ld for addr=%lu\n", (ULONG)slot_id, (ULONG)udev->virtual_address);
+    KprintfH("assigned slot_id=%lu for addr=%lu\n", (ULONG)slot_id, (ULONG)udev->virtual_address);
 
     /* Point to output device context in dcbaa. */
     ctrl->dcbaa->dev_context_ptrs[slot_id] = le64((dma_addr_t)udev->out_ctx->bytes);
 
     xhci_flush_cache(&ctrl->dcbaa->dev_context_ptrs[slot_id], sizeof(__le64));
-    KprintfH("DCBAA[%ld]=%lx\n", (ULONG)slot_id, (ULONG)le64(ctrl->dcbaa->dev_context_ptrs[slot_id]));
+    KprintfH("DCBAA[%lu]=%lx\n", (ULONG)slot_id, (ULONG)le64(ctrl->dcbaa->dev_context_ptrs[slot_id]));
 
     // Continue with Address Device command, passing cmd->req
     xhci_address_device(udev, cmd->req);
@@ -406,17 +408,18 @@ static void handle_enable_slot(struct xhci_ctrl *ctrl, struct pending_command *c
 static void handle_disable_slot(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
     (void)ctrl;
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)le32(event->event_cmd.status), (ULONG)le32(event->event_cmd.flags));
-    xhci_comp_code comp = GET_COMP_CODE(le32(event->event_cmd.status));
+    const u32 status = le32(event->event_cmd.status);
+    const xhci_comp_code comp = GET_COMP_CODE(status);
 
+    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)le32(event->event_cmd.flags));
     if (comp != COMP_SUCCESS)
     {
-        Kprintf("ERROR: Disable Slot command failed for slot %ld (comp=%ld).\n",
-                (ULONG)cmd->udev->slot_id, comp);
+        Kprintf("ERROR: Disable Slot command failed for slot %lu (comp=%lu).\n",
+                (ULONG)cmd->udev->slot_id, (ULONG)comp);
     }
     else
     {
-        KprintfH("Disabled slot %ld successfully (comp=%ld).\n", cmd->udev->slot_id, comp);
+        KprintfH("Disabled slot %lu successfully (comp=%lu).\n", (ULONG)cmd->udev->slot_id, (ULONG)comp);
     }
     cmd->udev->slot_state = USB_DEV_SLOT_STATE_DISABLED;
     xhci_udev_free(cmd->udev);
@@ -425,14 +428,17 @@ static void handle_disable_slot(struct xhci_ctrl *ctrl, struct pending_command *
 static void handle_address_device(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
     (void)ctrl;
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)le32(event->event_cmd.status), (ULONG)le32(event->event_cmd.flags));
+    const u32 status = le32(event->event_cmd.status);
+    const xhci_comp_code comp = GET_COMP_CODE(status);
 
-    int err = ERR_NO_ERROR;
-    switch (GET_COMP_CODE(le32(event->event_cmd.status)))
+    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)le32(event->event_cmd.flags));
+
+    s8 err = ERR_NO_ERROR;
+    switch (comp)
     {
     case COMP_CTX_STATE:
     case COMP_EBADSLT:
-        Kprintf("Setup ERROR: address device command for slot %ld.\n", cmd->udev->slot_id);
+        Kprintf("Setup ERROR: address device command for slot %lu.\n", (ULONG)cmd->udev->slot_id);
         err = ERR_HCI_ERROR;
         break;
     case COMP_TX_ERR:
@@ -457,7 +463,7 @@ static void handle_address_device(struct xhci_ctrl *ctrl, struct pending_command
     {
         if (cmd->udev)
         {
-            Kprintf("Address Device failure for slot %ld (code %ld)\n", (ULONG)cmd->udev->slot_id, (ULONG)err);
+            Kprintf("Address Device failure for slot %lu (code %lu)\n", (ULONG)cmd->udev->slot_id, (ULONG)err);
             xhci_dump_slot_ctx("[xhci-commands] handle_address_device:", cmd->udev, TRUE);
             xhci_dump_slot_ctx("[xhci-commands] handle_address_device:", cmd->udev, FALSE);
         }
@@ -471,9 +477,9 @@ static void handle_address_device(struct xhci_ctrl *ctrl, struct pending_command
         return;
     }
 
-    cmd->udev->xhci_address = xhci_get_hardware_address(cmd->udev);
+    cmd->udev->xhci_address = xhci_get_hardware_address(cmd->udev) & 0xffU;
     cmd->udev->slot_state = USB_DEV_SLOT_STATE_ADDRESSED;
-    KprintfH("Assigned xHCI address %ld to slot %ld (Virtual address %ld)\n",
+    KprintfH("Assigned xHCI address %lu to slot %lu (Virtual address %lu)\n",
              (ULONG)cmd->udev->xhci_address, (ULONG)cmd->udev->slot_id, (cmd->req) ? (ULONG)cmd->req->virtual_address : (ULONG)0);
 
     /* Continue the original request after the device is addressed. */
@@ -490,7 +496,7 @@ static void handle_address_device(struct xhci_ctrl *ctrl, struct pending_command
         }
         else
         {
-            int ret = xhci_udev_send_ctrl(cmd->udev, cmd->req);
+            s8 ret = xhci_udev_send_ctrl(cmd->udev, cmd->req);
             if (ret != ERR_NO_ERROR)
                 xhci_udev_io_reply_failed(ctrl, cmd->req, ret);
         }
@@ -500,14 +506,16 @@ static void handle_address_device(struct xhci_ctrl *ctrl, struct pending_command
 static void handle_reset_device(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
     (void)ctrl;
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)le32(event->event_cmd.status), (ULONG)le32(event->event_cmd.flags));
-    if (GET_COMP_CODE(le32(event->event_cmd.status)) != COMP_SUCCESS)
+    const u32 status = le32(event->event_cmd.status);
+
+    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)le32(event->event_cmd.flags));
+    if (GET_COMP_CODE(status) != COMP_SUCCESS)
     {
-        Kprintf("ERROR: Reset Device command failed for slot %ld.\n", cmd->udev->slot_id);
+        Kprintf("ERROR: Reset Device command failed for slot %lu.\n", (ULONG)cmd->udev->slot_id);
         return;
     }
 
-    KprintfH("Reset Device for slot %ld completed successfully.\n", cmd->udev->slot_id);
+    KprintfH("Reset Device for slot %lu completed successfully.\n", (ULONG)cmd->udev->slot_id);
 }
 
 /*
@@ -555,7 +563,7 @@ void xhci_process_command_timeouts(struct xhci_ctrl *ctrl)
     if (!cmd->deadline_active)
         return; /* abort already fired */
 
-    ULONG now_us = get_time();
+    u32 now_us = get_time();
     if ((int32_t)(now_us - cmd->deadline_us) < 0)
         return; /* not timed out yet */
 
@@ -642,7 +650,7 @@ void xhci_dispatch_command_event(struct xhci_ctrl *ctrl, union xhci_trb *event)
  * Send reset endpoint command for given endpoint. This recovers from a
  * halted endpoint (e.g. due to a stall error).
  */
-void xhci_reset_ep(struct usb_device *udev, u32 ep_index)
+void xhci_reset_ep(struct usb_device *udev, u8 ep_index)
 {
     // TODO for error state, just set deq pointer to current enqueue pointer
     // ep needs be in halted state, otherwise this command will fail
@@ -651,7 +659,7 @@ void xhci_reset_ep(struct usb_device *udev, u32 ep_index)
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
     if (!ep_ctx)
     {
-        Kprintf("No ep context for addr %ld ep %ld\n", (LONG)udev->virtual_address, (LONG)ep_index);
+        Kprintf("No ep context for addr %lu ep %lu\n", (ULONG)udev->virtual_address, (ULONG)ep_index);
         return;
     }
 
@@ -666,7 +674,7 @@ void xhci_reset_ep(struct usb_device *udev, u32 ep_index)
  * After the ring is stopped, we can set the dequeue pointer to the current enqueue pointer to flush any pending transfers and then restart the ring to continue processing new transfers.
  * The endpoint needs be in either Running or Halted state, otherwise this command will fail.
  */
-void xhci_stop_ring(struct usb_device *udev, u32 ep_index)
+void xhci_stop_ring(struct usb_device *udev, u8 ep_index)
 {
     if (!udev || !udev->controller)
         return;
@@ -679,13 +687,13 @@ void xhci_stop_ring(struct usb_device *udev, u32 ep_index)
  * Used after a reset endpoint command to continue processing.
  * The endpoint needs to be either in Error or Stopped state.
  */
-void xhci_set_deq_pointer(struct usb_device *udev, u32 ep_index, u32 deq_ptr)
+void xhci_set_deq_pointer(struct usb_device *udev, u8 ep_index, u32 deq_ptr)
 {
     struct xhci_ctrl *ctrl = udev->controller;
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
     if (!ep_ctx)
     {
-        Kprintf("No ep context for addr %ld ep %ld\n", (LONG)udev->virtual_address, (LONG)ep_index);
+        Kprintf("No ep context for addr %lu ep %lu\n", (ULONG)udev->virtual_address, (ULONG)ep_index);
         return;
     }
 
@@ -741,7 +749,7 @@ void xhci_enable_slot(struct usb_device *udev, struct USBIORequest *req)
 void xhci_disable_slot(struct usb_device *udev)
 {
     struct xhci_ctrl *ctrl = udev->controller;
-    for (int ep_index = 0; ep_index < USB_MAX_ENDPOINT_CONTEXTS; ep_index++)
+    for (u8 ep_index = 0; ep_index < USB_MAX_ENDPOINT_CONTEXTS; ep_index++)
     {
         struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
         if (ep_ctx)
@@ -750,7 +758,7 @@ void xhci_disable_slot(struct usb_device *udev)
 
     if (udev->slot_state == USB_DEV_SLOT_STATE_DISABLED)
     {
-        KprintfH("queue DISABLE_SLOT skipped; slot_id=%ld already disabled\n", (ULONG)udev->slot_id);
+        KprintfH("queue DISABLE_SLOT skipped; slot_id=%lu already disabled\n", (ULONG)udev->slot_id);
         return;
     }
 
@@ -761,12 +769,12 @@ void xhci_disable_slot(struct usb_device *udev)
 static void xhci_set_address(struct usb_device *udev, struct USBIORequest *req)
 {
     struct xhci_ctrl *ctrl = udev->controller;
-    unsigned int slot_id = udev->slot_id;
+    u32 slot_id = udev->slot_id;
 
     /* If already addressed (internal address non-zero), don't re-issue. */
     if (udev->slot_state >= USB_DEV_SLOT_STATE_ADDRESSED)
     {
-        KprintfH("slot %ld already addressed (xhci_address=0x%lx), skipping.\n",
+        KprintfH("slot %lu already addressed (xhci_address=0x%lx), skipping.\n",
                  (ULONG)slot_id, (ULONG)udev->xhci_address);
         if (req)
             xhci_udev_io_reply_data(udev, req, ERR_NO_ERROR, 0);
@@ -783,7 +791,7 @@ static void xhci_set_address(struct usb_device *udev, struct USBIORequest *req)
      */
     xhci_setup_addressable_virt_dev(ctrl, udev);
 
-    KprintfH("queue ADDR_DEV cmd, in_ctx->bytes=%lx addr=%lu slot=%lu parent_addr=%lu parent_port=%lu route=0x%lx, depth=%ld\n",
+    KprintfH("queue ADDR_DEV cmd, in_ctx->bytes=%lx addr=%lu slot=%lu parent_addr=%lu parent_port=%lu route=0x%lx, depth=%lu\n",
              (ULONG)udev->in_ctx->bytes,
              (ULONG)udev->virtual_address,
              (ULONG)slot_id,

--- a/xhci.device/src/xhci/xhci-commands.c
+++ b/xhci.device/src/xhci/xhci-commands.c
@@ -34,7 +34,7 @@ struct pending_command
     struct MinNode node;
     dma_addr_t cmd_trb_dma;  /* value from queue_trb */
     struct usb_device *udev; /* for slot/endpoint checks */
-    u8 ep_index;            /* endpoint index encoded into the command */
+    u8 ep_index;             /* endpoint index encoded into the command */
     command_handler complete;
     struct USBIORequest *req; /* to continue control transfers */
     trb_type type;            /* command type */
@@ -522,16 +522,15 @@ static void handle_reset_device(struct xhci_ctrl *ctrl, struct pending_command *
  * Mapping of commands to their handlers
  */
 static const command_handler command_handlers[] = {
-    [TRB_ENABLE_SLOT] = handle_enable_slot, /* Enable Slot Command */
-    [TRB_DISABLE_SLOT] = handle_disable_slot,
-    /* Disable Slot Command */              // TODO should do DISABLE_SLOT when device is disconnected
-    [TRB_ADDR_DEV] = handle_address_device, /* Address Device Command */
-    [TRB_CONFIG_EP] = handle_config_ep,     /* Configure Endpoint Command */
-    [TRB_EVAL_CONTEXT] = handle_config_ep,  /* Evaluate Context Command */
-    [TRB_RESET_EP] = handle_reset_ep,       /* Reset Endpoint Command */
-    [TRB_STOP_RING] = handle_stop_ring,     /* Stop Transfer Ring Command */
-    [TRB_SET_DEQ] = handle_set_deq,         /* Set Transfer Ring Dequeue Pointer Command */
-    [TRB_RESET_DEV] = handle_reset_device,  /* Reset Device Command */
+    [TRB_ENABLE_SLOT] = handle_enable_slot,   /* Enable Slot Command */
+    [TRB_DISABLE_SLOT] = handle_disable_slot, /* Disable Slot Command */
+    [TRB_ADDR_DEV] = handle_address_device,   /* Address Device Command */
+    [TRB_CONFIG_EP] = handle_config_ep,       /* Configure Endpoint Command */
+    [TRB_EVAL_CONTEXT] = handle_config_ep,    /* Evaluate Context Command */
+    [TRB_RESET_EP] = handle_reset_ep,         /* Reset Endpoint Command */
+    [TRB_STOP_RING] = handle_stop_ring,       /* Stop Transfer Ring Command */
+    [TRB_SET_DEQ] = handle_set_deq,           /* Set Transfer Ring Dequeue Pointer Command */
+    [TRB_RESET_DEV] = handle_reset_device,    /* Reset Device Command */
 };
 
 /* Command ring timeout handler
@@ -710,7 +709,7 @@ void xhci_reset_device(struct usb_device *udev)
 {
     struct xhci_ctrl *ctrl = udev->controller;
     // set slot id, cycle bit; clear other fields and issue reset device command
-    xhci_queue_command(ctrl, 0, udev->slot_id, 0, TRB_RESET_DEV, NULL, udev); // TODO handle_reset_device - wait for command completion
+    xhci_queue_command(ctrl, 0, udev->slot_id, 0, TRB_RESET_DEV, NULL, udev);
 }
 
 /**

--- a/xhci.device/src/xhci/xhci-commands.c
+++ b/xhci.device/src/xhci/xhci-commands.c
@@ -1,9 +1,9 @@
 #include <debug.h>
 #include <config.h>
 
-#include <emu_iomem.h>
-#include <emu_memory.h>
-#include <emu_timing.h>
+#include <iomem.h>
+#include <memory.h>
+#include <timing.h>
 
 #include <xhci/xhci.h>
 #include <xhci/xhci-commands.h>
@@ -163,7 +163,7 @@ static void xhci_queue_command(struct xhci_ctrl *ctrl, dma_addr_t addr, u32 slot
     }
 
     /* Add command handler to pending list */
-    struct pending_command *pending_cmd = AllocVecPooled(ctrl->memoryPool, sizeof(struct pending_command));
+    struct pending_command *pending_cmd = pool_zalloc(ctrl->memoryPool, sizeof(struct pending_command));
     if (!pending_cmd)
     {
         Kprintf("Failed to allocate pending command\n");
@@ -194,7 +194,7 @@ static void xhci_queue_command(struct xhci_ctrl *ctrl, dma_addr_t addr, u32 slot
     /* Ring the command ring doorbell — suppressed while an abort is in
      * progress; COMP_CMD_STOP will restart the ring once the HC has stopped. */
     if (!ctrl->cmd_abort_pending)
-        writel(DB_VALUE_HOST, &ctrl->dba->doorbell[0]);
+        mmio_write32(DB_VALUE_HOST, &ctrl->dba->doorbell[0]);
 }
 
 /*
@@ -204,7 +204,7 @@ static void xhci_queue_command(struct xhci_ctrl *ctrl, dma_addr_t addr, u32 slot
 static void handle_reset_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
     (void)ctrl;
-    const u32 flags = LE32(event->event_cmd.flags);
+    const u32 flags = le32(event->event_cmd.flags);
     const ULONG slot_id = cmd->udev->slot_id;
     const ULONG ep_index = cmd->ep_index;
 
@@ -231,10 +231,10 @@ static void handle_reset_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd,
 static void handle_set_deq(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
     (void)ctrl;
-    u32 flags = LE32(event->event_cmd.flags);
+    u32 flags = le32(event->event_cmd.flags);
     ULONG slot_id = cmd->udev->slot_id;
     ULONG ep_index = cmd->ep_index;
-    xhci_comp_code comp = GET_COMP_CODE(LE32(event->event_cmd.status));
+    xhci_comp_code comp = GET_COMP_CODE(le32(event->event_cmd.status));
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(cmd->udev, ep_index);
     if (!ep_ctx)
     {
@@ -286,9 +286,9 @@ static void handle_set_deq(struct xhci_ctrl *ctrl, struct pending_command *cmd, 
 static void handle_stop_ring(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
     (void)ctrl;
-    u32 flags = LE32(event->event_cmd.flags);
+    u32 flags = le32(event->event_cmd.flags);
     trb_type type = TRB_FIELD_TO_TYPE(flags);
-    xhci_comp_code comp = GET_COMP_CODE(LE32(event->event_cmd.status));
+    xhci_comp_code comp = GET_COMP_CODE(le32(event->event_cmd.status));
     ULONG slot_id = cmd->udev->slot_id;
     ULONG ep_index = cmd->ep_index;
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(cmd->udev, ep_index);
@@ -343,7 +343,7 @@ static void handle_config_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd
     trb_type type = cmd->type;
     const char *type_name = xhci_command_type_name(type);
 #endif
-    xhci_comp_code comp = GET_COMP_CODE(LE32(event->event_cmd.status));
+    xhci_comp_code comp = GET_COMP_CODE(le32(event->event_cmd.status));
 
 #ifdef DEBUG_HIGH
     if (type == TRB_EVAL_CONTEXT && cmd->udev)
@@ -355,11 +355,11 @@ static void handle_config_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd
 
     if (comp != COMP_SUCCESS)
     {
-        KprintfH("ERROR: %s command for slot %ld returned completion code 0x%lx.\n", type_name, TRB_TO_SLOT_ID(LE32(event->event_cmd.flags)), (ULONG)comp);
+        KprintfH("ERROR: %s command for slot %ld returned completion code 0x%lx.\n", type_name, TRB_TO_SLOT_ID(le32(event->event_cmd.flags)), (ULONG)comp);
         return;
     }
 
-    KprintfH("%s command for slot %ld completed successfully\n", type_name, TRB_TO_SLOT_ID(LE32(event->event_cmd.flags)));
+    KprintfH("%s command for slot %ld completed successfully\n", type_name, TRB_TO_SLOT_ID(le32(event->event_cmd.flags)));
 
     cmd->udev->slot_state = USB_DEV_SLOT_STATE_CONFIGURED;
 
@@ -375,8 +375,8 @@ static void handle_config_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd
 
 static void handle_enable_slot(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)LE32(event->event_cmd.status), (ULONG)LE32(event->event_cmd.flags));
-    if (GET_COMP_CODE(LE32(event->event_cmd.status)) != COMP_SUCCESS)
+    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)le32(event->event_cmd.status), (ULONG)le32(event->event_cmd.flags));
+    if (GET_COMP_CODE(le32(event->event_cmd.status)) != COMP_SUCCESS)
     {
         Kprintf("ERROR: Enable Slot command failed.\n");
         xhci_udev_io_reply_failed(ctrl, cmd->req, ERR_HCI_ERROR);
@@ -384,7 +384,7 @@ static void handle_enable_slot(struct xhci_ctrl *ctrl, struct pending_command *c
     }
 
     struct usb_device *udev = cmd->udev;
-    int slot_id = TRB_TO_SLOT_ID(LE32(event->event_cmd.flags));
+    int slot_id = TRB_TO_SLOT_ID(le32(event->event_cmd.flags));
 
     udev->slot_id = slot_id;
     udev->slot_state = USB_DEV_SLOT_STATE_ENABLED;
@@ -392,10 +392,10 @@ static void handle_enable_slot(struct xhci_ctrl *ctrl, struct pending_command *c
     KprintfH("assigned slot_id=%ld for addr=%lu\n", (ULONG)slot_id, (ULONG)udev->virtual_address);
 
     /* Point to output device context in dcbaa. */
-    ctrl->dcbaa->dev_context_ptrs[slot_id] = LE64((dma_addr_t)udev->out_ctx->bytes);
+    ctrl->dcbaa->dev_context_ptrs[slot_id] = le64((dma_addr_t)udev->out_ctx->bytes);
 
     xhci_flush_cache(&ctrl->dcbaa->dev_context_ptrs[slot_id], sizeof(__le64));
-    KprintfH("DCBAA[%ld]=%lx\n", (ULONG)slot_id, (ULONG)LE64(ctrl->dcbaa->dev_context_ptrs[slot_id]));
+    KprintfH("DCBAA[%ld]=%lx\n", (ULONG)slot_id, (ULONG)le64(ctrl->dcbaa->dev_context_ptrs[slot_id]));
 
     // Continue with Address Device command, passing cmd->req
     xhci_address_device(udev, cmd->req);
@@ -404,8 +404,8 @@ static void handle_enable_slot(struct xhci_ctrl *ctrl, struct pending_command *c
 static void handle_disable_slot(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
     (void)ctrl;
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)LE32(event->event_cmd.status), (ULONG)LE32(event->event_cmd.flags));
-    xhci_comp_code comp = GET_COMP_CODE(LE32(event->event_cmd.status));
+    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)le32(event->event_cmd.status), (ULONG)le32(event->event_cmd.flags));
+    xhci_comp_code comp = GET_COMP_CODE(le32(event->event_cmd.status));
 
     if (comp != COMP_SUCCESS)
     {
@@ -423,10 +423,10 @@ static void handle_disable_slot(struct xhci_ctrl *ctrl, struct pending_command *
 static void handle_address_device(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
     (void)ctrl;
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)LE32(event->event_cmd.status), (ULONG)LE32(event->event_cmd.flags));
+    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)le32(event->event_cmd.status), (ULONG)le32(event->event_cmd.flags));
 
     int err = ERR_NO_ERROR;
-    switch (GET_COMP_CODE(LE32(event->event_cmd.status)))
+    switch (GET_COMP_CODE(le32(event->event_cmd.status)))
     {
     case COMP_CTX_STATE:
     case COMP_EBADSLT:
@@ -446,7 +446,7 @@ static void handle_address_device(struct xhci_ctrl *ctrl, struct pending_command
         break;
     default:
         Kprintf("ERROR: unexpected command completion code 0x%lx.\n",
-                GET_COMP_CODE(LE32(event->event_cmd.status)));
+                GET_COMP_CODE(le32(event->event_cmd.status)));
         err = ERR_HCI_ERROR;
         break;
     }
@@ -498,8 +498,8 @@ static void handle_address_device(struct xhci_ctrl *ctrl, struct pending_command
 static void handle_reset_device(struct xhci_ctrl *ctrl, struct pending_command *cmd, union xhci_trb *event)
 {
     (void)ctrl;
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)LE32(event->event_cmd.status), (ULONG)LE32(event->event_cmd.flags));
-    if (GET_COMP_CODE(LE32(event->event_cmd.status)) != COMP_SUCCESS)
+    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)le32(event->event_cmd.status), (ULONG)le32(event->event_cmd.flags));
+    if (GET_COMP_CODE(le32(event->event_cmd.status)) != COMP_SUCCESS)
     {
         Kprintf("ERROR: Reset Device command failed for slot %ld.\n", cmd->udev->slot_id);
         return;
@@ -581,8 +581,8 @@ void xhci_process_command_timeouts(struct xhci_ctrl *ctrl)
  */
 void xhci_dispatch_command_event(struct xhci_ctrl *ctrl, union xhci_trb *event)
 {
-    const xhci_comp_code comp = (xhci_comp_code)GET_COMP_CODE(LE32(event->event_cmd.status));
-    const dma_addr_t trb_addr = (dma_addr_t)LE64(event->event_cmd.cmd_trb);
+    const xhci_comp_code comp = (xhci_comp_code)GET_COMP_CODE(le32(event->event_cmd.status));
+    const dma_addr_t trb_addr = (dma_addr_t)le64(event->event_cmd.cmd_trb);
 
     /* COMP_CMD_STOP means the command ring has stopped after a CA abort.
      * The aborted command is handled by COMP_CMD_ABORT below; here we only
@@ -593,7 +593,7 @@ void xhci_dispatch_command_event(struct xhci_ctrl *ctrl, union xhci_trb *event)
         ctrl->cmd_abort_pending = FALSE;
         /* Restart only if there are still pending commands. */
         if (ctrl->pending_commands.mlh_Head->mln_Succ)
-            writel(DB_VALUE_HOST, &ctrl->dba->doorbell[0]);
+            mmio_write32(DB_VALUE_HOST, &ctrl->dba->doorbell[0]);
         return;
     }
 
@@ -613,7 +613,7 @@ void xhci_dispatch_command_event(struct xhci_ctrl *ctrl, union xhci_trb *event)
                 (ULONG)cmd->cmd_trb_dma);
         Remove((struct Node *)cmd);
         xhci_fail_timed_out_command(ctrl, cmd);
-        FreeVecPooled(ctrl->memoryPool, cmd);
+        pool_free(ctrl->memoryPool, cmd);
         return;
     }
 
@@ -625,15 +625,15 @@ void xhci_dispatch_command_event(struct xhci_ctrl *ctrl, union xhci_trb *event)
             Kprintf("No handler for command TRB %lx\n", cmd->cmd_trb_dma);
 
         Remove((struct Node *)cmd);
-        FreeVecPooled(ctrl->memoryPool, cmd);
+        pool_free(ctrl->memoryPool, cmd);
         return;
     }
 
     Kprintf("No matching pending command for command completion event TRB (%08lx %08lx %08lx %08lx)\n",
-            (ULONG)LE32(event->generic.field[0]),
-            (ULONG)LE32(event->generic.field[1]),
-            (ULONG)LE32(event->generic.field[2]),
-            (ULONG)LE32(event->generic.field[3]));
+            (ULONG)le32(event->generic.field[0]),
+            (ULONG)le32(event->generic.field[1]),
+            (ULONG)le32(event->generic.field[2]),
+            (ULONG)le32(event->generic.field[3]));
 }
 
 /*

--- a/xhci.device/src/xhci/xhci-commands.c
+++ b/xhci.device/src/xhci/xhci-commands.c
@@ -1,6 +1,9 @@
 #include <debug.h>
 #include <config.h>
-#include <compat.h>
+
+#include <emu_iomem.h>
+#include <emu_memory.h>
+#include <emu_timing.h>
 
 #include <xhci/xhci.h>
 #include <xhci/xhci-commands.h>

--- a/xhci.device/src/xhci/xhci-commands.c
+++ b/xhci.device/src/xhci/xhci-commands.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #include <debug.h>
 #include <config.h>
 

--- a/xhci.device/src/xhci/xhci-context.c
+++ b/xhci.device/src/xhci/xhci-context.c
@@ -16,11 +16,15 @@
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
 #endif
 
-#include <compat.h>
 #include <debug.h>
+
+#include <emu_iomem.h>
+#include <emu_memory.h>
 
 #include <xhci/xhci.h>
 #include <xhci/xhci-commands.h>

--- a/xhci.device/src/xhci/xhci-context.c
+++ b/xhci.device/src/xhci/xhci-context.c
@@ -389,7 +389,7 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
     /* EP 0 can handle "burst" sizes of 1, so Max Burst Size field is 0 */
     ep0_ctx->ep_info2 |= le32(MAX_BURST(0) | ERROR_COUNT(3));
 
-    BOOL result = xhci_ep_create_context(udev, 0, max_packet_size, ctrl->memoryPool);
+    BOOL result = xhci_ep_create_context(udev, 0, max_packet_size, /*max_burst*/ 0, ctrl->memoryPool);
     if (!result)
         Kprintf("Failed to create EP0 context\n");
 
@@ -568,7 +568,7 @@ static s8 xhci_init_ep_contexts_if(struct usb_device *udev,
 
         u16 max_packet_size = usb_endpoint_maxp(endpt_desc);
         /* Allocate the ep rings */
-        BOOL result = xhci_ep_create_context(udev, ep_index, max_packet_size, ctrl->memoryPool);
+        BOOL result = xhci_ep_create_context(udev, ep_index, max_packet_size, max_burst, ctrl->memoryPool);
         if (!result)
             return ERR_ALLOC_ERROR;
 

--- a/xhci.device/src/xhci/xhci-context.c
+++ b/xhci.device/src/xhci/xhci-context.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * USB HOST XHCI Controller stack
  *

--- a/xhci.device/src/xhci/xhci-context.c
+++ b/xhci.device/src/xhci/xhci-context.c
@@ -590,6 +590,8 @@ static s8 xhci_init_ep_contexts_if(struct usb_device *udev,
         struct xhci_ring *ring = xhci_ep_get_ring(ep_context);
         ep_ctx[ep_index]->deq = le64(xhci_ring_get_new_dequeue_ptr(ring));
 
+        xhci_ep_set_rt_interval(ep_context, interval);
+
         /*
          * xHCI spec 6.2.3:
          * 'Average TRB Length' should be 8 for control endpoints.

--- a/xhci.device/src/xhci/xhci-context.c
+++ b/xhci.device/src/xhci/xhci-context.c
@@ -51,7 +51,7 @@
  * @param type type of XHCI Container Context
  * Return: NULL if failed else pointer to the context on success
  */
-struct xhci_container_ctx *xhci_alloc_container_ctx(struct xhci_ctrl *ctrl, int type)
+struct xhci_container_ctx *xhci_alloc_container_ctx(struct xhci_ctrl *ctrl, u32 type)
 {
     struct xhci_container_ctx *ctx = pool_zalloc(ctrl->memoryPool, sizeof(struct xhci_container_ctx));
     if (!ctx)
@@ -127,7 +127,7 @@ static struct xhci_slot_ctx *xhci_get_slot_ctx(struct xhci_ctrl *ctrl, struct xh
  * @param ep_index	index of the endpoint
  * Return: pointer to the End point context
  */
-static struct xhci_ep_ctx *xhci_get_ep_ctx(struct xhci_ctrl *ctrl, struct xhci_container_ctx *ctx, unsigned int ep_index)
+static struct xhci_ep_ctx *xhci_get_ep_ctx(struct xhci_ctrl *ctrl, struct xhci_container_ctx *ctx, u8 ep_index)
 {
     /* increment ep index by offset of start of ep ctx array */
     ep_index++;
@@ -144,7 +144,7 @@ u32 xhci_get_hardware_address(struct usb_device *udev)
     return le32(slot_ctx->dev_state) & DEV_ADDR_MASK;
 }
 
-u64 xhci_get_endpoint_deq_ptr(struct usb_device *udev, unsigned int ep_index)
+u64 xhci_get_endpoint_deq_ptr(struct usb_device *udev, u8 ep_index)
 {
     struct xhci_ep_ctx *ep_ctx = xhci_get_ep_ctx(udev->controller, udev->out_ctx, ep_index);
     xhci_inval_cache(ep_ctx, sizeof(struct xhci_ep_ctx));
@@ -165,7 +165,7 @@ u64 xhci_get_endpoint_deq_ptr(struct usb_device *udev, unsigned int ep_index)
 static void xhci_endpoint_copy(struct xhci_ctrl *ctrl,
                                struct xhci_container_ctx *in_ctx,
                                struct xhci_container_ctx *out_ctx,
-                               unsigned int ep_index)
+                               u8 ep_index)
 {
     struct xhci_ep_ctx *out_ep_ctx = xhci_get_ep_ctx(ctrl, out_ctx, ep_index);
     struct xhci_ep_ctx *in_ep_ctx = xhci_get_ep_ctx(ctrl, in_ctx, ep_index);
@@ -214,11 +214,12 @@ static void build_route_string(struct usb_device *udev)
         return;
     }
 
-    unsigned int nibble = (udev->parent_port > 15) ? 0xf : udev->parent_port & 0xF;
-    udev->route_depth = parent->route_depth + 1;
+    u8 nibble = (udev->parent_port > 15) ? 0xf : udev->parent_port;
+    u32 route_depth = parent->route_depth + 1U;
+    udev->route_depth = (u8)((route_depth <= 0xffU) ? route_depth : 0xffU);
     if (parent->route_depth > 5)
     {
-        Kprintf("Route depth %ld exceeds xHCI max of 5, not adding to route string\n", (ULONG)parent->route_depth);
+        Kprintf("Route depth %lu exceeds xHCI max of 5, not adding to route string\n", (ULONG)parent->route_depth);
         udev->route = parent->route;
         return;
     }
@@ -231,7 +232,8 @@ static void build_route_string(struct usb_device *udev)
      * route_depth tracks tier count (1 for first tier), so the nibble
      * shift is based on parent depth.
      */
-    udev->route = parent->route | (nibble << (parent->route_depth << 2));
+    u32 route_shift = (u32)parent->route_depth << 2;
+    udev->route = parent->route | ((u32)nibble << route_shift);
 }
 
 static u32 find_root_port(struct usb_device *udev)
@@ -263,16 +265,16 @@ static u32 find_root_port(struct usb_device *udev)
  */
 void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *udev)
 {
-    KprintfH("Setting up addressable virtual device addr=%ld parent_addr=%ld parent_port=%ld\n",
-             (LONG)udev->virtual_address,
-             (LONG)(udev->parent ? udev->parent->virtual_address : 0),
-             udev->parent_port);
+    KprintfH("Setting up addressable virtual device addr=%lu parent_addr=%lu parent_port=%lu\n",
+             (ULONG)udev->virtual_address,
+             (ULONG)(udev->parent ? udev->parent->virtual_address : 0),
+             (ULONG)udev->parent_port);
     build_route_string(udev);
 
     /* Extract the EP0 and Slot Ctrl */
     struct xhci_ep_ctx *ep0_ctx = xhci_get_ep_ctx(ctrl, udev->in_ctx, 0);
     struct xhci_slot_ctx *slot_ctx = xhci_get_slot_ctx(ctrl, udev->in_ctx);
-    KprintfH("slot=%ld in_ctx=%lx out_ctx=%lx ep0_ctx=%lx slot_ctx=%lx\n",
+    KprintfH("slot=%lu in_ctx=%lx out_ctx=%lx ep0_ctx=%lx slot_ctx=%lx\n",
              (ULONG)udev->slot_id, (ULONG)udev->in_ctx, (ULONG)udev->out_ctx,
              (ULONG)ep0_ctx, (ULONG)slot_ctx);
 
@@ -299,7 +301,7 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
         break;
     default:
         /* Speed was set earlier, this shouldn't happen. */
-        Kprintf("Unknown device speed %ld\n", (ULONG)udev->speed);
+        Kprintf("Unknown device speed %lu\n", (ULONG)udev->speed);
     }
 
     /*
@@ -314,11 +316,11 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
     // Find root hub port number
     u32 root_port = find_root_port(udev);
 
-    KprintfH("xhci_setup_addressable_virt_dev: parent_addr=%ld port_num=%ld root_port_num=%ld speed=%ld route=%lx route_depth=%ld\n",
-             (ULONG)udev->parent->virtual_address, udev->parent_port, root_port, (ULONG)udev->speed, (ULONG)udev->route, (ULONG)udev->route_depth);
+    KprintfH("xhci_setup_addressable_virt_dev: parent_addr=%lu port_num=%lu root_port_num=%lu speed=%lu route=%lx route_depth=%lu\n",
+             (ULONG)udev->parent->virtual_address, (ULONG)udev->parent_port, (ULONG)root_port, (ULONG)udev->speed, (ULONG)udev->route, (ULONG)udev->route_depth);
 
     u32 dev_info2 = le32(slot_ctx->dev_info2);
-    dev_info2 &= ~((ROOT_HUB_PORT_MASK) << ROOT_HUB_PORT_SHIFT);
+    dev_info2 &= ~(ROOT_HUB_PORT_MASK << ROOT_HUB_PORT_SHIFT);
     dev_info2 |= ROOT_HUB_PORT(root_port);
     slot_ctx->dev_info2 = le32(dev_info2);
 
@@ -326,7 +328,7 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
     if (udev->speed == USB_SPEED_LOW || udev->speed == USB_SPEED_FULL)
     {
         struct usb_device *tt_hub = udev->parent;
-        unsigned int parent_port = udev->parent_port;
+        u8 parent_port = udev->parent_port;
 
         while (tt_hub)
         {
@@ -334,8 +336,8 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
             {
                 // TODO set MTT if parent hub has multiple transaction translator capability enabled
                 tt_info = TT_SLOT(tt_hub->slot_id) | TT_PORT(parent_port);
-                KprintfH("xhci_setup_addressable_virt_dev: tt_slot=%ld tt_port=%ld tt_info=%08lx\n",
-                         tt_hub->slot_id, parent_port, tt_info);
+                KprintfH("xhci_setup_addressable_virt_dev: tt_slot=%lu tt_port=%lu tt_info=%08lx\n",
+                         (ULONG)tt_hub->slot_id, (ULONG)parent_port, (ULONG)tt_info);
                 break;
             }
             parent_port = tt_hub->parent_port;
@@ -343,7 +345,7 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
         }
 
         if (!tt_hub)
-            Kprintf("Low or full speed device addr %ld not behind a high-speed hub???\n", (ULONG)udev->virtual_address);
+            Kprintf("Low or full speed device addr %lu not behind a high-speed hub???\n", (ULONG)udev->virtual_address);
     }
 
     /* TODO for SS/SSP if connected by higher rank hub:
@@ -356,9 +358,9 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
     /* Step 4 - ring already allocated */
     /* Step 5 */
     ep0_ctx->ep_info2 = le32(EP_TYPE(CTRL_EP));
-    KprintfH("xhci_setup_addressable_virt_dev: SPEED=%ld\n", (ULONG)udev->speed);
+    KprintfH("xhci_setup_addressable_virt_dev: SPEED=%lu\n", (ULONG)udev->speed);
 
-    int max_packet_size = 0;
+    u32 max_packet_size = 0;
     switch (udev->speed)
     {
     case USB_SPEED_SUPER:
@@ -381,7 +383,7 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
         break;
     default:
         /* New speed? */
-        Kprintf("Unknown device speed %ld\n", (ULONG)udev->speed);
+        Kprintf("Unknown device speed %lu\n", (ULONG)udev->speed);
     }
 
     /* EP 0 can handle "burst" sizes of 1, so Max Burst Size field is 0 */
@@ -462,26 +464,25 @@ static void xhci_update_hub_tt(struct usb_device *udev, struct xhci_container_ct
  * @param udev	pointer to the Device Data Structure
  * Return: returns the status of the xhci_configure_endpoints
  */
-void xhci_update_maxpacket(struct usb_device *udev, unsigned int max_packet_size)
+void xhci_update_maxpacket(struct usb_device *udev, u16 max_packet_size)
 {
     struct xhci_ctrl *ctrl = udev->controller;
-    int ep_index = 0; /* control endpoint */
-    unsigned int hw_max_packet_size;
+    u8 ep_index = 0; /* control endpoint */
 
     xhci_inval_cache(udev->out_ctx->bytes, udev->out_ctx->size);
-    KprintfH("Checking max packet size for ep 0 of address %ld (slot %ld)\n", (LONG)udev->virtual_address, (LONG)udev->slot_id);
+    KprintfH("Checking max packet size for ep 0 of address %lu (slot %lu)\n", (ULONG)udev->virtual_address, (ULONG)udev->slot_id);
 
     struct xhci_ep_ctx *ep_ctx = xhci_get_ep_ctx(ctrl, udev->out_ctx, ep_index);
-    hw_max_packet_size = MAX_PACKET_DECODED(le32(ep_ctx->ep_info2));
+    u16 hw_max_packet_size = (u16)MAX_PACKET_DECODED(le32(ep_ctx->ep_info2));
 
     if (hw_max_packet_size == max_packet_size)
     {
-        KprintfH("Max Packet Size for ep 0 is already correct at %ld.\n", max_packet_size);
+        KprintfH("Max Packet Size for ep 0 is already correct at %lu.\n", (ULONG)max_packet_size);
         return;
     }
 
-    KprintfH("Max Packet Size for ep 0 changed to %ld.\n", max_packet_size);
-    KprintfH("Max packet size in xHCI HW = %ld\n", hw_max_packet_size);
+    KprintfH("Max Packet Size for ep 0 changed to %lu.\n", (ULONG)max_packet_size);
+    KprintfH("Max packet size in xHCI HW = %lu\n", (ULONG)hw_max_packet_size);
 
     // Update the EP context's max packet size as well
     struct ep_context *ep_context = xhci_ep_get_context_for_index(udev, ep_index);
@@ -515,31 +516,31 @@ void xhci_update_maxpacket(struct usb_device *udev, unsigned int max_packet_size
  * @param ifdesc	pointer to the USB interface config descriptor
  * Return: returns the status of xhci_init_ep_contexts_if
  */
-static int xhci_init_ep_contexts_if(struct usb_device *udev,
+static s8 xhci_init_ep_contexts_if(struct usb_device *udev,
                                     struct xhci_ctrl *ctrl,
                                     struct usb_interface *ifdesc)
 {
     KprintfH("xhci_init_ep_contexts_if: enter\n");
     struct xhci_ep_ctx *ep_ctx[USB_MAX_ENDPOINT_CONTEXTS];
-    int cur_ep;
-    int ep_index;
-    unsigned int dir;
-    unsigned int ep_type;
+    u8 cur_ep;
+    u8 ep_index;
+    u8 dir;
+    u8 ep_type;
     u32 max_esit_payload;
-    unsigned int interval;
-    unsigned int mult;
-    unsigned int max_burst;
-    unsigned int avg_trb_len;
-    unsigned int err_count = 0;
+    u8 interval;
+    u8 mult;
+    u8 max_burst;
+    u32 avg_trb_len;
+    u8 err_count = 0;
     struct usb_interface_altsetting *active_alt = ifdesc->active_altsetting;
     if (!active_alt)
     {
-        Kprintf("xhci_init_ep_contexts_if: no active altsetting for iface %ld\n",
+        Kprintf("xhci_init_ep_contexts_if: no active altsetting for iface %lu\n",
                 (ULONG)ifdesc->interface_number);
         return ERR_BAD_PARAMETERS;
     }
 
-    int num_of_ep = active_alt->no_of_ep;
+    u8 num_of_ep = active_alt->no_of_ep;
 
     for (cur_ep = 0; cur_ep < num_of_ep; cur_ep++)
     {
@@ -565,7 +566,7 @@ static int xhci_init_ep_contexts_if(struct usb_device *udev,
         ep_index = xhci_get_ep_index(endpt_desc);
         ep_ctx[ep_index] = xhci_get_ep_ctx(ctrl, udev->in_ctx, ep_index);
 
-        int max_packet_size = usb_endpoint_maxp(endpt_desc);
+        u16 max_packet_size = usb_endpoint_maxp(endpt_desc);
         /* Allocate the ep rings */
         BOOL result = xhci_ep_create_context(udev, ep_index, max_packet_size, ctrl->memoryPool);
         if (!result)
@@ -573,7 +574,7 @@ static int xhci_init_ep_contexts_if(struct usb_device *udev,
 
         /*NOTE: ep_desc[0] actually represents EP1 and so on */
         dir = (((endpt_desc->bEndpointAddress) & (0x80)) >> 7);
-        ep_type = (((endpt_desc->bmAttributes) & (0x3)) | (dir << 2));
+        ep_type = ((endpt_desc->bmAttributes & 0x3U) | ((u32)dir << 2u)) & 0xffU;
 
         ep_ctx[ep_index]->ep_info = le32(EP_MAX_ESIT_PAYLOAD_HI(max_esit_payload) | EP_INTERVAL(interval) | EP_MULT(mult));
 
@@ -597,8 +598,8 @@ static int xhci_init_ep_contexts_if(struct usb_device *udev,
             avg_trb_len = 8;
         ep_ctx[ep_index]->tx_info = le32(EP_MAX_ESIT_PAYLOAD_LO(max_esit_payload) | EP_AVG_TRB_LENGTH(avg_trb_len));
 
-        KprintfH("EP%ld %s: type=%ld maxp=%ld maxesit=%ld "
-                 "interval=%ld mult=%ld maxburst=%ld\n",
+        KprintfH("EP%lu %s: type=%lu maxp=%lu maxesit=%lu "
+                 "interval=%lu mult=%lu maxburst=%lu\n",
                  (ULONG)usb_endpoint_num(endpt_desc),
                  dir ? "IN" : "OUT",
                  (ULONG)ep_type,
@@ -614,7 +615,7 @@ static int xhci_init_ep_contexts_if(struct usb_device *udev,
 
 static void xhci_update_slot_last_ctx(struct xhci_ctrl *ctrl,
                                       struct usb_device *udev,
-                                      unsigned int max_ep_flag)
+                                      u32 max_ep_flag)
 {
     if (!ctrl || !udev)
         return;
@@ -635,29 +636,29 @@ static void xhci_update_slot_last_ctx(struct xhci_ctrl *ctrl,
  * @param udev	pointer to the USB device structure
  * Return: returns the status of the xhci_configure_endpoints
  */
-int xhci_set_configuration(struct usb_device *udev, int config_value)
+s8 xhci_set_configuration(struct usb_device *udev, u32 config_value)
 {
-    KprintfH("xhci_set_configuration: config_val=%ld\n", (LONG)config_value);
+    KprintfH("xhci_set_configuration: config_val=%lu\n", (ULONG)config_value);
 
-    struct usb_config *cfg = xhci_find_config(udev, config_value);
+    struct usb_config *cfg = xhci_find_config(udev, (int)config_value);
     if (!cfg)
     {
-        Kprintf("xhci_set_configuration: config_val=%ld not found!\n", (LONG)config_value);
+        Kprintf("xhci_set_configuration: config_val=%lu not found!\n", (ULONG)config_value);
         return ERR_BAD_PARAMETERS;
     }
 
     udev->active_config = cfg;
-    for (unsigned int i = 0; i < cfg->no_of_if; ++i)
+    for (u8 i = 0; i < cfg->no_of_if; ++i)
         xhci_select_active_alt(&cfg->if_desc[i]);
 
 #ifdef DEBUG_HIGH
     /* Dump entire cfg using kprintf (all fields and all interfaces and endpoints) */
-    xhci_dump_config("[xhci] xhci_set_configuration:", cfg, (LONG)udev->virtual_address);
+    xhci_dump_config("[xhci] xhci_set_configuration:", cfg, udev->virtual_address);
 #endif
 
     struct xhci_ctrl *ctrl = udev->controller;
-    unsigned int max_ifnum = cfg->no_of_if;
-    unsigned int max_ep_flag = 0;
+    u8 max_ifnum = cfg->no_of_if;
+    u32 max_ep_flag = 0;
 
     struct xhci_container_ctx *out_ctx = udev->out_ctx;
     struct xhci_container_ctx *in_ctx = udev->in_ctx;
@@ -681,10 +682,10 @@ int xhci_set_configuration(struct usb_device *udev, int config_value)
     xhci_update_hub_tt(udev, in_ctx);
 
     /* filling up ep contexts */
-    for (unsigned int ifnum = 0; ifnum < max_ifnum; ++ifnum)
+    for (u8 ifnum = 0; ifnum < max_ifnum; ++ifnum)
     {
         struct usb_interface *ifdesc = &cfg->if_desc[ifnum];
-        int err = xhci_init_ep_contexts_if(udev, ctrl, ifdesc);
+        s8 err = xhci_init_ep_contexts_if(udev, ctrl, ifdesc);
         if (err != ERR_NO_ERROR)
         {
             return err;
@@ -693,7 +694,7 @@ int xhci_set_configuration(struct usb_device *udev, int config_value)
     return ERR_NO_ERROR;
 }
 
-int xhci_set_interface(struct usb_device *udev, unsigned int iface_number, unsigned int alt_setting)
+s8 xhci_set_interface(struct usb_device *udev, u8 iface_number, u8 alt_setting)
 {
     if (!udev || !udev->controller)
     {
@@ -704,15 +705,15 @@ int xhci_set_interface(struct usb_device *udev, unsigned int iface_number, unsig
     struct usb_config *cfg = udev->active_config;
     if (!cfg)
     {
-        Kprintf("xhci_set_interface: no active config for addr %ld\n", (LONG)udev->virtual_address);
+        Kprintf("xhci_set_interface: no active config for addr %lu\n", (ULONG)udev->virtual_address);
         return ERR_BAD_PARAMETERS;
     }
 
     struct usb_interface *iface = xhci_find_interface(cfg, iface_number);
     if (!iface)
     {
-        Kprintf("xhci_set_interface: interface %ld not found in config %ld\n",
-                (LONG)iface_number, (LONG)cfg->desc.bConfigurationValue);
+        Kprintf("xhci_set_interface: interface %lu not found in config %lu\n",
+                (ULONG)iface_number, (ULONG)cfg->desc.bConfigurationValue);
         return ERR_BAD_PARAMETERS;
     }
 
@@ -720,16 +721,16 @@ int xhci_set_interface(struct usb_device *udev, unsigned int iface_number, unsig
 
     if (current_alt && current_alt->desc.bAlternateSetting == alt_setting)
     {
-        KprintfH("xhci_set_interface: iface %ld already at alt %ld\n",
-                 (LONG)iface_number, (LONG)alt_setting);
+        KprintfH("xhci_set_interface: iface %lu already at alt %lu\n",
+                 (ULONG)iface_number, (ULONG)alt_setting);
         return ERR_NO_ERROR;
     }
 
     struct usb_interface_altsetting *new_alt = xhci_find_altsetting(iface, alt_setting);
     if (!new_alt)
     {
-        Kprintf("xhci_set_interface: alt %ld missing for iface %ld\n",
-                (LONG)alt_setting, (LONG)iface_number);
+        Kprintf("xhci_set_interface: alt %lu missing for iface %lu\n",
+                (ULONG)alt_setting, (ULONG)iface_number);
         return ERR_BAD_PARAMETERS;
     }
 
@@ -753,7 +754,7 @@ int xhci_set_interface(struct usb_device *udev, unsigned int iface_number, unsig
         return ERR_HCI_ERROR;
     }
 
-    int err = ERR_NO_ERROR;
+    s8 err = ERR_NO_ERROR;
     if (new_alt->no_of_ep > 0)
     {
         err = xhci_init_ep_contexts_if(udev, ctrl, iface);
@@ -770,13 +771,13 @@ int xhci_set_interface(struct usb_device *udev, unsigned int iface_number, unsig
     ctrl_ctx->add_flags = le32(add_flags);
     ctrl_ctx->drop_flags = le32(drop_flags);
 
-    unsigned int max_ep_flag = compute_max_ep_flag(cfg);
+    u32 max_ep_flag = compute_max_ep_flag(cfg);
     xhci_update_slot_last_ctx(ctrl, udev, max_ep_flag);
 
-    KprintfH("xhci_set_interface: updating device context for addr=%ld iface=%ld alt=%ld drop=0x%lx add=0x%lx\n",
-             (LONG)udev->virtual_address,
-             (LONG)iface_number,
-             (LONG)alt_setting,
+    KprintfH("xhci_set_interface: updating device context for addr=%lu iface=%lu alt=%lu drop=0x%lx add=0x%lx\n",
+             (ULONG)udev->virtual_address,
+             (ULONG)iface_number,
+             (ULONG)alt_setting,
              (ULONG)drop_mask,
              (ULONG)add_mask);
 
@@ -785,7 +786,7 @@ int xhci_set_interface(struct usb_device *udev, unsigned int iface_number, unsig
     return err;
 }
 
-static const char *slot_state_name(ULONG state)
+static const char *slot_state_name(u32 state)
 {
     switch (state)
     {
@@ -802,7 +803,7 @@ static const char *slot_state_name(ULONG state)
     }
 }
 
-static const char *slot_speed_name(ULONG dev_info)
+static const char *slot_speed_name(u32 dev_info)
 {
     switch (dev_info & DEV_SPEED)
     {
@@ -819,7 +820,7 @@ static const char *slot_speed_name(ULONG dev_info)
     }
 }
 
-static const char *ep_state_name(ULONG state)
+static const char *ep_state_name(u32 state)
 {
     switch (state & EP_STATE_MASK)
     {
@@ -838,7 +839,7 @@ static const char *ep_state_name(ULONG state)
     }
 }
 
-static const char *ep_type_name(ULONG type)
+static const char *ep_type_name(u32 type)
 {
     switch (type & 0x7)
     {
@@ -874,26 +875,26 @@ void xhci_dump_slot_ctx(const char *tag, struct usb_device *udev, BOOL in_ctx)
         return;
     }
 
-    ULONG dev_info = le32(slot_ctx->dev_info);
-    ULONG dev_info2 = le32(slot_ctx->dev_info2);
-    ULONG tt_info = le32(slot_ctx->tt_info);
-    ULONG dev_state = le32(slot_ctx->dev_state);
+    u32 dev_info = le32(slot_ctx->dev_info);
+    u32 dev_info2 = le32(slot_ctx->dev_info2);
+    u32 tt_info = le32(slot_ctx->tt_info);
+    u32 dev_state = le32(slot_ctx->dev_state);
 
-    ULONG route = dev_info & ROUTE_STRING_MASK;
-    ULONG last_ctx = (dev_info & LAST_CTX_MASK) >> 27;
-    LONG last_ep = (last_ctx == 0) ? -1 : ((LONG)last_ctx - 1);
+    u32 route = dev_info & ROUTE_STRING_MASK;
+    u32 last_ctx = (dev_info & LAST_CTX_MASK) >> 27;
+    s32 last_ep = (last_ctx == 0) ? -1 : ((s32)last_ctx - 1);
 
-    ULONG max_exit_latency = dev_info2 & MAX_EXIT;
-    ULONG root_port = DEVINFO_TO_ROOT_HUB_PORT(dev_info2);
-    ULONG max_ports = (dev_info2 >> 24) & 0xff;
+    u32 max_exit_latency = dev_info2 & MAX_EXIT;
+    u32 root_port = DEVINFO_TO_ROOT_HUB_PORT(dev_info2);
+    u32 max_ports = (dev_info2 >> 24) & 0xff;
 
-    ULONG tt_slot = tt_info & 0xff;
-    ULONG tt_port = (tt_info >> 8) & 0xff;
-    ULONG tt_think_code = (tt_info >> 16) & 0x3;
-    ULONG tt_think_bits = (tt_think_code + 1) * 8;
+    u32 tt_slot = tt_info & 0xff;
+    u32 tt_port = (tt_info >> 8) & 0xff;
+    u32 tt_think_code = (tt_info >> 16) & 0x3;
+    u32 tt_think_bits = (tt_think_code + 1) * 8;
 
-    ULONG address = dev_state & DEV_ADDR_MASK;
-    ULONG slot_state = GET_SLOT_STATE(dev_state);
+    u32 address = dev_state & DEV_ADDR_MASK;
+    u32 slot_state = GET_SLOT_STATE(dev_state);
     Kprintf("%s Slot context %s @%lx\n", pfx, (in_ctx) ? "IN" : "OUT", (ULONG)slot_ctx);
     Kprintf("%s  dev_info=0x%08lx route=0x%05lx speed=%s hub=%ld mtt=%ld last_ctx=%lu (last_ep=%ld)\n",
             pfx,
@@ -925,7 +926,7 @@ void xhci_dump_slot_ctx(const char *tag, struct usb_device *udev, BOOL in_ctx)
             slot_state);
 }
 
-void xhci_dump_ep_ctx(const char *tag, struct usb_device *udev, UBYTE ep_index)
+void xhci_dump_ep_ctx(const char *tag, struct usb_device *udev, u8 ep_index)
 {
     struct xhci_ep_ctx *ep_ctx = xhci_get_ep_ctx(udev->controller, udev->out_ctx, ep_index);
     xhci_inval_cache(ep_ctx, sizeof(struct xhci_ep_ctx));
@@ -937,32 +938,32 @@ void xhci_dump_ep_ctx(const char *tag, struct usb_device *udev, UBYTE ep_index)
         return;
     }
 
-    ULONG ep_info = le32(ep_ctx->ep_info);
-    ULONG ep_info2 = le32(ep_ctx->ep_info2);
+    u32 ep_info = le32(ep_ctx->ep_info);
+    u32 ep_info2 = le32(ep_ctx->ep_info2);
     u64 deq = le64(ep_ctx->deq);
-    ULONG tx_info = le32(ep_ctx->tx_info);
+    u32 tx_info = le32(ep_ctx->tx_info);
 
-    ULONG state = ep_info & EP_STATE_MASK;
-    ULONG mult = CTX_TO_EP_MULT(ep_info);
-    ULONG mult_count = mult + 1;
-    ULONG interval = CTX_TO_EP_INTERVAL(ep_info);
-    ULONG max_ps = (ep_info >> 10) & 0x1f;
-    LONG has_lsa = (ep_info & EP_HAS_LSA) != 0;
+    u32 state = ep_info & EP_STATE_MASK;
+    u32 mult = CTX_TO_EP_MULT(ep_info);
+    u32 mult_count = mult + 1;
+    u32 interval = CTX_TO_EP_INTERVAL(ep_info);
+    u32 max_ps = (ep_info >> 10) & 0x1f;
+    BOOL has_lsa = (ep_info & EP_HAS_LSA) != 0;
 
-    ULONG ep_type = CTX_TO_EP_TYPE(ep_info2);
-    ULONG error_count = (ep_info2 >> 1) & 0x3;
-    ULONG max_burst = CTX_TO_MAX_BURST(ep_info2);
-    ULONG max_packet = MAX_PACKET_DECODED(ep_info2);
-    LONG force_event = (ep_info2 & FORCE_EVENT) != 0;
+    u32 ep_type = CTX_TO_EP_TYPE(ep_info2);
+    u32 error_count = (ep_info2 >> 1) & 0x3;
+    u32 max_burst = CTX_TO_MAX_BURST(ep_info2);
+    u32 max_packet = MAX_PACKET_DECODED(ep_info2);
+    BOOL force_event = (ep_info2 & FORCE_EVENT) != 0;
 
-    ULONG esit_lo = (tx_info >> 16) & 0xffff;
-    ULONG esit_hi = (tx_info >> 24) & 0xff;
-    ULONG max_esit_payload = esit_lo | (esit_hi << 16);
-    ULONG avg_trb_len = EP_AVG_TRB_LENGTH(tx_info);
+    u32 esit_lo = (tx_info >> 16) & 0xffff;
+    u32 esit_hi = (tx_info >> 24) & 0xff;
+    u32 max_esit_payload = esit_lo | (esit_hi << 16);
+    u32 avg_trb_len = EP_AVG_TRB_LENGTH(tx_info);
 
-    ULONG deq_low = (ULONG)(deq & 0xffffffffUL);
-    ULONG deq_high = (ULONG)((deq >> 32) & 0xffffffffUL);
-    LONG cycle_state = (deq & EP_CTX_CYCLE_MASK) != 0;
+    u32 deq_low = (u32)(deq & 0xffffffffUL);
+    u32 deq_high = (u32)((deq >> 32) & 0xffffffffUL);
+    BOOL cycle_state = (deq & EP_CTX_CYCLE_MASK) != 0;
 
     Kprintf("%s Endpoint context[%lu] @%lx\n", pfx, ep_index, (ULONG)ep_ctx);
     Kprintf("%s  ep_info=0x%08lx state=%s(%lu) mult=%lu (%lu per uframe) interval=%lu streams=%lu lsa=%ld\n",

--- a/xhci.device/src/xhci/xhci-context.c
+++ b/xhci.device/src/xhci/xhci-context.c
@@ -23,8 +23,8 @@
 
 #include <debug.h>
 
-#include <emu_iomem.h>
-#include <emu_memory.h>
+#include <iomem.h>
+#include <memory.h>
 
 #include <xhci/xhci.h>
 #include <xhci/xhci-commands.h>
@@ -53,7 +53,7 @@
  */
 struct xhci_container_ctx *xhci_alloc_container_ctx(struct xhci_ctrl *ctrl, int type)
 {
-    struct xhci_container_ctx *ctx = AllocVecPooled(ctrl->memoryPool, sizeof(struct xhci_container_ctx));
+    struct xhci_container_ctx *ctx = pool_zalloc(ctrl->memoryPool, sizeof(struct xhci_container_ctx));
     if (!ctx)
     {
         Kprintf("Failed to allocate container context\n");
@@ -63,14 +63,14 @@ struct xhci_container_ctx *xhci_alloc_container_ctx(struct xhci_ctrl *ctrl, int 
     if ((type != XHCI_CTX_TYPE_DEVICE) && (type != XHCI_CTX_TYPE_INPUT))
     {
         Kprintf("Invalid context type\n");
-        FreeVecPooled(ctrl->memoryPool, ctx);
+        pool_free(ctrl->memoryPool, ctx);
         return NULL;
     }
 
     ctx->type = type;
-    ctx->size = (USB_MAX_ENDPOINT_CONTEXTS + 1) * CTX_SIZE(readl(&ctrl->hccr->cr_hccparams1));
+    ctx->size = (USB_MAX_ENDPOINT_CONTEXTS + 1) * CTX_SIZE(mmio_read32(&ctrl->hccr->cr_hccparams1));
     if (type == XHCI_CTX_TYPE_INPUT)
-        ctx->size += CTX_SIZE(readl(&ctrl->hccr->cr_hccparams1));
+        ctx->size += CTX_SIZE(mmio_read32(&ctrl->hccr->cr_hccparams1));
 
     ctx->bytes = xhci_malloc(ctrl, ctx->size);
     return ctx;
@@ -84,8 +84,8 @@ struct xhci_container_ctx *xhci_alloc_container_ctx(struct xhci_ctrl *ctrl, int 
  */
 void xhci_free_container_ctx(struct xhci_ctrl *ctrl, struct xhci_container_ctx *ctx)
 {
-    memalign_free(ctrl->memoryPool, ctx->bytes);
-    FreeVecPooled(ctrl->memoryPool, ctx);
+    dma_free(ctrl->memoryPool, ctx->bytes);
+    pool_free(ctrl->memoryPool, ctx);
 }
 
 /**
@@ -116,7 +116,7 @@ static struct xhci_slot_ctx *xhci_get_slot_ctx(struct xhci_ctrl *ctrl, struct xh
     if (ctx->type == XHCI_CTX_TYPE_DEVICE)
         return (struct xhci_slot_ctx *)ctx->bytes;
 
-    return (struct xhci_slot_ctx *)(ctx->bytes + CTX_SIZE(readl(&ctrl->hccr->cr_hccparams1)));
+    return (struct xhci_slot_ctx *)(ctx->bytes + CTX_SIZE(mmio_read32(&ctrl->hccr->cr_hccparams1)));
 }
 
 /**
@@ -134,21 +134,21 @@ static struct xhci_ep_ctx *xhci_get_ep_ctx(struct xhci_ctrl *ctrl, struct xhci_c
     if (ctx->type == XHCI_CTX_TYPE_INPUT)
         ep_index++;
 
-    return (struct xhci_ep_ctx *)(ctx->bytes + (ep_index * CTX_SIZE(readl(&ctrl->hccr->cr_hccparams1))));
+    return (struct xhci_ep_ctx *)(ctx->bytes + (ep_index * CTX_SIZE(mmio_read32(&ctrl->hccr->cr_hccparams1))));
 }
 
 u32 xhci_get_hardware_address(struct usb_device *udev)
 {
     struct xhci_slot_ctx *slot_ctx = xhci_get_slot_ctx(udev->controller, udev->out_ctx);
     xhci_inval_cache(slot_ctx, sizeof(struct xhci_slot_ctx));
-    return LE32(slot_ctx->dev_state) & DEV_ADDR_MASK;
+    return le32(slot_ctx->dev_state) & DEV_ADDR_MASK;
 }
 
 u64 xhci_get_endpoint_deq_ptr(struct usb_device *udev, unsigned int ep_index)
 {
     struct xhci_ep_ctx *ep_ctx = xhci_get_ep_ctx(udev->controller, udev->out_ctx, ep_index);
     xhci_inval_cache(ep_ctx, sizeof(struct xhci_ep_ctx));
-    return LE64(ep_ctx->deq);
+    return le64(ep_ctx->deq);
 }
 
 /**
@@ -276,7 +276,7 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
              (ULONG)udev->slot_id, (ULONG)udev->in_ctx, (ULONG)udev->out_ctx,
              (ULONG)ep0_ctx, (ULONG)slot_ctx);
 
-    u32 dev_info = LE32(slot_ctx->dev_info);
+    u32 dev_info = le32(slot_ctx->dev_info);
     dev_info &= ~(ROUTE_STRING_MASK | DEV_SPEED | DEV_MTT | LAST_CTX_MASK);
     dev_info |= (udev->route & ROUTE_STRING_MASK);
     /* Only the control endpoint is valid - one endpoint context */
@@ -309,7 +309,7 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
      * minimum interval for any isoch endpoint
      * worst case time to transfer isoch data
      */
-    slot_ctx->dev_info = LE32(dev_info);
+    slot_ctx->dev_info = le32(dev_info);
 
     // Find root hub port number
     u32 root_port = find_root_port(udev);
@@ -317,10 +317,10 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
     KprintfH("xhci_setup_addressable_virt_dev: parent_addr=%ld port_num=%ld root_port_num=%ld speed=%ld route=%lx route_depth=%ld\n",
              (ULONG)udev->parent->virtual_address, udev->parent_port, root_port, (ULONG)udev->speed, (ULONG)udev->route, (ULONG)udev->route_depth);
 
-    u32 dev_info2 = LE32(slot_ctx->dev_info2);
+    u32 dev_info2 = le32(slot_ctx->dev_info2);
     dev_info2 &= ~((ROOT_HUB_PORT_MASK) << ROOT_HUB_PORT_SHIFT);
     dev_info2 |= ROOT_HUB_PORT(root_port);
-    slot_ctx->dev_info2 = LE32(dev_info2);
+    slot_ctx->dev_info2 = le32(dev_info2);
 
     u32 tt_info = 0;
     if (udev->speed == USB_SPEED_LOW || udev->speed == USB_SPEED_FULL)
@@ -351,11 +351,11 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
      * - TT_PORT should be the port number on the parent hub that this device is connected to
      */
 
-    slot_ctx->tt_info = LE32(tt_info);
+    slot_ctx->tt_info = le32(tt_info);
 
     /* Step 4 - ring already allocated */
     /* Step 5 */
-    ep0_ctx->ep_info2 = LE32(EP_TYPE(CTRL_EP));
+    ep0_ctx->ep_info2 = le32(EP_TYPE(CTRL_EP));
     KprintfH("xhci_setup_addressable_virt_dev: SPEED=%ld\n", (ULONG)udev->speed);
 
     int max_packet_size = 0;
@@ -363,19 +363,19 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
     {
     case USB_SPEED_SUPER:
     case USB_SPEED_SUPER_PLUS:
-        ep0_ctx->ep_info2 |= LE32(MAX_PACKET(512));
+        ep0_ctx->ep_info2 |= le32(MAX_PACKET(512));
         max_packet_size = 512;
         KprintfH("xhci_setup_addressable_virt_dev: MPS=512\n");
         break;
     case USB_SPEED_HIGH:
     /* USB core guesses at a 64-byte max packet first for FS devices */
     case USB_SPEED_FULL:
-        ep0_ctx->ep_info2 |= LE32(MAX_PACKET(64));
+        ep0_ctx->ep_info2 |= le32(MAX_PACKET(64));
         max_packet_size = 64;
         KprintfH("xhci_setup_addressable_virt_dev: MPS=64\n");
         break;
     case USB_SPEED_LOW:
-        ep0_ctx->ep_info2 |= LE32(MAX_PACKET(8));
+        ep0_ctx->ep_info2 |= le32(MAX_PACKET(8));
         max_packet_size = 8;
         KprintfH("xhci_setup_addressable_virt_dev: MPS=8\n");
         break;
@@ -385,7 +385,7 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
     }
 
     /* EP 0 can handle "burst" sizes of 1, so Max Burst Size field is 0 */
-    ep0_ctx->ep_info2 |= LE32(MAX_BURST(0) | ERROR_COUNT(3));
+    ep0_ctx->ep_info2 |= le32(MAX_BURST(0) | ERROR_COUNT(3));
 
     BOOL result = xhci_ep_create_context(udev, 0, max_packet_size, ctrl->memoryPool);
     if (!result)
@@ -393,24 +393,24 @@ void xhci_setup_addressable_virt_dev(struct xhci_ctrl *ctrl, struct usb_device *
 
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, 0);
     struct xhci_ring *ring = xhci_ep_get_ring(ep_ctx);
-    ep0_ctx->deq = LE64(xhci_ring_get_new_dequeue_ptr(ring));
+    ep0_ctx->deq = le64(xhci_ring_get_new_dequeue_ptr(ring));
 
     /*
      * xHCI spec 6.2.3:
      * software shall set 'Average TRB Length' to 8 for control endpoints.
      */
-    ep0_ctx->tx_info = LE32(EP_AVG_TRB_LENGTH(8));
+    ep0_ctx->tx_info = le32(EP_AVG_TRB_LENGTH(8));
 
     /* Steps 7 and 8 were done in xhci_alloc_virt_device() */
 
     xhci_flush_cache(ep0_ctx, sizeof(struct xhci_ep_ctx));
     xhci_flush_cache(slot_ctx, sizeof(struct xhci_slot_ctx));
     KprintfH("xhci_setup_addressable_virt_dev: ep0 deq=%lx tx_info=%08lx dev_info=%08lx dev_info2=%08lx\n",
-             (ULONG)LE64(ep0_ctx->deq), (ULONG)LE32(ep0_ctx->tx_info),
-             (ULONG)LE32(slot_ctx->dev_info), (ULONG)LE32(slot_ctx->dev_info2));
+             (ULONG)le64(ep0_ctx->deq), (ULONG)le32(ep0_ctx->tx_info),
+             (ULONG)le32(slot_ctx->dev_info), (ULONG)le32(slot_ctx->dev_info2));
 
     struct xhci_input_control_ctx *ctrl_ctx = xhci_get_input_control_ctx(udev->in_ctx);
-    ctrl_ctx->add_flags = LE32(SLOT_FLAG | EP0_FLAG);
+    ctrl_ctx->add_flags = le32(SLOT_FLAG | EP0_FLAG);
     ctrl_ctx->drop_flags = 0;
 
     xhci_flush_cache(ctrl_ctx, sizeof(struct xhci_input_control_ctx));
@@ -430,9 +430,9 @@ static void xhci_update_hub_tt(struct usb_device *udev, struct xhci_container_ct
     if (!slot_ctx)
         return;
 
-    u32 dev_info = LE32(slot_ctx->dev_info);
-    u32 dev_info2 = LE32(slot_ctx->dev_info2);
-    u32 tt_info = LE32(slot_ctx->tt_info);
+    u32 dev_info = le32(slot_ctx->dev_info);
+    u32 dev_info2 = le32(slot_ctx->dev_info2);
+    u32 tt_info = le32(slot_ctx->tt_info);
 
     if (udev->is_hub)
     {
@@ -448,9 +448,9 @@ static void xhci_update_hub_tt(struct usb_device *udev, struct xhci_container_ct
         }
     }
 
-    slot_ctx->dev_info = LE32(dev_info);
-    slot_ctx->dev_info2 = LE32(dev_info2);
-    slot_ctx->tt_info = LE32(tt_info);
+    slot_ctx->dev_info = le32(dev_info);
+    slot_ctx->dev_info2 = le32(dev_info2);
+    slot_ctx->tt_info = le32(tt_info);
 }
 
 /*
@@ -472,7 +472,7 @@ void xhci_update_maxpacket(struct usb_device *udev, unsigned int max_packet_size
     KprintfH("Checking max packet size for ep 0 of address %ld (slot %ld)\n", (LONG)udev->virtual_address, (LONG)udev->slot_id);
 
     struct xhci_ep_ctx *ep_ctx = xhci_get_ep_ctx(ctrl, udev->out_ctx, ep_index);
-    hw_max_packet_size = MAX_PACKET_DECODED(LE32(ep_ctx->ep_info2));
+    hw_max_packet_size = MAX_PACKET_DECODED(le32(ep_ctx->ep_info2));
 
     if (hw_max_packet_size == max_packet_size)
     {
@@ -491,8 +491,8 @@ void xhci_update_maxpacket(struct usb_device *udev, unsigned int max_packet_size
     xhci_endpoint_copy(ctrl, udev->in_ctx,
                        udev->out_ctx, ep_index);
     ep_ctx = xhci_get_ep_ctx(ctrl, udev->in_ctx, ep_index);
-    ep_ctx->ep_info2 &= LE32(~MAX_PACKET(MAX_PACKET_MASK));
-    ep_ctx->ep_info2 |= LE32(MAX_PACKET(max_packet_size));
+    ep_ctx->ep_info2 &= le32(~MAX_PACKET(MAX_PACKET_MASK));
+    ep_ctx->ep_info2 |= le32(MAX_PACKET(max_packet_size));
 
     /*
      * Set up the input context flags for the command
@@ -500,7 +500,7 @@ void xhci_update_maxpacket(struct usb_device *udev, unsigned int max_packet_size
      * changes max packet sizes.
      */
     struct xhci_input_control_ctx *ctrl_ctx = xhci_get_input_control_ctx(udev->in_ctx);
-    ctrl_ctx->add_flags = LE32(EP0_FLAG);
+    ctrl_ctx->add_flags = le32(EP0_FLAG);
     ctrl_ctx->drop_flags = 0;
 
     xhci_configure_endpoints(udev, TRUE, NULL);
@@ -575,19 +575,19 @@ static int xhci_init_ep_contexts_if(struct usb_device *udev,
         dir = (((endpt_desc->bEndpointAddress) & (0x80)) >> 7);
         ep_type = (((endpt_desc->bmAttributes) & (0x3)) | (dir << 2));
 
-        ep_ctx[ep_index]->ep_info = LE32(EP_MAX_ESIT_PAYLOAD_HI(max_esit_payload) | EP_INTERVAL(interval) | EP_MULT(mult));
+        ep_ctx[ep_index]->ep_info = le32(EP_MAX_ESIT_PAYLOAD_HI(max_esit_payload) | EP_INTERVAL(interval) | EP_MULT(mult));
 
-        ep_ctx[ep_index]->ep_info2 = LE32(EP_TYPE(ep_type));
-        ep_ctx[ep_index]->ep_info2 |= LE32(MAX_PACKET(max_packet_size));
+        ep_ctx[ep_index]->ep_info2 = le32(EP_TYPE(ep_type));
+        ep_ctx[ep_index]->ep_info2 |= le32(MAX_PACKET(max_packet_size));
 
         /* Allow 3 retries for everything but isoc, set CErr = 3 */
         if (!usb_endpoint_xfer_isoc(endpt_desc))
             err_count = 3;
-        ep_ctx[ep_index]->ep_info2 |= LE32(MAX_BURST(max_burst) | ERROR_COUNT(err_count));
+        ep_ctx[ep_index]->ep_info2 |= le32(MAX_BURST(max_burst) | ERROR_COUNT(err_count));
 
         struct ep_context *ep_context = xhci_ep_get_context_for_index(udev, ep_index);
         struct xhci_ring *ring = xhci_ep_get_ring(ep_context);
-        ep_ctx[ep_index]->deq = LE64(xhci_ring_get_new_dequeue_ptr(ring));
+        ep_ctx[ep_index]->deq = le64(xhci_ring_get_new_dequeue_ptr(ring));
 
         /*
          * xHCI spec 6.2.3:
@@ -595,7 +595,7 @@ static int xhci_init_ep_contexts_if(struct usb_device *udev,
          */
         if (usb_endpoint_xfer_control(endpt_desc))
             avg_trb_len = 8;
-        ep_ctx[ep_index]->tx_info = LE32(EP_MAX_ESIT_PAYLOAD_LO(max_esit_payload) | EP_AVG_TRB_LENGTH(avg_trb_len));
+        ep_ctx[ep_index]->tx_info = le32(EP_MAX_ESIT_PAYLOAD_LO(max_esit_payload) | EP_AVG_TRB_LENGTH(avg_trb_len));
 
         KprintfH("EP%ld %s: type=%ld maxp=%ld maxesit=%ld "
                  "interval=%ld mult=%ld maxburst=%ld\n",
@@ -623,10 +623,10 @@ static void xhci_update_slot_last_ctx(struct xhci_ctrl *ctrl,
     if (!slot_ctx)
         return;
 
-    u32 dev_info = LE32(slot_ctx->dev_info);
+    u32 dev_info = le32(slot_ctx->dev_info);
     dev_info &= ~LAST_CTX_MASK;
     dev_info |= LAST_CTX(max_ep_flag + 1);
-    slot_ctx->dev_info = LE32(dev_info);
+    slot_ctx->dev_info = le32(dev_info);
 }
 
 /**
@@ -666,7 +666,7 @@ int xhci_set_configuration(struct usb_device *udev, int config_value)
     u32 add_flags = SLOT_FLAG;
     u32 mask = xhci_collect_config_masks(cfg, max_ifnum, &max_ep_flag);
     add_flags |= mask;
-    ctrl_ctx->add_flags = LE32(add_flags);
+    ctrl_ctx->add_flags = le32(add_flags);
     ctrl_ctx->drop_flags = 0;
 
     xhci_inval_cache(out_ctx->bytes, out_ctx->size);
@@ -767,8 +767,8 @@ int xhci_set_interface(struct usb_device *udev, unsigned int iface_number, unsig
 
     u32 add_flags = SLOT_FLAG | add_mask;
     u32 drop_flags = drop_mask;
-    ctrl_ctx->add_flags = LE32(add_flags);
-    ctrl_ctx->drop_flags = LE32(drop_flags);
+    ctrl_ctx->add_flags = le32(add_flags);
+    ctrl_ctx->drop_flags = le32(drop_flags);
 
     unsigned int max_ep_flag = compute_max_ep_flag(cfg);
     xhci_update_slot_last_ctx(ctrl, udev, max_ep_flag);
@@ -874,10 +874,10 @@ void xhci_dump_slot_ctx(const char *tag, struct usb_device *udev, BOOL in_ctx)
         return;
     }
 
-    ULONG dev_info = LE32(slot_ctx->dev_info);
-    ULONG dev_info2 = LE32(slot_ctx->dev_info2);
-    ULONG tt_info = LE32(slot_ctx->tt_info);
-    ULONG dev_state = LE32(slot_ctx->dev_state);
+    ULONG dev_info = le32(slot_ctx->dev_info);
+    ULONG dev_info2 = le32(slot_ctx->dev_info2);
+    ULONG tt_info = le32(slot_ctx->tt_info);
+    ULONG dev_state = le32(slot_ctx->dev_state);
 
     ULONG route = dev_info & ROUTE_STRING_MASK;
     ULONG last_ctx = (dev_info & LAST_CTX_MASK) >> 27;
@@ -937,10 +937,10 @@ void xhci_dump_ep_ctx(const char *tag, struct usb_device *udev, UBYTE ep_index)
         return;
     }
 
-    ULONG ep_info = LE32(ep_ctx->ep_info);
-    ULONG ep_info2 = LE32(ep_ctx->ep_info2);
-    u64 deq = LE64(ep_ctx->deq);
-    ULONG tx_info = LE32(ep_ctx->tx_info);
+    ULONG ep_info = le32(ep_ctx->ep_info);
+    ULONG ep_info2 = le32(ep_ctx->ep_info2);
+    u64 deq = le64(ep_ctx->deq);
+    ULONG tx_info = le32(ep_ctx->tx_info);
 
     ULONG state = ep_info & EP_STATE_MASK;
     ULONG mult = CTX_TO_EP_MULT(ep_info);

--- a/xhci.device/src/xhci/xhci-descriptors.c
+++ b/xhci.device/src/xhci/xhci-descriptors.c
@@ -37,25 +37,25 @@
  * @param desc	USB enpdoint Descriptor
  * Return: index of the Endpoint
  */
-unsigned int xhci_get_ep_index(struct usb_endpoint_descriptor *desc)
+u8 xhci_get_ep_index(struct usb_endpoint_descriptor *desc)
 {
-    unsigned int index;
+    u8 index;
 
     if (usb_endpoint_xfer_control(desc))
-        index = (unsigned int)(usb_endpoint_num(desc) * 2);
+        index = (u8)(usb_endpoint_num(desc) * 2);
     else
-        index = (unsigned int)((usb_endpoint_num(desc) * 2) -
+        index = (u8)((usb_endpoint_num(desc) * 2) -
                                (usb_endpoint_dir_in(desc) ? 0 : 1));
 
     return index;
 }
 
-struct usb_interface *xhci_find_interface(struct usb_config *cfg, unsigned int iface_number)
+struct usb_interface *xhci_find_interface(struct usb_config *cfg, u32 iface_number)
 {
     if (!cfg)
         return NULL;
 
-    for (unsigned int i = 0; i < cfg->no_of_if; ++i)
+    for (u32 i = 0; i < cfg->no_of_if; ++i)
     {
         if (cfg->if_desc[i].interface_number == iface_number)
             return &cfg->if_desc[i];
@@ -64,12 +64,12 @@ struct usb_interface *xhci_find_interface(struct usb_config *cfg, unsigned int i
     return NULL;
 }
 
-struct usb_interface_altsetting *xhci_find_altsetting(struct usb_interface *iface, unsigned int alt_setting)
+struct usb_interface_altsetting *xhci_find_altsetting(struct usb_interface *iface, u8 alt_setting)
 {
     if (!iface)
         return NULL;
 
-    for (unsigned int idx = 0; idx < iface->num_altsetting; ++idx)
+    for (u32 idx = 0; idx < iface->num_altsetting; ++idx)
     {
         struct usb_interface_altsetting *candidate = &iface->altsetting[idx];
         if (candidate->desc.bAlternateSetting == alt_setting)
@@ -79,17 +79,17 @@ struct usb_interface_altsetting *xhci_find_altsetting(struct usb_interface *ifac
     return NULL;
 }
 
-u32 xhci_collect_ep_mask(const struct usb_interface_altsetting *alt, unsigned int *max_flag)
+u32 xhci_collect_ep_mask(const struct usb_interface_altsetting *alt, u32 *max_flag)
 {
     if (!alt)
         return 0;
 
     u32 mask = 0;
 
-    for (unsigned int i = 0; i < alt->no_of_ep; ++i)
+    for (u32 i = 0; i < alt->no_of_ep; ++i)
     {
         const struct usb_endpoint_descriptor *epd = &alt->ep_desc[i];
-        unsigned int ep_index = xhci_get_ep_index((struct usb_endpoint_descriptor *)epd);
+        u8 ep_index = xhci_get_ep_index((struct usb_endpoint_descriptor *)epd);
         mask |= 1U << (ep_index + 1);
         if (max_flag && ep_index > *max_flag)
             *max_flag = ep_index;
@@ -98,22 +98,22 @@ u32 xhci_collect_ep_mask(const struct usb_interface_altsetting *alt, unsigned in
     return mask;
 }
 
-u32 xhci_collect_config_masks(const struct usb_config *cfg, unsigned int limit, unsigned int *max_flag)
+u32 xhci_collect_config_masks(const struct usb_config *cfg, u32 limit, u32 *max_flag)
 {
     if (!cfg)
         return 0;
 
     u32 mask = 0;
-    unsigned int max_if = min(limit, cfg->no_of_if);
+    u32 max_if = limit < (u32)cfg->no_of_if ? limit : (u32)cfg->no_of_if;
 
-    for (unsigned int ifnum = 0; ifnum < max_if; ++ifnum)
+    for (u32 ifnum = 0; ifnum < max_if; ++ifnum)
     {
         const struct usb_interface *iface = &cfg->if_desc[ifnum];
         const struct usb_interface_altsetting *active_alt = iface->active_altsetting;
         if (!active_alt)
             continue;
 
-        KprintfH("Preparing iface=%ld alt=%ld\n", (ULONG)ifnum, (LONG)active_alt->desc.bAlternateSetting);
+        KprintfH("Preparing iface=%lu alt=%lu\n", (ULONG)ifnum, (ULONG)active_alt->desc.bAlternateSetting);
 
         mask |= xhci_collect_ep_mask(active_alt, max_flag);
     }
@@ -129,7 +129,7 @@ struct usb_config *xhci_find_config(struct usb_device *udev, int config_value)
     for (struct MinNode *node = udev->configurations.mlh_Head; node->mln_Succ != NULL; node = node->mln_Succ)
     {
         struct usb_config *cfg = (struct usb_config *)node;
-        KprintfH("  found config: bConfigurationValue=%ld\n", (LONG)cfg->desc.bConfigurationValue);
+        KprintfH("  found config: bConfigurationValue=%lu\n", (ULONG)cfg->desc.bConfigurationValue);
         if (cfg->desc.bConfigurationValue == config_value)
             return cfg;
     }
@@ -149,7 +149,7 @@ struct usb_interface_altsetting *xhci_select_active_alt(struct usb_interface *if
         return NULL;
 
     struct usb_interface_altsetting *fallback = NULL;
-    for (unsigned int idx = 0; idx < iface->num_altsetting; ++idx)
+    for (u32 idx = 0; idx < iface->num_altsetting; ++idx)
     {
         struct usb_interface_altsetting *candidate = &iface->altsetting[idx];
         if (candidate->desc.bAlternateSetting == 0)
@@ -166,12 +166,12 @@ struct usb_interface_altsetting *xhci_select_active_alt(struct usb_interface *if
     return fallback;
 }
 
-unsigned int compute_max_ep_flag(const struct usb_config *cfg)
+u32 compute_max_ep_flag(const struct usb_config *cfg)
 {
     if (!cfg)
         return 0;
 
-    unsigned int max_flag = 0;
+    u32 max_flag = 0;
     xhci_collect_config_masks(cfg, cfg->no_of_if, &max_flag);
 
     return max_flag;
@@ -181,22 +181,22 @@ unsigned int compute_max_ep_flag(const struct usb_config *cfg)
  * Convert bInterval expressed in microframes (in 1-255 range) to exponent of
  * microframes, rounded down to nearest power of 2.
  */
-static unsigned int xhci_microframes_to_exponent(unsigned int desc_interval,
-                                                 unsigned int min_exponent,
-                                                 unsigned int max_exponent)
+static u8 xhci_microframes_to_exponent(u32 desc_interval,
+                                       u32 min_exponent,
+                                       u32 max_exponent)
 {
-    unsigned int interval = log2_floor_u64(desc_interval);
+    u32 interval = log2_floor_u64(desc_interval);
     interval = clamp_val(interval, min_exponent, max_exponent);
 #ifdef DEBUG_HIGH
     if ((1U << interval) != desc_interval)
-        KprintfH("rounding interval to %ld microframes, ep desc says %ld microframes\n",
-                 1U << interval, desc_interval);
+        KprintfH("rounding interval to %lu microframes, ep desc says %lu microframes\n",
+                 (ULONG)(1U << interval), (ULONG)desc_interval);
 #endif
 
-    return interval;
+    return (u8)interval;
 }
 
-static unsigned int xhci_parse_microframe_interval(struct usb_endpoint_descriptor *endpt_desc)
+static u8 xhci_parse_microframe_interval(struct usb_endpoint_descriptor *endpt_desc)
 {
     if (endpt_desc->bInterval == 0)
         return 0;
@@ -204,24 +204,24 @@ static unsigned int xhci_parse_microframe_interval(struct usb_endpoint_descripto
     return xhci_microframes_to_exponent(endpt_desc->bInterval, 0, 15);
 }
 
-static unsigned int xhci_parse_frame_interval(struct usb_endpoint_descriptor *endpt_desc)
+static u8 xhci_parse_frame_interval(struct usb_endpoint_descriptor *endpt_desc)
 {
-    return xhci_microframes_to_exponent(endpt_desc->bInterval * 8, 3, 10);
+    return xhci_microframes_to_exponent((u32)endpt_desc->bInterval * 8U, 3, 10);
 }
 
 /*
  * Convert interval expressed as 2^(bInterval - 1) == interval into
  * straight exponent value 2^n == interval.
  */
-static unsigned int xhci_parse_exponent_interval(struct usb_device *udev,
-                                                 struct usb_endpoint_descriptor *endpt_desc)
+static u8 xhci_parse_exponent_interval(struct usb_device *udev,
+                                       struct usb_endpoint_descriptor *endpt_desc)
 {
-    unsigned int interval;
+    u8 interval;
 
-    interval = clamp_val(endpt_desc->bInterval, 1, 16) - 1;
+    interval = (u8)(clamp_val(endpt_desc->bInterval, 1, 16) - 1);
     if (interval != endpt_desc->bInterval - 1U)
-        Kprintf("ep %#lx - rounding interval to %ld %sframes\n",
-                endpt_desc->bEndpointAddress, 1 << interval,
+        Kprintf("ep %#lx - rounding interval to %lu %sframes\n",
+                (ULONG)endpt_desc->bEndpointAddress, (ULONG)(1U << interval),
                 udev->speed == USB_SPEED_FULL ? "" : "micro");
 
     if (udev->speed == USB_SPEED_FULL)
@@ -231,7 +231,7 @@ static unsigned int xhci_parse_exponent_interval(struct usb_device *udev,
          * not microframes. We are using microframes everywhere,
          * so adjust accordingly.
          */
-        interval += 3; /* 1 frame = 2^3 uframes */
+        interval = (u8)(interval + 3u); /* 1 frame = 2^3 uframes */
     }
 
     return interval;
@@ -246,9 +246,9 @@ static unsigned int xhci_parse_exponent_interval(struct usb_device *udev,
  * The NAK interval is one NAK per 1 to 255 microframes, or no NAKs if interval
  * is set to 0.
  */
-unsigned int xhci_get_endpoint_interval(struct usb_device *udev, struct usb_endpoint_descriptor *endpt_desc)
+u8 xhci_get_endpoint_interval(struct usb_device *udev, struct usb_endpoint_descriptor *endpt_desc)
 {
-    unsigned int interval = 0;
+    u8 interval = 0;
 
     switch (udev->speed)
     {
@@ -293,7 +293,7 @@ unsigned int xhci_get_endpoint_interval(struct usb_device *udev, struct usb_endp
         break;
 
     default:
-        Kprintf("Unsupported USB speed: %ld\n", udev->speed);
+        Kprintf("Unsupported USB speed: %lu\n", (ULONG)udev->speed);
     }
 
     return interval;
@@ -305,9 +305,9 @@ unsigned int xhci_get_endpoint_interval(struct usb_device *udev, struct usb_endp
  * transaction opportunities per microframe", but that goes in the Max Burst
  * endpoint context field.
  */
-u32 xhci_get_endpoint_mult(struct usb_device *udev,
-                           struct usb_endpoint_descriptor *endpt_desc,
-                           struct usb_ss_ep_comp_descriptor *ss_ep_comp_desc)
+u8 xhci_get_endpoint_mult(struct usb_device *udev,
+                          struct usb_endpoint_descriptor *endpt_desc,
+                          struct usb_ss_ep_comp_descriptor *ss_ep_comp_desc)
 {
     if (udev->speed < USB_SPEED_SUPER || !usb_endpoint_xfer_isoc(endpt_desc))
         return 0;
@@ -315,16 +315,16 @@ u32 xhci_get_endpoint_mult(struct usb_device *udev,
     return ss_ep_comp_desc->bmAttributes;
 }
 
-u32 xhci_get_endpoint_max_burst(struct usb_device *udev,
-                                struct usb_endpoint_descriptor *endpt_desc,
-                                struct usb_ss_ep_comp_descriptor *ss_ep_comp_desc)
+u8 xhci_get_endpoint_max_burst(struct usb_device *udev,
+                               struct usb_endpoint_descriptor *endpt_desc,
+                               struct usb_ss_ep_comp_descriptor *ss_ep_comp_desc)
 {
     /* Super speed and Plus have max burst in ep companion desc */
     if (udev->speed >= USB_SPEED_SUPER)
         return ss_ep_comp_desc->bMaxBurst;
 
     if (udev->speed == USB_SPEED_HIGH && (usb_endpoint_xfer_isoc(endpt_desc) || usb_endpoint_xfer_int(endpt_desc)))
-        return usb_endpoint_maxp_mult(endpt_desc) - 1;
+        return (u8)(usb_endpoint_maxp_mult(endpt_desc) - 1u);
 
     return 0;
 }
@@ -346,14 +346,14 @@ u32 xhci_get_max_esit_payload(struct usb_device *udev,
     if (udev->speed >= USB_SPEED_SUPER)
         return le16(ss_ep_comp_desc->wBytesPerInterval);
 
-    int max_packet = usb_endpoint_maxp(endpt_desc);
-    int max_burst = usb_endpoint_maxp_mult(endpt_desc);
+    u32 max_packet = usb_endpoint_maxp(endpt_desc);
+    u8 max_burst = usb_endpoint_maxp_mult(endpt_desc);
 
-    /* A 0 in max burst means 1 transfer per ESIT */
+    /* usb_endpoint_maxp_mult() already returns the encoded multiplier + 1. */
     return max_packet * max_burst;
 }
 
-static void xhci_dump_interface(const char *tag, UBYTE index, const struct usb_interface *iface)
+static void xhci_dump_interface(const char *tag, u8 index, const struct usb_interface *iface)
 {
     if (!iface)
         return;
@@ -389,7 +389,7 @@ static void xhci_dump_interface(const char *tag, UBYTE index, const struct usb_i
         return;
     }
 
-    for (UBYTE j = 0; j < active_alt->no_of_ep; ++j)
+    for (u8 j = 0; j < active_alt->no_of_ep; ++j)
     {
         const struct usb_endpoint_descriptor *ep = &active_alt->ep_desc[j];
         const struct usb_ss_ep_comp_descriptor *ss_ep = &active_alt->ss_ep_comp_desc[j];
@@ -407,14 +407,14 @@ static void xhci_dump_interface(const char *tag, UBYTE index, const struct usb_i
     }
 }
 
-void xhci_dump_config(const char *tag, const struct usb_config *cfg, UBYTE addr)
+void xhci_dump_config(const char *tag, const struct usb_config *cfg, u16 addr)
 {
     if (!cfg)
         return;
 
     const char *pfx = tag ? tag : "";
 
-    Kprintf("%s Addr %ld configuration dump:\n", pfx, (ULONG)addr);
+    Kprintf("%s Addr %lu configuration dump:\n", pfx, (ULONG)addr);
     Kprintf("%s  bLength=%lu bDescriptorType=%lu wTotalLength=%lu bNumInterfaces=%lu\n",
             pfx, (ULONG)cfg->desc.bLength, (ULONG)cfg->desc.bDescriptorType,
             (ULONG)le16(cfg->desc.wTotalLength), (ULONG)cfg->desc.bNumInterfaces);
@@ -422,6 +422,6 @@ void xhci_dump_config(const char *tag, const struct usb_config *cfg, UBYTE addr)
             pfx, (ULONG)cfg->desc.bConfigurationValue, (ULONG)cfg->desc.iConfiguration,
             (ULONG)cfg->desc.bmAttributes, (ULONG)cfg->desc.bMaxPower);
     Kprintf("%s  no_of_if=%lu\n", pfx, (ULONG)cfg->no_of_if);
-    for (UBYTE i = 0; i < cfg->no_of_if; ++i)
+    for (u8 i = 0; i < cfg->no_of_if; ++i)
         xhci_dump_interface(pfx, i, &cfg->if_desc[i]);
 }

--- a/xhci.device/src/xhci/xhci-descriptors.c
+++ b/xhci.device/src/xhci/xhci-descriptors.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #include <exec/types.h>
 #include <xhci/ch9.h>
 #include <xhci/usb_defs.h>

--- a/xhci.device/src/xhci/xhci-descriptors.c
+++ b/xhci.device/src/xhci/xhci-descriptors.c
@@ -183,7 +183,7 @@ static unsigned int xhci_microframes_to_exponent(unsigned int desc_interval,
                                                  unsigned int min_exponent,
                                                  unsigned int max_exponent)
 {
-    unsigned int interval = fls(desc_interval) - 1;
+    unsigned int interval = log2_floor_u64(desc_interval);
     interval = clamp_val(interval, min_exponent, max_exponent);
 #ifdef DEBUG_HIGH
     if ((1U << interval) != desc_interval)
@@ -342,7 +342,7 @@ u32 xhci_get_max_esit_payload(struct usb_device *udev,
 
     /* SuperSpeed Isoc ep with less than 48k per esit */
     if (udev->speed >= USB_SPEED_SUPER)
-        return LE16(ss_ep_comp_desc->wBytesPerInterval);
+        return le16(ss_ep_comp_desc->wBytesPerInterval);
 
     int max_packet = usb_endpoint_maxp(endpt_desc);
     int max_burst = usb_endpoint_maxp_mult(endpt_desc);
@@ -396,12 +396,12 @@ static void xhci_dump_interface(const char *tag, UBYTE index, const struct usb_i
                 pfx, (ULONG)ep->bLength, (ULONG)ep->bDescriptorType,
                 (ULONG)ep->bEndpointAddress, (ULONG)ep->bmAttributes);
         Kprintf("%s      wMaxPacketSize=%lu bInterval=%lu\n",
-                pfx, (ULONG)LE16(ep->wMaxPacketSize), (ULONG)ep->bInterval);
+                pfx, (ULONG)le16(ep->wMaxPacketSize), (ULONG)ep->bInterval);
         Kprintf("%s      SS Companion: bLength=%lu bDescriptorType=%lu bMaxBurst=%lu bmAttributes=0x%02lx\n",
                 pfx, (ULONG)ss_ep->bLength, (ULONG)ss_ep->bDescriptorType,
                 (ULONG)ss_ep->bMaxBurst, (ULONG)ss_ep->bmAttributes);
         Kprintf("%s      SS Companion: wBytesPerInterval=%lu\n",
-                pfx, (ULONG)LE16(ss_ep->wBytesPerInterval));
+                pfx, (ULONG)le16(ss_ep->wBytesPerInterval));
     }
 }
 
@@ -415,7 +415,7 @@ void xhci_dump_config(const char *tag, const struct usb_config *cfg, UBYTE addr)
     Kprintf("%s Addr %ld configuration dump:\n", pfx, (ULONG)addr);
     Kprintf("%s  bLength=%lu bDescriptorType=%lu wTotalLength=%lu bNumInterfaces=%lu\n",
             pfx, (ULONG)cfg->desc.bLength, (ULONG)cfg->desc.bDescriptorType,
-            (ULONG)LE16(cfg->desc.wTotalLength), (ULONG)cfg->desc.bNumInterfaces);
+            (ULONG)le16(cfg->desc.wTotalLength), (ULONG)cfg->desc.bNumInterfaces);
     Kprintf("%s  bConfigurationValue=%lu iConfiguration=%lu bmAttributes=0x%02lx bMaxPower=%lu\n",
             pfx, (ULONG)cfg->desc.bConfigurationValue, (ULONG)cfg->desc.iConfiguration,
             (ULONG)cfg->desc.bmAttributes, (ULONG)cfg->desc.bMaxPower);

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -63,9 +63,13 @@ struct ep_context
     /* Pending STOPRTISO command to reply once the pipe is fully stopped */
     struct USBIORequest *rt_stop_pending;
 
-    /* RT ISO frame tracking (frame number [0, 2047]) */
-    u16 rt_next_frame;
-    u16 rt_interval_frames; /* cached from HW EP context at add_handler time */
+    /* RT ISO frame tracking. Microframe-resolution to satisfy ESIT rules:
+     *  - ESIT >= 1ms: Frame ID begins on ESIT boundary (xHCI 4.11.2.5).
+     *  - ESIT  < 1ms: all TDs in the same frame share a Frame ID.
+     * rt_next_uframe is the microframe offset for the next TD, mod 16384
+     * (Frame ID is bits 13:3, an 11-bit field). Advance by rt_uframes_per_esit. */
+    u16 rt_uframes_per_esit;
+    u16 rt_next_uframe;
 
     /* Cache the last RT ISO buffer so hooks can omit repeating it */
     APTR rt_last_buffer;
@@ -509,40 +513,44 @@ void xhci_ep_flush(struct ep_context *ep_ctx, s8 reply_code)
  */
 void xhci_ep_set_rt_interval(struct ep_context *ep_ctx, u8 interval)
 {
-    u32 ivf = ((1U << interval) + 7U) >> 3;
-    ep_ctx->rt_interval_frames = ivf ? (u16)ivf : 1U;
+    /* xHCI EP Context Interval is log2 of microframes-per-ESIT. */
+    ep_ctx->rt_uframes_per_esit = (u16)(1U << interval);
 }
 
 #define RT_ISO_SCHED_OFFSET_UFRAMES 32U
+#define RT_ISO_FRAME_MASK 0x7ffU /* Frame ID modulus: 2048 frames */
+#define RT_ISO_UF_MASK 0x3fffU /* microframe modulus: 2048 frames * 8 = 16384 */
+#define RT_UFRAME_TO_FRAME(uf) (((uf) >> 3) & RT_ISO_FRAME_MASK)
 
-static u16 xhci_rt_iso_min_frame(struct ep_context *ep_ctx)
+/* Earliest microframe HW can accept, rounded UP to the next ESIT boundary. */
+static u16 xhci_rt_iso_min_uf(struct ep_context *ep_ctx)
 {
     u32 mfindex = mmio_read32(&ep_ctx->udev->controller->run_regs->microframe_index);
-    u32 start_mfindex = (mfindex + ep_ctx->rt_ist + RT_ISO_SCHED_OFFSET_UFRAMES) & ~0x7U;
-
-    /* Mask to TRB FrameID width (11 bits) — that's the modulus HW uses. */
-    return (u16)((start_mfindex >> 3) & 0x7ffU);
+    u32 raw = mfindex + ep_ctx->rt_ist + RT_ISO_SCHED_OFFSET_UFRAMES;
+    u32 ivf_mask = (u32)ep_ctx->rt_uframes_per_esit - 1U;
+    return (u16)(((raw + ivf_mask) & ~ivf_mask) & RT_ISO_UF_MASK);
 }
 
+/* If rt_next_uframe has fallen behind the HW window, advance it by whole
+ * ESITs to the next valid slot >= min. Updates rt_next_uframe in place
+ * so the caller's post-submit advance keeps the stream contiguous.
+ * Returns the 11-bit Frame ID for the resulting microframe. */
 static u16 xhci_rt_iso_clamp_frame(struct ep_context *ep_ctx)
 {
-    u16 frame = ep_ctx->rt_next_frame;
-    u16 min_frame = xhci_rt_iso_min_frame(ep_ctx);
-    /* Both values are in [0, 2047]; sign-extend the 11-bit difference
-     * so the comparison handles wraparound correctly. */
-    u16 raw_delta = (u16)(min_frame - frame) & 0x7ffU;
-    s16 delta = (raw_delta >= 0x400U) ? (s16)((s16)raw_delta - (s16)0x800)
-                                      : (s16)raw_delta;
+    u16 uf = ep_ctx->rt_next_uframe;
+    u16 min_uf = xhci_rt_iso_min_uf(ep_ctx);
+    /* 14-bit signed delta to handle wraparound. */
+    u16 raw_delta = (u16)(min_uf - uf) & RT_ISO_UF_MASK;
+    s32 delta = (raw_delta >= 0x2000U) ? ((s32)raw_delta - 0x4000) : (s32)raw_delta;
 
     if (delta > 0)
     {
-        /* rt_interval_frames is always a power of 2 (set by xhci_ep_set_rt_interval),
-         * so ceil(delta / ivf) * ivf reduces to a bitmask round-up. */
-        u32 ivf_mask = (u32)ep_ctx->rt_interval_frames - 1U;
+        u32 ivf_mask = (u32)ep_ctx->rt_uframes_per_esit - 1U;
         u32 advance = ((u32)delta + ivf_mask) & ~ivf_mask;
-        frame = (u16)((frame + advance) & 0x7ffU);
+        uf = (u16)((uf + advance) & RT_ISO_UF_MASK);
+        ep_ctx->rt_next_uframe = uf;
     }
-    return frame;
+    return RT_UFRAME_TO_FRAME(uf);
 }
 
 inline static void xhci_ep_rt_iso_update_counters(struct ep_context *ep_ctx, struct USBIORequest *req)
@@ -688,8 +696,9 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
 
         /* CFC controllers pin Frame ID to a slot; without CFC the HW chooses
          * via SIA, but we still hand the user hook a monotonic frame counter. */
-        u16 frame = ctrl->cfc_supported ? xhci_rt_iso_clamp_frame(ep_ctx)
-                                        : ep_ctx->rt_next_frame;
+        u16 frame = ctrl->cfc_supported
+                        ? xhci_rt_iso_clamp_frame(ep_ctx)
+                        : RT_UFRAME_TO_FRAME(ep_ctx->rt_next_uframe);
         struct USBIORequest *rt_io = slab_alloc(&ctrl->iso_clone_slab);
         if (!rt_io)
         {
@@ -744,7 +753,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
             break;
         }
 
-        ep_ctx->rt_next_frame = (u16)(((u32)frame + ep_ctx->rt_interval_frames) & 0x7ffU);
+        ep_ctx->rt_next_uframe = (u16)(((u32)ep_ctx->rt_next_uframe + ep_ctx->rt_uframes_per_esit) & RT_ISO_UF_MASK);
         ep_ctx->rt_inflight_bytes += rt_io->data_buffer_length;
         KprintfH("RT ISO OUT queued frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
@@ -768,8 +777,9 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
             break;
 
         struct xhci_ctrl *ctrl = ep_ctx->udev->controller;
-        u16 frame = ctrl->cfc_supported ? xhci_rt_iso_clamp_frame(ep_ctx)
-                                        : ep_ctx->rt_next_frame;
+        u16 frame = ctrl->cfc_supported
+                        ? xhci_rt_iso_clamp_frame(ep_ctx)
+                        : RT_UFRAME_TO_FRAME(ep_ctx->rt_next_uframe);
         const u32 packet_size = ep_ctx->max_packet_size;
 
         struct USBIORequest *rt_io = slab_alloc(&ctrl->iso_clone_slab);
@@ -820,7 +830,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
         }
         ++inflight;
 
-        ep_ctx->rt_next_frame = (u16)(((u32)frame + ep_ctx->rt_interval_frames) & 0x7ffU);
+        ep_ctx->rt_next_uframe = (u16)(((u32)ep_ctx->rt_next_uframe + ep_ctx->rt_uframes_per_esit) & RT_ISO_UF_MASK);
         ep_ctx->rt_inflight_bytes += rt_io->data_buffer_length;
         KprintfH("RT ISO IN queued frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
@@ -890,7 +900,7 @@ s8 xhci_ep_rt_iso_start(struct ep_context *ep_ctx)
      * Normalize to microframes once so users can add to MFINDEX directly. */
     u32 ist_raw = HCS_IST(mmio_read32(&ep_ctx->udev->controller->hccr->cr_hcsparams2));
     ep_ctx->rt_ist = (ist_raw & 0x8U) ? ((ist_raw & 0x7U) << 3) : (ist_raw & 0x7U);
-    ep_ctx->rt_next_frame = xhci_rt_iso_min_frame(ep_ctx);
+    ep_ctx->rt_next_uframe = xhci_rt_iso_min_uf(ep_ctx);
     ep_ctx->state = USB_DEV_EP_STATE_RT_ISO_RUNNING;
     xhci_ep_schedule_rt_iso(ep_ctx);
     return ERR_NO_ERROR;

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -62,8 +62,9 @@ struct ep_context
     /* Pending STOPRTISO command to reply once the pipe is fully stopped */
     struct USBIORequest *rt_stop_pending;
 
-    /* RT ISO frame tracking (monotonic frame number modulo 2^16) */
+    /* RT ISO frame tracking (frame number [0, 2047]) */
     u16 rt_next_frame;
+    u16 rt_interval_frames; /* cached from HW EP context at add_handler time */
 
     /* Cache the last RT ISO buffer so hooks can omit repeating it */
     APTR rt_last_buffer;
@@ -71,6 +72,8 @@ struct ep_context
 
     /* RT ISO inflight accounting */
     u32 rt_inflight_bytes;
+
+    u32 rt_ist; /* IST decoded to microframes, cached at RT ISO start */
 };
 
 static void xhci_ep_clear_stop_processing(struct ep_context *ep_ctx);
@@ -492,6 +495,43 @@ void xhci_ep_flush(struct ep_context *ep_ctx, s8 reply_code)
 /*
  * RT ISO functions
  */
+void xhci_ep_set_rt_interval(struct ep_context *ep_ctx, u8 interval)
+{
+    u32 ivf = ((1U << interval) + 7U) >> 3;
+    ep_ctx->rt_interval_frames = ivf ? (u16)ivf : 1U;
+}
+
+#define RT_ISO_SCHED_OFFSET_UFRAMES 32U
+
+static u16 xhci_rt_iso_min_frame(struct ep_context *ep_ctx)
+{
+    u32 mfindex = mmio_read32(&ep_ctx->udev->controller->run_regs->microframe_index);
+    u32 start_mfindex = (mfindex + ep_ctx->rt_ist + RT_ISO_SCHED_OFFSET_UFRAMES) & ~0x7U;
+
+    /* Mask to TRB FrameID width (11 bits) — that's the modulus HW uses. */
+    return (u16)((start_mfindex >> 3) & 0x7ffU);
+}
+
+static u16 xhci_rt_iso_clamp_frame(struct ep_context *ep_ctx)
+{
+    u16 frame = ep_ctx->rt_next_frame;
+    u16 min_frame = xhci_rt_iso_min_frame(ep_ctx);
+    /* Both values are in [0, 2047]; sign-extend the 11-bit difference
+     * so the comparison handles wraparound correctly. */
+    u16 raw_delta = (u16)(min_frame - frame) & 0x7ffU;
+    s16 delta = (raw_delta >= 0x400U) ? (s16)((s16)raw_delta - (s16)0x800)
+                                      : (s16)raw_delta;
+
+    if (delta > 0)
+    {
+        /* rt_interval_frames is always a power of 2 (set by xhci_ep_set_rt_interval),
+         * so ceil(delta / ivf) * ivf reduces to a bitmask round-up. */
+        u32 ivf_mask = (u32)ep_ctx->rt_interval_frames - 1U;
+        u32 advance = ((u32)delta + ivf_mask) & ~ivf_mask;
+        frame = (u16)((frame + advance) & 0x7ffU);
+    }
+    return frame;
+}
 
 inline static void xhci_ep_rt_iso_update_counters(struct ep_context *ep_ctx, struct USBIORequest *req)
 {
@@ -583,11 +623,11 @@ s8 xhci_ep_rt_iso_rem_handler(struct ep_context *ep_ctx, struct USBIORequest *re
     return ERR_NO_ERROR;
 }
 
-void xhci_ep_rt_iso_in(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len)
+void xhci_ep_rt_iso_in(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len, u16 rt_frame)
 {
     /* Pull a destination buffer from the class, copy staged DMA into it, then signal completion. */
     struct USBBufferRequest rt_buffer_req;
-    rt_buffer_req.frame = req->usb_frame;
+    rt_buffer_req.frame = rt_frame;
     rt_buffer_req.flags = 0;
     rt_buffer_req.length = act_len;
     rt_buffer_req.data = NULL;
@@ -606,14 +646,14 @@ void xhci_ep_rt_iso_in(struct ep_context *ep_ctx, struct USBIORequest *req, u32 
     xhci_ep_rt_iso_update_counters(ep_ctx, req);
 }
 
-void xhci_ep_rt_iso_out(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len)
+void xhci_ep_rt_iso_out(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len, u16 rt_frame)
 {
     if (ep_ctx->rt_req->output_done_hook)
     {
         /* OUT path: completion hook only. OutReqHook is before transfer. */
         struct USBBufferRequest rt_buffer_req;
         rt_buffer_req.data = req->data_buffer;
-        rt_buffer_req.frame = req->usb_frame;
+        rt_buffer_req.frame = rt_frame;
         rt_buffer_req.length = act_len;
         rt_buffer_req.flags = 0;
         CallHookPkt(ep_ctx->rt_req->output_done_hook, ep_ctx->rt_req, &rt_buffer_req);
@@ -633,7 +673,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
         if (!xhci_ring_has_room(ep_ctx, 2))
             break;
 
-        u16 frame = ep_ctx->rt_next_frame;
+        u16 frame = xhci_rt_iso_clamp_frame(ep_ctx);
         struct USBIORequest *rt_io = slab_alloc(&ep_ctx->udev->controller->iso_clone_slab);
         if (!rt_io)
         {
@@ -677,9 +717,8 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
 
         rt_io->data_buffer = (APTR)((u8 *)rt_buffer_req.data + offset);
         rt_io->data_buffer_length = rt_buffer_req.length;
-        rt_io->usb_frame = frame & 0xffffU;
 
-        s8 ret = xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */);
+        s8 ret = xhci_ring_enqueue_td_at_frame(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */, frame);
         if (ret != ERR_NO_ERROR)
         {
             slab_free(&ep_ctx->udev->controller->iso_clone_slab, rt_io);
@@ -687,7 +726,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
             break;
         }
 
-        ep_ctx->rt_next_frame = ((u32)frame + 1U) & 0xffffU;
+        ep_ctx->rt_next_frame = (u16)(((u32)frame + ep_ctx->rt_interval_frames) & 0x7ffU);
         ep_ctx->rt_inflight_bytes += rt_io->data_buffer_length;
         KprintfH("RT ISO OUT queued frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
@@ -710,7 +749,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
         if (!xhci_ring_has_room(ep_ctx, 2))
             break;
 
-        u16 frame = ep_ctx->rt_next_frame;
+        u16 frame = xhci_rt_iso_clamp_frame(ep_ctx);
         const u32 packet_size = ep_ctx->max_packet_size;
         struct xhci_ctrl *ctrl = ep_ctx->udev->controller;
 
@@ -740,7 +779,6 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
             break;
         }
         rt_io->data_buffer_length = packet_size;
-        rt_io->usb_frame = frame & 0xffffU;
 
         KprintfH("RT ISO IN sched frame=%lu maxpkt=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
@@ -748,7 +786,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
                  (ULONG)ep_ctx->rt_inflight_bytes,
                  (ULONG)xhci_ep_get_active_td_count(ep_ctx));
 
-        s8 ret = xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */);
+        s8 ret = xhci_ring_enqueue_td_at_frame(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */, frame);
         if (ret != ERR_NO_ERROR)
         {
             if (rt_io->driver_private_flags & REQ_RT_IN_BUF_SLABBED)
@@ -761,7 +799,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
         }
         ++inflight;
 
-        ep_ctx->rt_next_frame = ((u32)frame + 1U) & 0xffffU;
+        ep_ctx->rt_next_frame = (u16)(((u32)frame + ep_ctx->rt_interval_frames) & 0x7ffU);
         ep_ctx->rt_inflight_bytes += rt_io->data_buffer_length;
         KprintfH("RT ISO IN queued frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
@@ -826,8 +864,12 @@ s8 xhci_ep_rt_iso_start(struct ep_context *ep_ctx)
         return ERR_HCI_ERROR;
     }
 
-    /* microframe_index is in 125us units; for FS frames use the frame number (divide by 8). */
-    ep_ctx->rt_next_frame = (mmio_read32(&ep_ctx->udev->controller->run_regs->microframe_index) >> 3) & 0xffff;
+    /* HCSPARAMS2.IST is 4 bits (xHCI 5.3.6): bit 3 selects the unit of bits[2:0]
+     * — 0 = microframes (0..7), 1 = frames (0..7, i.e. 0..56 microframes).
+     * Normalize to microframes once so users can add to MFINDEX directly. */
+    u32 ist_raw = HCS_IST(mmio_read32(&ep_ctx->udev->controller->hccr->cr_hcsparams2));
+    ep_ctx->rt_ist = (ist_raw & 0x8U) ? ((ist_raw & 0x7U) << 3) : (ist_raw & 0x7U);
+    ep_ctx->rt_next_frame = xhci_rt_iso_min_frame(ep_ctx);
     ep_ctx->state = USB_DEV_EP_STATE_RT_ISO_RUNNING;
     xhci_ep_schedule_rt_iso(ep_ctx);
     return ERR_NO_ERROR;

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -37,9 +37,9 @@
 struct ep_context
 {
     struct usb_device *udev; /* back reference to device */
-    int ep_index;            /* Endpoint context index (0-30) */
+    u8 ep_index;             /* Endpoint context index (0-30) */
     enum ep_state state;     /* Current endpoint state */
-    int max_packet_size;     /* Cached max packet size for this endpoint */
+    u32 max_packet_size;     /* Cached max packet size for this endpoint */
     APTR memoryPool;         /* Memory pool for this endpoint */
 
     IOReqList pending_reqs;             /* list of pending requests */
@@ -63,19 +63,19 @@ struct ep_context
     struct USBIORequest *rt_stop_pending;
 
     /* RT ISO frame tracking (monotonic frame number modulo 2^16) */
-    ULONG rt_next_frame;
+    u16 rt_next_frame;
 
     /* Cache the last RT ISO buffer so hooks can omit repeating it */
     APTR rt_last_buffer;
-    ULONG rt_last_filled;
+    u32 rt_last_filled;
 
     /* RT ISO inflight accounting */
-    ULONG rt_inflight_bytes;
+    u32 rt_inflight_bytes;
 };
 
 static void xhci_ep_clear_stop_processing(struct ep_context *ep_ctx);
 
-BOOL xhci_ep_create_context(struct usb_device *udev, int ep_index, int max_packet_size, APTR memoryPool)
+BOOL xhci_ep_create_context(struct usb_device *udev, u8 ep_index, u32 max_packet_size, APTR memoryPool)
 {
     struct ep_context *ep_ctx = pool_zalloc(memoryPool, sizeof(struct ep_context));
     if (!ep_ctx)
@@ -109,14 +109,14 @@ BOOL xhci_ep_create_context(struct usb_device *udev, int ep_index, int max_packe
     return TRUE;
 }
 
-void xhci_ep_destroy_contexts(struct usb_device *udev, BYTE reply_code)
+void xhci_ep_destroy_contexts(struct usb_device *udev, s8 reply_code)
 {
     for (int i = 0; i < USB_MAX_ENDPOINT_CONTEXTS; ++i)
     {
         struct ep_context *ep_ctx = udev->ep_context[i];
         if (ep_ctx)
         {
-            KprintfH("tearing down addr %ld EP %ld context, state %ld\n", (LONG)udev->virtual_address, (LONG)i, (LONG)ep_ctx->state);
+            KprintfH("tearing down addr %lu EP %lu context, state %lu\n", (ULONG)udev->virtual_address, (ULONG)i, (ULONG)ep_ctx->state);
             struct MinNode *node;
             while ((node = RemHeadMinList(&ep_ctx->pending_reqs)) != NULL)
             {
@@ -150,18 +150,18 @@ void xhci_ep_destroy_contexts(struct usb_device *udev, BYTE reply_code)
     }
 }
 
-struct ep_context *xhci_ep_get_context_for_index(struct usb_device *udev, int ep_index)
+struct ep_context *xhci_ep_get_context_for_index(struct usb_device *udev, u8 ep_index)
 {
-    if (ep_index < 0 || ep_index >= USB_MAX_ENDPOINT_CONTEXTS)
+    if (ep_index >= USB_MAX_ENDPOINT_CONTEXTS)
     {
-        Kprintf("Invalid endpoint index %ld\n", (LONG)ep_index);
+        Kprintf("Invalid endpoint index %lu\n", (ULONG)ep_index);
         return NULL;
     }
 
     return udev->ep_context[ep_index];
 }
 
-void xhci_ep_set_max_packet_size(struct ep_context *ep_ctx, int max_packet_size)
+void xhci_ep_set_max_packet_size(struct ep_context *ep_ctx, u32 max_packet_size)
 {
     if (!ep_ctx || !ep_ctx->ring)
         return;
@@ -180,7 +180,7 @@ void xhci_ep_set_max_packet_size(struct ep_context *ep_ctx, int max_packet_size)
 
 void xhci_ep_set_failed(struct ep_context *ep_ctx)
 {
-    Kprintf("EP %ld state %ld -> FAILED\n", (LONG)ep_ctx->ep_index, (LONG)ep_ctx->state);
+    Kprintf("EP %lu state %lu -> FAILED\n", (ULONG)ep_ctx->ep_index, (ULONG)ep_ctx->state);
     ep_ctx->state = USB_DEV_EP_STATE_FAILED;
     xhci_ep_clear_stop_processing(ep_ctx);
     xhci_td_fail_all(ep_ctx->active_tds, ERR_HCI_ERROR);
@@ -196,9 +196,9 @@ void xhci_ep_enqueue(struct ep_context *ep_ctx, struct USBIORequest *io)
         AddTailMinList(&ep_ctx->pending_reqs, (struct MinNode *)io);
     }
 
-    KprintfH("Ring busy, queued request cmd=%ld ep=%ld\n",
-             (LONG)io->req.io_Command,
-             (LONG)(io->endpoint & 0x0F));
+    KprintfH("Ring busy, queued request cmd=%lu ep=%lu\n",
+             (ULONG)io->req.io_Command,
+             (ULONG)(io->endpoint & 0x0F));
 }
 
 BOOL xhci_ep_has_request(struct ep_context *ep_ctx, struct USBIORequest *io)
@@ -224,11 +224,11 @@ static void xhci_ep_schedule_next(struct ep_context *ep_ctx)
     {
         struct USBIORequest *req = (struct USBIORequest *)node;
 
-        KprintfH("starting queued request cmd=%ld ep=%ld\n",
-                 (LONG)req->req.io_Command,
-                 (LONG)(req->endpoint & 0x0F));
+        KprintfH("starting queued request cmd=%lu ep=%lu\n",
+                 (ULONG)req->req.io_Command,
+                 (ULONG)(req->endpoint & 0x0F));
 
-        int err;
+        s8 err;
         if (req->driver_private_flags & REQ_INTERNAL)
             err = xhci_udev_send_ctrl(ep_ctx->udev, req);
         else
@@ -257,11 +257,11 @@ void xhci_ep_set_idle(struct ep_context *ep_ctx)
         xhci_ep_schedule_next(ep_ctx);
 }
 
-void xhci_ep_set_receiving(struct ep_context *ep_ctx, struct USBIORequest *req, dma_addr_t *trb_addrs, ULONG timeout_ms, unsigned int trb_count)
+void xhci_ep_set_receiving(struct ep_context *ep_ctx, struct USBIORequest *req, dma_addr_t *trb_addrs, u32 timeout_ms, u32 trb_count)
 {
     if (!trb_addrs || trb_count == 0)
     {
-        Kprintf("Invalid TRB list for EP %ld\n", (LONG)ep_ctx->ep_index);
+        Kprintf("Invalid TRB list for EP %lu\n", (ULONG)ep_ctx->ep_index);
         xhci_ep_set_failed(ep_ctx);
         return;
     }
@@ -403,7 +403,7 @@ void xhci_ep_request_stop(struct ep_context *ep_ctx)
         state != USB_DEV_EP_STATE_RT_ISO_RUNNING)
         return;
 
-    KprintfH("EP %ld state %ld -> ABORTING (stop requested)\n", (LONG)ep_ctx->ep_index, (LONG)state);
+    KprintfH("EP %lu state %lu -> ABORTING (stop requested)\n", (ULONG)ep_ctx->ep_index, (ULONG)state);
     xhci_ep_set_aborting(ep_ctx);
     xhci_stop_ring(ep_ctx->udev, ep_ctx->ep_index);
 }
@@ -418,7 +418,7 @@ void xhci_ep_process_stop(struct ep_context *ep_ctx, dma_addr_t *deq_ptr)
     if (!xhci_ep_has_stop_abort_requests(ep_ctx) && !ep_ctx->stop_process_timeouts)
         return;
 
-    dma_addr_t stopped_deq_ptr = xhci_get_endpoint_deq_ptr(ep_ctx->udev, ep_ctx->ep_index);
+    dma_addr_t stopped_deq_ptr = (dma_addr_t)xhci_get_endpoint_deq_ptr(ep_ctx->udev, ep_ctx->ep_index);
 
     xhci_td_patch_recovery(ep_ctx->active_tds,
                            ep_ctx->ring,
@@ -434,7 +434,7 @@ enum ep_state xhci_ep_get_state(struct ep_context *ep_ctx)
     return ep_ctx->state;
 }
 
-int xhci_ep_get_ep_index(struct ep_context *ep_ctx)
+u8 xhci_ep_get_ep_index(struct ep_context *ep_ctx)
 {
     return ep_ctx->ep_index;
 }
@@ -464,17 +464,17 @@ struct USBIORequest *xhci_ep_get_by_trb(struct ep_context *ep_ctx, dma_addr_t tr
     return xhci_td_get_by_trb(td_list, trb_addr);
 }
 
-int xhci_ep_get_active_trb_count(struct ep_context *ep_ctx)
+u32 xhci_ep_get_active_trb_count(struct ep_context *ep_ctx)
 {
     return xhci_td_get_queued_trb_count(ep_ctx->active_tds);
 }
 
-inline static int xhci_ep_get_active_td_count(struct ep_context *ep_ctx)
+inline static u32 xhci_ep_get_active_td_count(struct ep_context *ep_ctx)
 {
     return xhci_td_get_queued_td_count(ep_ctx->active_tds);
 }
 
-void xhci_ep_flush(struct ep_context *ep_ctx, BYTE reply_code)
+void xhci_ep_flush(struct ep_context *ep_ctx, s8 reply_code)
 {
     struct MinNode *node;
     while ((node = RemHeadMinList(&ep_ctx->pending_reqs)) != NULL)
@@ -509,7 +509,7 @@ static void xhci_ep_set_rt_stopped(struct ep_context *ep_ctx)
     xhci_ep_rt_iso_zero_counters(ep_ctx);
 }
 
-BYTE xhci_ep_rt_iso_add_handler(struct ep_context *ep_ctx, struct USBIORequest *req)
+s8 xhci_ep_rt_iso_add_handler(struct ep_context *ep_ctx, struct USBIORequest *req)
 {
     if (!req || !ep_ctx)
         return FALSE;
@@ -517,7 +517,7 @@ BYTE xhci_ep_rt_iso_add_handler(struct ep_context *ep_ctx, struct USBIORequest *
     if (ep_ctx->state != USB_DEV_EP_STATE_IDLE)
     {
         /* can only enable RT ISO if EP is idle */
-        Kprintf("EP not idle. Current state: %ld\n", ep_ctx->state);
+        Kprintf("EP not idle. Current state: %lu\n", (ULONG)ep_ctx->state);
         return ERR_HCI_ERROR;
     }
 
@@ -537,17 +537,17 @@ BYTE xhci_ep_rt_iso_add_handler(struct ep_context *ep_ctx, struct USBIORequest *
     struct USBRealtimeHooks *rt = (struct USBRealtimeHooks *)req->data_buffer;
     if (req->direction == DIRECTION_IN)
     {
-        KprintfH("Added ISO handler: EP %ld in req hook: %lx, in done hook: %lx, prefetch: %ld\n", ep_ctx->ep_index, rt->input_request_hook, rt->input_done_hook, rt->max_output_prefetch);
+        KprintfH("Added ISO handler: EP %lu in req hook: %lx, in done hook: %lx, prefetch: %lu\n", (ULONG)ep_ctx->ep_index, (ULONG)rt->input_request_hook, (ULONG)rt->input_done_hook, (ULONG)rt->max_output_prefetch);
     }
     else
     {
-        KprintfH("Added ISO handler: EP %ld out req hook: %lx, out done hook: %lx, prefetch: %ld\n", ep_ctx->ep_index, rt->output_request_hook, rt->output_done_hook, rt->max_output_prefetch);
+        KprintfH("Added ISO handler: EP %lu out req hook: %lx, out done hook: %lx, prefetch: %lu\n", (ULONG)ep_ctx->ep_index, (ULONG)rt->output_request_hook, (ULONG)rt->output_done_hook, (ULONG)rt->max_output_prefetch);
     }
 #endif
     return ERR_NO_ERROR;
 }
 
-BYTE xhci_ep_rt_iso_rem_handler(struct ep_context *ep_ctx, struct USBIORequest *req)
+s8 xhci_ep_rt_iso_rem_handler(struct ep_context *ep_ctx, struct USBIORequest *req)
 {
     if (!req || !ep_ctx)
     {
@@ -557,7 +557,7 @@ BYTE xhci_ep_rt_iso_rem_handler(struct ep_context *ep_ctx, struct USBIORequest *
 
     if (ep_ctx->state != USB_DEV_EP_STATE_RT_ISO_STOPPED)
     {
-        Kprintf("EP not in RT_ISO_STOPPED/IDLE state. Current state: %ld\n", ep_ctx->state);
+        Kprintf("EP not in RT_ISO_STOPPED/IDLE state. Current state: %lu\n", (ULONG)ep_ctx->state);
         return ERR_HCI_ERROR;
     }
 
@@ -578,7 +578,7 @@ BYTE xhci_ep_rt_iso_rem_handler(struct ep_context *ep_ctx, struct USBIORequest *
     return ERR_NO_ERROR;
 }
 
-void xhci_ep_rt_iso_in(struct ep_context *ep_ctx, struct USBIORequest *req, ULONG act_len)
+void xhci_ep_rt_iso_in(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len)
 {
     /* Pull a destination buffer from the class, copy staged DMA into it, then signal completion. */
     struct USBBufferRequest rt_buffer_req;
@@ -591,7 +591,7 @@ void xhci_ep_rt_iso_in(struct ep_context *ep_ctx, struct USBIORequest *req, ULON
 
     if (rt_buffer_req.data)
     {
-        ULONG copy_len = min(act_len, rt_buffer_req.length);
+        u32 copy_len = act_len < rt_buffer_req.length ? act_len : rt_buffer_req.length;
         CopyMem(req->data_buffer, rt_buffer_req.data, copy_len);
         rt_buffer_req.length = copy_len;
 
@@ -601,7 +601,7 @@ void xhci_ep_rt_iso_in(struct ep_context *ep_ctx, struct USBIORequest *req, ULON
     xhci_ep_rt_iso_update_counters(ep_ctx, req);
 }
 
-void xhci_ep_rt_iso_out(struct ep_context *ep_ctx, struct USBIORequest *req, ULONG act_len)
+void xhci_ep_rt_iso_out(struct ep_context *ep_ctx, struct USBIORequest *req, u32 act_len)
 {
     if (ep_ctx->rt_req->output_done_hook)
     {
@@ -620,11 +620,11 @@ void xhci_ep_rt_iso_out(struct ep_context *ep_ctx, struct USBIORequest *req, ULO
 static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
 {
     struct USBIORequest *template = ep_ctx->rt_template_req;
-    ULONG prefetch_bytes = ep_ctx->rt_req->max_output_prefetch;
+    u32 prefetch_bytes = ep_ctx->rt_req->max_output_prefetch;
 
     while (ep_ctx->rt_inflight_bytes < prefetch_bytes)
     {
-        ULONG frame = ep_ctx->rt_next_frame;
+        u16 frame = ep_ctx->rt_next_frame;
         struct USBIORequest *rt_io = pool_alloc(ep_ctx->memoryPool, sizeof(struct USBIORequest));
         if (!rt_io)
         {
@@ -654,7 +654,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
             break;
         }
 
-        ULONG offset = 0;
+        u32 offset = 0;
         if (rt_buffer_req.data == ep_ctx->rt_last_buffer)
         {
             offset = ep_ctx->rt_last_filled;
@@ -665,11 +665,11 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
         }
         ep_ctx->rt_last_filled = offset + rt_buffer_req.length;
 
-        rt_io->data_buffer = (APTR)((ULONG)rt_buffer_req.data + offset);
+        rt_io->data_buffer = (APTR)((u8 *)rt_buffer_req.data + offset);
         rt_io->data_buffer_length = rt_buffer_req.length;
-        rt_io->usb_frame = (UWORD)frame;
+        rt_io->usb_frame = frame & 0xffffU;
 
-        int ret = xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */);
+        s8 ret = xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */);
         if (ret != ERR_NO_ERROR)
         {
             pool_free(ep_ctx->memoryPool, rt_io);
@@ -677,7 +677,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
             break;
         }
 
-        ep_ctx->rt_next_frame = (frame + 1) & 0xffff;
+        ep_ctx->rt_next_frame = ((u32)frame + 1U) & 0xffffU;
         ep_ctx->rt_inflight_bytes += rt_io->data_buffer_length;
         KprintfH("RT ISO OUT queued frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
@@ -693,10 +693,11 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
 {
     struct USBIORequest *template = ep_ctx->rt_template_req;
 
-    int inflight = xhci_ep_get_active_td_count(ep_ctx);
+    u32 inflight = xhci_ep_get_active_td_count(ep_ctx);
     while (inflight < RT_ISO_IN_TARGET_TDS)
     {
-        ULONG frame = ep_ctx->rt_next_frame;
+        u16 frame = ep_ctx->rt_next_frame;
+        const u32 packet_size = ep_ctx->max_packet_size;
         struct USBIORequest *rt_io = pool_alloc(ep_ctx->memoryPool, sizeof(struct USBIORequest));
         if (!rt_io)
         {
@@ -705,15 +706,15 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
         }
         CopyMem(template, rt_io, sizeof(struct USBIORequest));
 
-        rt_io->data_buffer = pool_alloc(ep_ctx->memoryPool, ep_ctx->max_packet_size);
+        rt_io->data_buffer = pool_alloc(ep_ctx->memoryPool, packet_size);
         if (!rt_io->data_buffer)
         {
             Kprintf("Failed to alloc RT ISO staging buffer\n");
             pool_free(ep_ctx->memoryPool, rt_io);
             break;
         }
-        rt_io->data_buffer_length = ep_ctx->max_packet_size;
-        rt_io->usb_frame = (UWORD)frame;
+        rt_io->data_buffer_length = packet_size;
+        rt_io->usb_frame = frame & 0xffffU;
 
         KprintfH("RT ISO IN sched frame=%lu maxpkt=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
@@ -721,7 +722,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
                  (ULONG)ep_ctx->rt_inflight_bytes,
                  (ULONG)xhci_ep_get_active_td_count(ep_ctx));
 
-        int ret = xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */);
+        s8 ret = xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */);
         if (ret != ERR_NO_ERROR)
         {
             pool_free(ep_ctx->memoryPool, rt_io->data_buffer);
@@ -731,7 +732,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
         }
         ++inflight;
 
-        ep_ctx->rt_next_frame = (frame + 1) & 0xffff;
+        ep_ctx->rt_next_frame = ((u32)frame + 1U) & 0xffffU;
         ep_ctx->rt_inflight_bytes += rt_io->data_buffer_length;
         KprintfH("RT ISO IN queued frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
@@ -788,7 +789,7 @@ void xhci_ep_schedule_rt_iso(struct ep_context *ep_ctx)
         xhci_ep_schedule_rt_iso_out(ep_ctx);
 }
 
-BYTE xhci_ep_rt_iso_start(struct ep_context *ep_ctx)
+s8 xhci_ep_rt_iso_start(struct ep_context *ep_ctx)
 {
     if (ep_ctx->state != USB_DEV_EP_STATE_RT_ISO_STOPPED)
     {
@@ -803,7 +804,7 @@ BYTE xhci_ep_rt_iso_start(struct ep_context *ep_ctx)
     return ERR_NO_ERROR;
 }
 
-BYTE xhci_ep_rt_iso_stop(struct ep_context *ep_ctx, struct USBIORequest *req)
+s8 xhci_ep_rt_iso_stop(struct ep_context *ep_ctx, struct USBIORequest *req)
 {
     if (ep_ctx->state != USB_DEV_EP_STATE_RT_ISO_RUNNING)
     {
@@ -832,9 +833,9 @@ BYTE xhci_ep_rt_iso_stop(struct ep_context *ep_ctx, struct USBIORequest *req)
     }
     else
     {
-        KprintfH("RT ISO stopping addr=%ld ep=%ld inflight_tds=%lu inflight_bytes=%lu\n",
-                 (LONG)req->virtual_address,
-                 (LONG)ep_ctx->ep_index,
+        KprintfH("RT ISO stopping addr=%lu ep=%lu inflight_tds=%lu inflight_bytes=%lu\n",
+                 (ULONG)req->virtual_address,
+                 (ULONG)ep_ctx->ep_index,
                  (ULONG)xhci_ep_get_active_td_count(ep_ctx),
                  (ULONG)ep_ctx->rt_inflight_bytes);
         ep_ctx->state = USB_DEV_EP_STATE_RT_ISO_STOPPING;

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #include <clib/utility_protos.h>

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -9,7 +9,7 @@
 #include <proto/utility.h>
 #endif
 
-#include <emu_memory.h>
+#include <memory.h>
 #include <debug.h>
 #include <config.h>
 #include <minlist.h>
@@ -75,7 +75,7 @@ static void xhci_ep_clear_stop_processing(struct ep_context *ep_ctx);
 
 BOOL xhci_ep_create_context(struct usb_device *udev, int ep_index, int max_packet_size, APTR memoryPool)
 {
-    struct ep_context *ep_ctx = AllocVecPooled(memoryPool, sizeof(struct ep_context));
+    struct ep_context *ep_ctx = pool_zalloc(memoryPool, sizeof(struct ep_context));
     if (!ep_ctx)
     {
         Kprintf("Failed to allocate ep_context for EP %d\n", ep_index);
@@ -97,7 +97,7 @@ BOOL xhci_ep_create_context(struct usb_device *udev, int ep_index, int max_packe
             xhci_td_destroy_list(ep_ctx->active_tds, ERR_ALLOC_ERROR);
         if (ep_ctx->ring)
             xhci_ring_free(udev->controller, ep_ctx->ring);
-        FreeVecPooled(memoryPool, ep_ctx);
+        pool_free(memoryPool, ep_ctx);
         return FALSE;
     }
 
@@ -126,7 +126,7 @@ void xhci_ep_destroy_contexts(struct usb_device *udev, BYTE reply_code)
 
             if (ep_ctx->rt_template_req)
             {
-                FreeVecPooled(ep_ctx->memoryPool, ep_ctx->rt_template_req);
+                pool_free(ep_ctx->memoryPool, ep_ctx->rt_template_req);
                 ep_ctx->rt_template_req = NULL;
             }
             if (ep_ctx->rt_stop_pending)
@@ -142,7 +142,7 @@ void xhci_ep_destroy_contexts(struct usb_device *udev, BYTE reply_code)
             if (ep_ctx->ring)
                 xhci_ring_free(udev->controller, ep_ctx->ring);
 
-            FreeVecPooled(ep_ctx->memoryPool, ep_ctx);
+            pool_free(ep_ctx->memoryPool, ep_ctx);
             udev->ep_context[i] = NULL;
         }
     }
@@ -288,7 +288,7 @@ void xhci_ep_set_receiving(struct ep_context *ep_ctx, struct USBIORequest *req, 
     if (!result)
     {
         Kprintf("Failed to add TD to active list\n");
-        FreeVecPooled(ep_ctx->memoryPool, trb_addrs);
+        pool_free(ep_ctx->memoryPool, trb_addrs);
         xhci_ep_set_failed(ep_ctx);
         return;
     }
@@ -323,7 +323,7 @@ static BOOL xhci_ep_has_stop_abort_requests(struct ep_context *ep_ctx)
 
 static BOOL xhci_ep_append_stop_abort_request(struct ep_context *ep_ctx, struct USBIORequest *abort_req)
 {
-    IOReqNode *node = AllocVecPooled(ep_ctx->memoryPool, sizeof(*node));
+    IOReqNode *node = pool_alloc(ep_ctx->memoryPool, sizeof(*node));
     if (!node)
         return FALSE;
 
@@ -336,7 +336,7 @@ static void xhci_ep_clear_stop_processing(struct ep_context *ep_ctx)
 {
     struct MinNode *node;
     while ((node = RemHeadMinList(&ep_ctx->stop_abort_reqs)) != NULL)
-        FreeVecPooled(ep_ctx->memoryPool, node);
+        pool_free(ep_ctx->memoryPool, node);
 
     ep_ctx->stop_process_timeouts = FALSE;
 }
@@ -522,7 +522,7 @@ BYTE xhci_ep_rt_iso_add_handler(struct ep_context *ep_ctx, struct USBIORequest *
     xhci_ep_set_rt_stopped(ep_ctx);
 
     ep_ctx->rt_req = (struct USBRealtimeHooks *)req->data_buffer;
-    ep_ctx->rt_template_req = AllocVecPooled(ep_ctx->memoryPool, sizeof(struct USBIORequest));
+    ep_ctx->rt_template_req = pool_alloc(ep_ctx->memoryPool, sizeof(struct USBIORequest));
     if (!ep_ctx->rt_template_req)
     {
         Kprintf("Failed to allocate memory\n");
@@ -568,7 +568,7 @@ BYTE xhci_ep_rt_iso_rem_handler(struct ep_context *ep_ctx, struct USBIORequest *
     ep_ctx->rt_req = NULL;
     if (ep_ctx->rt_template_req)
     {
-        FreeVecPooled(ep_ctx->memoryPool, ep_ctx->rt_template_req);
+        pool_free(ep_ctx->memoryPool, ep_ctx->rt_template_req);
         ep_ctx->rt_template_req = NULL;
     }
     xhci_ep_set_idle(ep_ctx);
@@ -623,7 +623,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
     while (ep_ctx->rt_inflight_bytes < prefetch_bytes)
     {
         ULONG frame = ep_ctx->rt_next_frame;
-        struct USBIORequest *rt_io = AllocVecPooled(ep_ctx->memoryPool, sizeof(struct USBIORequest));
+        struct USBIORequest *rt_io = pool_alloc(ep_ctx->memoryPool, sizeof(struct USBIORequest));
         if (!rt_io)
         {
             Kprintf("Failed to alloc RT ISO IO req\n");
@@ -648,7 +648,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
         if (!rt_buffer_req.data || rt_buffer_req.length == 0)
         {
             KprintfH("RT ISO hook provided no buffer/length\n");
-            FreeVecPooled(ep_ctx->memoryPool, rt_io);
+            pool_free(ep_ctx->memoryPool, rt_io);
             break;
         }
 
@@ -670,7 +670,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
         int ret = xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */);
         if (ret != ERR_NO_ERROR)
         {
-            FreeVecPooled(ep_ctx->memoryPool, rt_io);
+            pool_free(ep_ctx->memoryPool, rt_io);
             Kprintf("RT ISO submit failed %ld\n", (LONG)ret);
             break;
         }
@@ -695,7 +695,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
     while (inflight < RT_ISO_IN_TARGET_TDS)
     {
         ULONG frame = ep_ctx->rt_next_frame;
-        struct USBIORequest *rt_io = AllocVecPooled(ep_ctx->memoryPool, sizeof(struct USBIORequest));
+        struct USBIORequest *rt_io = pool_alloc(ep_ctx->memoryPool, sizeof(struct USBIORequest));
         if (!rt_io)
         {
             Kprintf("Failed to alloc RT ISO IO req\n");
@@ -703,11 +703,11 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
         }
         CopyMem(template, rt_io, sizeof(struct USBIORequest));
 
-        rt_io->data_buffer = AllocVecPooled(ep_ctx->memoryPool, ep_ctx->max_packet_size);
+        rt_io->data_buffer = pool_alloc(ep_ctx->memoryPool, ep_ctx->max_packet_size);
         if (!rt_io->data_buffer)
         {
             Kprintf("Failed to alloc RT ISO staging buffer\n");
-            FreeVecPooled(ep_ctx->memoryPool, rt_io);
+            pool_free(ep_ctx->memoryPool, rt_io);
             break;
         }
         rt_io->data_buffer_length = ep_ctx->max_packet_size;
@@ -722,8 +722,8 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
         int ret = xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */);
         if (ret != ERR_NO_ERROR)
         {
-            FreeVecPooled(ep_ctx->memoryPool, rt_io->data_buffer);
-            FreeVecPooled(ep_ctx->memoryPool, rt_io);
+            pool_free(ep_ctx->memoryPool, rt_io->data_buffer);
+            pool_free(ep_ctx->memoryPool, rt_io);
             Kprintf("RT ISO submit failed %ld\n", (LONG)ret);
             break;
         }
@@ -795,7 +795,7 @@ BYTE xhci_ep_rt_iso_start(struct ep_context *ep_ctx)
     }
 
     /* microframe_index is in 125us units; for FS frames use the frame number (divide by 8). */
-    ep_ctx->rt_next_frame = (readl(ep_ctx->udev->controller->run_regs->microframe_index) >> 3) & 0xffff;
+    ep_ctx->rt_next_frame = (mmio_read32(&ep_ctx->udev->controller->run_regs->microframe_index) >> 3) & 0xffff;
     ep_ctx->state = USB_DEV_EP_STATE_RT_ISO_RUNNING;
     xhci_ep_schedule_rt_iso(ep_ctx);
     return ERR_NO_ERROR;

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -40,6 +40,7 @@ struct ep_context
     u8 ep_index;             /* Endpoint context index (0-30) */
     enum ep_state state;     /* Current endpoint state */
     u32 max_packet_size;     /* Cached max packet size for this endpoint */
+    u8 max_burst;            /* bMaxBurst (zero-based: 0 = 1 packet/burst) */
     APTR memoryPool;         /* Memory pool for this endpoint */
 
     IOReqList pending_reqs;             /* list of pending requests */
@@ -78,7 +79,7 @@ struct ep_context
 
 static void xhci_ep_clear_stop_processing(struct ep_context *ep_ctx);
 
-BOOL xhci_ep_create_context(struct usb_device *udev, u8 ep_index, u32 max_packet_size, APTR memoryPool)
+BOOL xhci_ep_create_context(struct usb_device *udev, u8 ep_index, u32 max_packet_size, u8 max_burst, APTR memoryPool)
 {
     struct ep_context *ep_ctx = pool_zalloc(memoryPool, sizeof(struct ep_context));
     if (!ep_ctx)
@@ -91,6 +92,7 @@ BOOL xhci_ep_create_context(struct usb_device *udev, u8 ep_index, u32 max_packet
     ep_ctx->memoryPool = memoryPool;
     ep_ctx->state = USB_DEV_EP_STATE_IDLE;
     ep_ctx->max_packet_size = max_packet_size;
+    ep_ctx->max_burst = max_burst;
     _NewMinList(&ep_ctx->pending_reqs);
     _NewMinList(&ep_ctx->stop_abort_reqs);
     ep_ctx->active_tds = xhci_td_create_list(udev->controller);
@@ -171,6 +173,16 @@ void xhci_ep_set_max_packet_size(struct ep_context *ep_ctx, u32 max_packet_size)
 
     xhci_ring_set_max_packet_size(ep_ctx->ring, max_packet_size);
     ep_ctx->max_packet_size = max_packet_size;
+}
+
+u32 xhci_ep_get_max_packet_size(struct ep_context *ep_ctx)
+{
+    return ep_ctx->max_packet_size;
+}
+
+u8 xhci_ep_get_max_burst(struct ep_context *ep_ctx)
+{
+    return ep_ctx->max_burst;
 }
 
 /*
@@ -666,6 +678,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
 {
     struct USBIORequest *template = ep_ctx->rt_template_req;
     u32 prefetch_bytes = ep_ctx->rt_req->max_output_prefetch;
+    struct xhci_ctrl *ctrl = ep_ctx->udev->controller;
 
     while (ep_ctx->rt_inflight_bytes < prefetch_bytes)
     {
@@ -673,8 +686,11 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
         if (!xhci_ring_has_room(ep_ctx, 2))
             break;
 
-        u16 frame = xhci_rt_iso_clamp_frame(ep_ctx);
-        struct USBIORequest *rt_io = slab_alloc(&ep_ctx->udev->controller->iso_clone_slab);
+        /* CFC controllers pin Frame ID to a slot; without CFC the HW chooses
+         * via SIA, but we still hand the user hook a monotonic frame counter. */
+        u16 frame = ctrl->cfc_supported ? xhci_rt_iso_clamp_frame(ep_ctx)
+                                        : ep_ctx->rt_next_frame;
+        struct USBIORequest *rt_io = slab_alloc(&ctrl->iso_clone_slab);
         if (!rt_io)
         {
             Kprintf("Failed to alloc RT ISO IO req\n");
@@ -700,7 +716,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
         if (!rt_buffer_req.data || rt_buffer_req.length == 0)
         {
             KprintfH("RT ISO hook provided no buffer/length\n");
-            slab_free(&ep_ctx->udev->controller->iso_clone_slab, rt_io);
+            slab_free(&ctrl->iso_clone_slab, rt_io);
             break;
         }
 
@@ -718,10 +734,12 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
         rt_io->data_buffer = (APTR)((u8 *)rt_buffer_req.data + offset);
         rt_io->data_buffer_length = rt_buffer_req.length;
 
-        s8 ret = xhci_ring_enqueue_td_at_frame(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */, frame);
+        s8 ret = ctrl->cfc_supported
+                     ? xhci_ring_enqueue_td_at_frame(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */, frame)
+                     : xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE);
         if (ret != ERR_NO_ERROR)
         {
-            slab_free(&ep_ctx->udev->controller->iso_clone_slab, rt_io);
+            slab_free(&ctrl->iso_clone_slab, rt_io);
             Kprintf("RT ISO submit failed %ld\n", (LONG)ret);
             break;
         }
@@ -749,9 +767,10 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
         if (!xhci_ring_has_room(ep_ctx, 2))
             break;
 
-        u16 frame = xhci_rt_iso_clamp_frame(ep_ctx);
-        const u32 packet_size = ep_ctx->max_packet_size;
         struct xhci_ctrl *ctrl = ep_ctx->udev->controller;
+        u16 frame = ctrl->cfc_supported ? xhci_rt_iso_clamp_frame(ep_ctx)
+                                        : ep_ctx->rt_next_frame;
+        const u32 packet_size = ep_ctx->max_packet_size;
 
         struct USBIORequest *rt_io = slab_alloc(&ctrl->iso_clone_slab);
         if (!rt_io)
@@ -786,7 +805,9 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
                  (ULONG)ep_ctx->rt_inflight_bytes,
                  (ULONG)xhci_ep_get_active_td_count(ep_ctx));
 
-        s8 ret = xhci_ring_enqueue_td_at_frame(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */, frame);
+        s8 ret = ctrl->cfc_supported
+                     ? xhci_ring_enqueue_td_at_frame(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */, frame)
+                     : xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE);
         if (ret != ERR_NO_ERROR)
         {
             if (rt_io->driver_private_flags & REQ_RT_IN_BUF_SLABBED)

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -115,7 +115,7 @@ BOOL xhci_ep_create_context(struct usb_device *udev, u8 ep_index, u32 max_packet
     _NewMinList(&ep_ctx->pending_reqs);
     _NewMinList(&ep_ctx->stop_abort_reqs);
     ep_ctx->active_tds = xhci_td_create_list(udev->controller, ep_ctx);
-    ep_ctx->ring = xhci_ring_alloc(udev->controller, XHCI_SEGMENTS_PER_RING, /*link_trbs*/ TRUE, /*is_event_ring*/ FALSE, ep_index, max_packet_size);
+    ep_ctx->ring = xhci_ring_alloc(udev->controller, XHCI_INITIAL_SEGMENTS_PER_RING, /*link_trbs*/ TRUE, /*is_event_ring*/ FALSE, ep_index, max_packet_size);
     if (!ep_ctx->active_tds || !ep_ctx->ring)
     {
         Kprintf("Failed to create resources for EP %d\n", ep_index);
@@ -717,9 +717,13 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
 
     while (ep_ctx->rt_inflight_bytes < prefetch_bytes)
     {
-        /* Don't enqueue if the ring can't fit one more TRB+spare */
+        /* Don't enqueue if the ring can't fit one more TRB+spare; try to grow first */
         if (!xhci_ring_has_room(ep_ctx, 2))
-            break;
+        {
+            if (!xhci_ring_grow(ctrl, xhci_ep_get_ring(ep_ctx), XHCI_SEGMENTS_PER_RING) ||
+                !xhci_ring_has_room(ep_ctx, 2))
+                break;
+        }
 
         /* CFC controllers pin Frame ID to a slot; without CFC the HW chooses
          * via SIA, but we still hand the user hook a monotonic frame counter. */
@@ -795,15 +799,19 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
 static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
 {
     struct USBIORequest *template = ep_ctx->rt_template_req;
+    struct xhci_ctrl *ctrl = ep_ctx->udev->controller;
 
     u32 inflight = xhci_ep_get_active_td_count(ep_ctx);
     while (inflight < ep_ctx->rt_inflight_tds_target)
     {
         /* Same backpressure rule as the OUT path: bail before alloc if no room. */
         if (!xhci_ring_has_room(ep_ctx, 2))
-            break;
+        {
+            if (!xhci_ring_grow(ctrl, xhci_ep_get_ring(ep_ctx), XHCI_SEGMENTS_PER_RING) ||
+                !xhci_ring_has_room(ep_ctx, 2))
+                break;
+        }
 
-        struct xhci_ctrl *ctrl = ep_ctx->udev->controller;
         u16 frame = ctrl->cfc_supported
                         ? xhci_rt_iso_clamp_frame(ep_ctx)
                         : RT_UFRAME_TO_FRAME(ep_ctx->rt_next_uframe);

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -629,6 +629,10 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
 
     while (ep_ctx->rt_inflight_bytes < prefetch_bytes)
     {
+        /* Don't enqueue if the ring can't fit one more TRB+spare */
+        if (!xhci_ring_has_room(ep_ctx, 2))
+            break;
+
         u16 frame = ep_ctx->rt_next_frame;
         struct USBIORequest *rt_io = pool_alloc(ep_ctx->memoryPool, sizeof(struct USBIORequest));
         if (!rt_io)
@@ -701,6 +705,10 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
     u32 inflight = xhci_ep_get_active_td_count(ep_ctx);
     while (inflight < RT_ISO_IN_TARGET_TDS)
     {
+        /* Same backpressure rule as the OUT path: bail before alloc if no room. */
+        if (!xhci_ring_has_room(ep_ctx, 2))
+            break;
+
         u16 frame = ep_ctx->rt_next_frame;
         const u32 packet_size = ep_ctx->max_packet_size;
         struct USBIORequest *rt_io = pool_alloc(ep_ctx->memoryPool, sizeof(struct USBIORequest));

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -240,6 +240,11 @@ static void xhci_ep_schedule_next(struct ep_context *ep_ctx)
             continue;
         }
 
+        /* If the request was deferred (ring full or ep busy), stop and wait for a
+         * completion to free ring space. xhci_ep_set_idle() will re-enter here. */
+        if ((struct MinNode *)req == ep_ctx->pending_reqs.mlh_Head)
+            break;
+
         /* If the endpoint went idle immediately (e.g. zero-length or error), keep draining */
         if (xhci_ep_get_state(ep_ctx) == USB_DEV_EP_STATE_FAILED)
             return;

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -2,11 +2,14 @@
 #include <clib/exec_protos.h>
 #include <clib/utility_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
+#define UTILITY_BASE_NAME ep_ctx->udev->controller->utilityBase
 #include <proto/utility.h>
 #endif
 
-#include <compat.h>
+#include <emu_memory.h>
 #include <debug.h>
 #include <config.h>
 #include <minlist.h>

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -76,12 +76,27 @@ struct ep_context
     u32 rt_last_filled;
 
     /* RT ISO inflight accounting */
+    u32 rt_inflight_tds_target; /* target number of inflight TDs based on scheduling horizon */
     u32 rt_inflight_bytes;
 
     u32 rt_ist; /* IST decoded to microframes, cached at RT ISO start */
+
+    /* Per-endpoint RT ISO IN staging slab: created in xhci_ep_rt_iso_start for IN
+     * endpoints, object size = max_packet_size, capacity = rt_inflight_tds_target.
+     * Destroyed in xhci_ep_set_rt_stopped and as a safety net in xhci_ep_destroy_contexts. */
+    struct slab_cache iso_in_staging_slab;
+    BOOL iso_in_staging_active;
 };
 
 static void xhci_ep_clear_stop_processing(struct ep_context *ep_ctx);
+
+static void xhci_ep_destroy_rt_staging_slab(struct ep_context *ep_ctx)
+{
+    if (!ep_ctx->iso_in_staging_active)
+        return;
+    slab_cache_destroy(&ep_ctx->iso_in_staging_slab);
+    ep_ctx->iso_in_staging_active = FALSE;
+}
 
 BOOL xhci_ep_create_context(struct usb_device *udev, u8 ep_index, u32 max_packet_size, u8 max_burst, APTR memoryPool)
 {
@@ -99,7 +114,7 @@ BOOL xhci_ep_create_context(struct usb_device *udev, u8 ep_index, u32 max_packet
     ep_ctx->max_burst = max_burst;
     _NewMinList(&ep_ctx->pending_reqs);
     _NewMinList(&ep_ctx->stop_abort_reqs);
-    ep_ctx->active_tds = xhci_td_create_list(udev->controller);
+    ep_ctx->active_tds = xhci_td_create_list(udev->controller, ep_ctx);
     ep_ctx->ring = xhci_ring_alloc(udev->controller, XHCI_SEGMENTS_PER_RING, /*link_trbs*/ TRUE, /*is_event_ring*/ FALSE, ep_index, max_packet_size);
     if (!ep_ctx->active_tds || !ep_ctx->ring)
     {
@@ -147,6 +162,7 @@ void xhci_ep_destroy_contexts(struct usb_device *udev, s8 reply_code)
             }
 
             xhci_ep_clear_stop_processing(ep_ctx);
+            xhci_ep_destroy_rt_staging_slab(ep_ctx);
             ep_ctx->rt_req = NULL;
             ep_ctx->state = USB_DEV_EP_STATE_IDLE;
 
@@ -519,7 +535,7 @@ void xhci_ep_set_rt_interval(struct ep_context *ep_ctx, u8 interval)
 
 #define RT_ISO_SCHED_OFFSET_UFRAMES 32U
 #define RT_ISO_FRAME_MASK 0x7ffU /* Frame ID modulus: 2048 frames */
-#define RT_ISO_UF_MASK 0x3fffU /* microframe modulus: 2048 frames * 8 = 16384 */
+#define RT_ISO_UF_MASK 0x3fffU   /* microframe modulus: 2048 frames * 8 = 16384 */
 #define RT_UFRAME_TO_FRAME(uf) (((uf) >> 3) & RT_ISO_FRAME_MASK)
 
 /* Earliest microframe HW can accept, rounded UP to the next ESIT boundary. */
@@ -565,6 +581,16 @@ inline static void xhci_ep_rt_iso_zero_counters(struct ep_context *ep_ctx)
     ep_ctx->rt_inflight_bytes = 0;
 }
 
+/* Free a staging buffer that was allocated from this endpoint's iso_in_staging_slab.
+ * Falls back to pool_free if the slab is no longer active (edge-case teardown guard). */
+void xhci_ep_free_rt_iso_buffer(struct ep_context *ep_ctx, APTR data_buffer)
+{
+    if (!data_buffer)
+        return;
+    if (ep_ctx && ep_ctx->iso_in_staging_active)
+        slab_free(&ep_ctx->iso_in_staging_slab, data_buffer);
+}
+
 static void xhci_ep_set_rt_stopped(struct ep_context *ep_ctx)
 {
     ep_ctx->state = USB_DEV_EP_STATE_RT_ISO_STOPPED;
@@ -572,6 +598,7 @@ static void xhci_ep_set_rt_stopped(struct ep_context *ep_ctx)
     ep_ctx->rt_last_buffer = NULL;
     ep_ctx->rt_last_filled = 0;
     xhci_ep_rt_iso_zero_counters(ep_ctx);
+    xhci_ep_destroy_rt_staging_slab(ep_ctx);
 }
 
 s8 xhci_ep_rt_iso_add_handler(struct ep_context *ep_ctx, struct USBIORequest *req)
@@ -770,7 +797,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
     struct USBIORequest *template = ep_ctx->rt_template_req;
 
     u32 inflight = xhci_ep_get_active_td_count(ep_ctx);
-    while (inflight < RT_ISO_IN_TARGET_TDS)
+    while (inflight < ep_ctx->rt_inflight_tds_target)
     {
         /* Same backpressure rule as the OUT path: bail before alloc if no room. */
         if (!xhci_ring_has_room(ep_ctx, 2))
@@ -791,16 +818,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
         CopyMem(template, rt_io, sizeof(struct USBIORequest));
         rt_io->driver_private_flags = REQ_RT_ISO_CLONE;
 
-        if (packet_size <= XHCI_ISO_IN_STAGING_SIZE)
-        {
-            rt_io->data_buffer = slab_alloc(&ctrl->iso_in_staging_slab);
-            if (rt_io->data_buffer)
-                rt_io->driver_private_flags |= REQ_RT_IN_BUF_SLABBED;
-        }
-        else
-        {
-            rt_io->data_buffer = pool_alloc(ep_ctx->memoryPool, packet_size);
-        }
+        rt_io->data_buffer = slab_alloc(&ep_ctx->iso_in_staging_slab);
         if (!rt_io->data_buffer)
         {
             Kprintf("Failed to alloc RT ISO staging buffer\n");
@@ -820,10 +838,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
                      : xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE);
         if (ret != ERR_NO_ERROR)
         {
-            if (rt_io->driver_private_flags & REQ_RT_IN_BUF_SLABBED)
-                slab_free(&ctrl->iso_in_staging_slab, rt_io->data_buffer);
-            else
-                pool_free(ep_ctx->memoryPool, rt_io->data_buffer);
+            slab_free(&ep_ctx->iso_in_staging_slab, rt_io->data_buffer);
             slab_free(&ctrl->iso_clone_slab, rt_io);
             Kprintf("RT ISO submit failed %ld\n", (LONG)ret);
             break;
@@ -902,6 +917,31 @@ s8 xhci_ep_rt_iso_start(struct ep_context *ep_ctx)
     ep_ctx->rt_ist = (ist_raw & 0x8U) ? ((ist_raw & 0x7U) << 3) : (ist_raw & 0x7U);
     ep_ctx->rt_next_uframe = xhci_rt_iso_min_uf(ep_ctx);
     ep_ctx->state = USB_DEV_EP_STATE_RT_ISO_RUNNING;
+
+    const u32 uframes_per_td = ep_ctx->rt_uframes_per_esit ? (u32)ep_ctx->rt_uframes_per_esit : 1U;
+    const u32 target_uframes = RT_ISO_IN_TARGET_FRAMES * 8U;
+    ep_ctx->rt_inflight_tds_target = (target_uframes + uframes_per_td - 1U) / uframes_per_td;
+
+    /* Build the per-endpoint IN staging slab now that we know both the packet size
+     * and the target inflight depth.  OUT endpoints have no staging buffer. */
+    if (ep_ctx->rt_template_req->direction == DIRECTION_IN && ep_ctx->max_packet_size > 0)
+    {
+        slab_cache_init(&ep_ctx->iso_in_staging_slab,
+                        ep_ctx->memoryPool,
+                        ep_ctx->max_packet_size,
+                        DMA_ALIGN_MIN,
+                        ep_ctx->rt_inflight_tds_target);
+        ep_ctx->iso_in_staging_active = TRUE;
+    }
+
+    KprintfH("Starting RT ISO stream: IST=%lu uframes rt_next_uframe=%lu target_ms=%lu target_uframes=%lu uframes_per_td=%lu target_tds=%lu\n",
+             (ULONG)ep_ctx->rt_ist,
+             (ULONG)ep_ctx->rt_next_uframe,
+             (ULONG)RT_ISO_IN_TARGET_FRAMES,
+             (ULONG)target_uframes,
+             (ULONG)uframes_per_td,
+             (ULONG)ep_ctx->rt_inflight_tds_target);
+
     xhci_ep_schedule_rt_iso(ep_ctx);
     return ERR_NO_ERROR;
 }

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -634,13 +634,14 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
             break;
 
         u16 frame = ep_ctx->rt_next_frame;
-        struct USBIORequest *rt_io = pool_alloc(ep_ctx->memoryPool, sizeof(struct USBIORequest));
+        struct USBIORequest *rt_io = slab_alloc(&ep_ctx->udev->controller->iso_clone_slab);
         if (!rt_io)
         {
             Kprintf("Failed to alloc RT ISO IO req\n");
             break;
         }
         CopyMem(template, rt_io, sizeof(struct USBIORequest));
+        rt_io->driver_private_flags = REQ_RT_ISO_CLONE;
 
         struct USBBufferRequest rt_buffer_req;
         rt_buffer_req.length = prefetch_bytes;
@@ -659,7 +660,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
         if (!rt_buffer_req.data || rt_buffer_req.length == 0)
         {
             KprintfH("RT ISO hook provided no buffer/length\n");
-            pool_free(ep_ctx->memoryPool, rt_io);
+            slab_free(&ep_ctx->udev->controller->iso_clone_slab, rt_io);
             break;
         }
 
@@ -681,7 +682,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
         s8 ret = xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */);
         if (ret != ERR_NO_ERROR)
         {
-            pool_free(ep_ctx->memoryPool, rt_io);
+            slab_free(&ep_ctx->udev->controller->iso_clone_slab, rt_io);
             Kprintf("RT ISO submit failed %ld\n", (LONG)ret);
             break;
         }
@@ -711,19 +712,31 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
 
         u16 frame = ep_ctx->rt_next_frame;
         const u32 packet_size = ep_ctx->max_packet_size;
-        struct USBIORequest *rt_io = pool_alloc(ep_ctx->memoryPool, sizeof(struct USBIORequest));
+        struct xhci_ctrl *ctrl = ep_ctx->udev->controller;
+
+        struct USBIORequest *rt_io = slab_alloc(&ctrl->iso_clone_slab);
         if (!rt_io)
         {
             Kprintf("Failed to alloc RT ISO IO req\n");
             break;
         }
         CopyMem(template, rt_io, sizeof(struct USBIORequest));
+        rt_io->driver_private_flags = REQ_RT_ISO_CLONE;
 
-        rt_io->data_buffer = pool_alloc(ep_ctx->memoryPool, packet_size);
+        if (packet_size <= XHCI_ISO_IN_STAGING_SIZE)
+        {
+            rt_io->data_buffer = slab_alloc(&ctrl->iso_in_staging_slab);
+            if (rt_io->data_buffer)
+                rt_io->driver_private_flags |= REQ_RT_IN_BUF_SLABBED;
+        }
+        else
+        {
+            rt_io->data_buffer = pool_alloc(ep_ctx->memoryPool, packet_size);
+        }
         if (!rt_io->data_buffer)
         {
             Kprintf("Failed to alloc RT ISO staging buffer\n");
-            pool_free(ep_ctx->memoryPool, rt_io);
+            slab_free(&ctrl->iso_clone_slab, rt_io);
             break;
         }
         rt_io->data_buffer_length = packet_size;
@@ -738,8 +751,11 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
         s8 ret = xhci_ring_enqueue_td(ep_ctx->udev, rt_io, 0, TRUE /* RT ISO defers doorbell to per-run giveback */);
         if (ret != ERR_NO_ERROR)
         {
-            pool_free(ep_ctx->memoryPool, rt_io->data_buffer);
-            pool_free(ep_ctx->memoryPool, rt_io);
+            if (rt_io->driver_private_flags & REQ_RT_IN_BUF_SLABBED)
+                slab_free(&ctrl->iso_in_staging_slab, rt_io->data_buffer);
+            else
+                pool_free(ep_ctx->memoryPool, rt_io->data_buffer);
+            slab_free(&ctrl->iso_clone_slab, rt_io);
             Kprintf("RT ISO submit failed %ld\n", (LONG)ret);
             break;
         }

--- a/xhci.device/src/xhci/xhci-events.c
+++ b/xhci.device/src/xhci/xhci-events.c
@@ -407,9 +407,21 @@ static void ep_handle_aborting(struct usb_device *udev, struct ep_context *ep_ct
         Kprintf("Expected a TRB for slot %lu, got %lu\n", (ULONG)udev->slot_id, (ULONG)TRB_TO_SLOT_ID(flags));
         return;
     }
-    if (GET_COMP_CODE(le32(event->trans_event.transfer_len)) != COMP_STOP)
+
+    const xhci_comp_code comp = GET_COMP_CODE(le32(event->trans_event.transfer_len));
+    switch(comp)
     {
-        Kprintf("Expected a TRB with STOP, got %lu\n", (ULONG)GET_COMP_CODE(le32(event->trans_event.transfer_len)));
+        case COMP_STOP:
+            KprintfH("Transfer stopped successfully\n");
+            break;
+        case COMP_STOP_INVAL:
+            KprintfH("Transfer stopped with invalid length\n");
+            break;
+        case COMP_STOP_SHORT:
+            KprintfH("Transfer stopped after short packet\n");
+            break;
+        default:
+            Kprintf("Expected a TRB with STOP, got %lu\n", (ULONG)comp);
     }
 
     /* no state change - that is done by handle_abort_stop_ring */

--- a/xhci.device/src/xhci/xhci-events.c
+++ b/xhci.device/src/xhci/xhci-events.c
@@ -352,13 +352,16 @@ void ep_handle_rt_iso(struct USBIORequest *req, u32 act_len, struct ep_context *
         if (act_len > 0)
             xhci_ep_rt_iso_in(ep_ctx, req, act_len);
 
-        pool_free(ctrl->memoryPool, req->data_buffer);
+        if (req->driver_private_flags & REQ_RT_IN_BUF_SLABBED)
+            slab_free(&ctrl->iso_in_staging_slab, req->data_buffer);
+        else
+            pool_free(ctrl->memoryPool, req->data_buffer);
     }
     else
         xhci_ep_rt_iso_out(ep_ctx, req, act_len);
 
     /* RT ISO TDs clone IO requests; free them after completion to avoid leaks. */
-    pool_free(ctrl->memoryPool, req);
+    slab_free(&ctrl->iso_clone_slab, req);
 
     xhci_ep_schedule_rt_iso(ep_ctx);
 }

--- a/xhci.device/src/xhci/xhci-events.c
+++ b/xhci.device/src/xhci/xhci-events.c
@@ -100,7 +100,6 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
     {
         activity = TRUE;
         trb_type type = TRB_FIELD_TO_TYPE(le32(event->event_cmd.flags));
-        xhci_ring_acknowledge_event(ctrl);
 
         switch (type)
         {
@@ -167,6 +166,9 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
                     (ULONG)le32(event->generic.field[3]));
             break;
         }
+
+        /* Acknowledge only after the handler finishes reading this TRB. */
+        xhci_ring_acknowledge_event(ctrl);
     }
     return activity;
 }
@@ -258,7 +260,7 @@ static void ep_handle_default(struct usb_device *udev, struct ep_context *ep_ctx
     enum ep_state state = xhci_ep_get_state(ep_ctx);
     const u8 ep_index = xhci_ep_get_ep_index(ep_ctx);
 
-    Kprintf("No handler for endpoint %lu state %lu addr %lu\n", (ULONG)ep_index, (ULONG)state, (ULONG)udev->virtual_address);
+    Kprintf("No handler for addr %lu endpoint %lu state %lu\n", (ULONG)udev->virtual_address, (ULONG)ep_index, (ULONG)state);
     KprintfH("Event TRB: (%08lx %08lx %08lx %08lx)\n",
              (ULONG)le32(event->generic.field[0]),
              (ULONG)le32(event->generic.field[1]),
@@ -354,6 +356,9 @@ static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_conte
 
     xhci_udev_io_reply_data(udev, req, status, act_len);
     if (req->req.io_Command == CMD_REQUEST_CONTROL && comp == COMP_SHORT_TX)
+        //TODO rework this, we should just keep the TD around until the status stage completes 
+        //instead of special-casing short control transfers here and in the event handler
+        // just remove the request as replied
         xhci_ep_set_receiving_control_short(ep_ctx);
     else
         xhci_ep_set_idle(ep_ctx);

--- a/xhci.device/src/xhci/xhci-events.c
+++ b/xhci.device/src/xhci/xhci-events.c
@@ -49,7 +49,7 @@ typedef void (*ep_state_handler)(struct usb_device *udev, struct ep_context *ep_
 
 static void ep_handle_default(struct usb_device *udev, struct ep_context *ep_ctx, union xhci_trb *event);
 static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_context *ep_ctx, union xhci_trb *event);
-static void ep_handle_rt_iso(struct USBIORequest *req, ULONG act_len, struct ep_context *ep_ctx, struct usb_device *udev);
+static void ep_handle_rt_iso(struct USBIORequest *req, u32 act_len, struct ep_context *ep_ctx, struct usb_device *udev);
 static void ep_handle_receiving_control_short(struct usb_device *udev, struct ep_context *ep_ctx, union xhci_trb *event);
 static void ep_handle_aborting(struct usb_device *udev, struct ep_context *ep_ctx, union xhci_trb *event);
 
@@ -69,19 +69,20 @@ static const ep_state_handler ep_state_dispatch[] = {
  */
 static void dispatch_ep_event(struct usb_device *udev, union xhci_trb *event)
 {
-    UWORD ep_index = TRB_TO_EP_INDEX(le32(event->trans_event.flags));
+    const u32 flags = le32(event->trans_event.flags);
+    const u8 ep_index = TRB_TO_EP_INDEX(flags);
 
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
     if (!ep_ctx)
     {
-        KprintfH("No ep context for addr %ld ep %ld\n", (LONG)udev->virtual_address, (LONG)ep_index);
+        KprintfH("No ep context for addr %lu ep %lu\n", (ULONG)udev->virtual_address, (ULONG)ep_index);
         return;
     }
     enum ep_state state = xhci_ep_get_state(ep_ctx);
 
     if (ep_state_dispatch[state])
     {
-        KprintfH("addr %ld EP %ld state %ld -> handling event\n", udev->virtual_address, (LONG)ep_index, (LONG)state);
+        KprintfH("addr %lu EP %lu state %lu -> handling event\n", (ULONG)udev->virtual_address, (ULONG)ep_index, (ULONG)state);
         ep_state_handler handler = ep_state_dispatch[state];
         handler(udev, ep_ctx, event);
     }
@@ -105,22 +106,23 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
         {
         case TRB_TRANSFER:
         {
-            int slot = TRB_TO_SLOT_ID(le32(event->trans_event.flags));
-            KprintfH("Transfer Event TRB detected: slot %ld ep %ld (%08lx %08lx %08lx %08lx)\n",
-                     (LONG)slot,
-                     (LONG)TRB_TO_EP_INDEX(le32(event->trans_event.flags)),
-                     (LONG)le32(event->generic.field[0]),
-                     (LONG)le32(event->generic.field[1]),
-                     (LONG)le32(event->generic.field[2]),
-                     (LONG)le32(event->generic.field[3]));
+            const u32 flags = le32(event->trans_event.flags);
+            const u32 slot = TRB_TO_SLOT_ID(flags);
+            KprintfH("Transfer Event TRB detected: slot %lu ep %lu (%08lx %08lx %08lx %08lx)\n",
+                     (ULONG)slot,
+                     (ULONG)TRB_TO_EP_INDEX(flags),
+                     (ULONG)le32(event->generic.field[0]),
+                     (ULONG)le32(event->generic.field[1]),
+                     (ULONG)le32(event->generic.field[2]),
+                     (ULONG)le32(event->generic.field[3]));
 
             struct usb_device *udev = ctrl->devices_by_slot_id[slot];
             if (!udev)
             {
-                Kprintf("No usb_device for slot %ld\n", slot);
+                Kprintf("No usb_device for slot %lu\n", (ULONG)slot);
                 break;
             }
-            KprintfH("USB device addr %ld on slot %ld\n", (LONG)udev->virtual_address, (LONG)slot);
+            KprintfH("USB device addr %lu on slot %lu\n", (ULONG)udev->virtual_address, (ULONG)slot);
 
             dispatch_ep_event(udev, event);
         }
@@ -133,10 +135,13 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
         case TRB_PORT_STATUS:
         {
 #ifdef DEBUG_HIGH
-            const ULONG port_field = (ULONG)le32(event->generic.field[0]);
-            const ULONG flags = (ULONG)le32(event->generic.field[3]);
-            const ULONG port_id = (ULONG)GET_PORT_ID(port_field);
-            ULONG portsc = 0;
+            const u32 port_field = le32(event->generic.field[0]);
+            const u32 field1 = le32(event->generic.field[1]);
+            const u32 field2 = le32(event->generic.field[2]);
+            const u32 flags = le32(event->generic.field[3]);
+            const u32 port_id = GET_PORT_ID(port_field);
+            const u32 usbsts = mmio_read32(&ctrl->hcor->or_usbsts);
+            u32 portsc = 0;
 
             if (port_id > 0 && port_id <= MAX_HC_PORTS)
                 portsc = mmio_read32(&ctrl->hcor->portregs[port_id - 1].or_portsc);
@@ -144,17 +149,17 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
             Kprintf("Port Status Change Event port=%lu portsc=%08lx usbsts=%08lx trb=(%08lx %08lx %08lx %08lx)\n",
                     port_id,
                     portsc,
-                    (ULONG)mmio_read32(&ctrl->hcor->or_usbsts),
+                    usbsts,
                     port_field,
-                    (ULONG)le32(event->generic.field[1]),
-                    (ULONG)le32(event->generic.field[2]),
+                    field1,
+                    field2,
                     flags);
 #endif
             xhci_roothub_complete_int_request(ctrl->root_hub);
             break;
         }
         default:
-            Kprintf("Unexpected XHCI event type %ld, skipping... (%08lx %08lx %08lx %08lx)\n",
+            Kprintf("Unexpected XHCI event type %lu, skipping... (%08lx %08lx %08lx %08lx)\n",
                     (ULONG)type,
                     (ULONG)le32(event->generic.field[0]),
                     (ULONG)le32(event->generic.field[1]),
@@ -168,27 +173,27 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
 
 void xhci_process_event_timeouts(struct xhci_ctrl *ctrl)
 {
-    for (int i = 0; i < USB_MAX_ADDRESS; i++)
+    for (u32 i = 0; i < USB_MAX_ADDRESS; i++)
     {
         struct usb_device *udev = ctrl->devices_by_virtual_address[i];
         if (!udev)
             continue;
 
-        for (int ep_index = 0; ep_index < USB_MAX_ENDPOINT_CONTEXTS; ep_index++)
+        for (u8 ep_index = 0; ep_index < USB_MAX_ENDPOINT_CONTEXTS; ep_index++)
         {
             struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
             if (ep_ctx && xhci_ep_is_expired(ep_ctx))
             {
-                KprintfH("XHCI TD timeout on slot %ld ep %ld\n", (LONG)udev->slot_id, (LONG)ep_index);
+                KprintfH("XHCI TD timeout on slot %lu ep %lu\n", (ULONG)udev->slot_id, (ULONG)ep_index);
                 xhci_ep_request_timeout_recovery(ep_ctx);
             }
         }
     }
 }
 
-inline static ULONG translate_status(xhci_comp_code comp)
+inline static s8 translate_status(xhci_comp_code comp)
 {
-    ULONG status;
+    s8 status;
 
     switch (comp)
     {
@@ -229,7 +234,7 @@ inline static ULONG translate_status(xhci_comp_code comp)
         status = ERR_TIMEOUT;
         break;
     default:
-        Kprintf("Unhandled completion code %ld\n", (LONG)comp);
+        Kprintf("Unhandled completion code %lu\n", (ULONG)comp);
         status = ERR_HCI_ERROR;
     }
 
@@ -247,8 +252,9 @@ static void ep_handle_default(struct usb_device *udev, struct ep_context *ep_ctx
 {
     (void)event;
     enum ep_state state = xhci_ep_get_state(ep_ctx);
-    int ep_index = xhci_ep_get_ep_index(ep_ctx);
-    Kprintf("No handler for endpoint %ld state %ld addr %ld\n", ep_index, state, udev->virtual_address);
+    const u8 ep_index = xhci_ep_get_ep_index(ep_ctx);
+
+    Kprintf("No handler for endpoint %lu state %lu addr %lu\n", (ULONG)ep_index, (ULONG)state, (ULONG)udev->virtual_address);
     KprintfH("Event TRB: (%08lx %08lx %08lx %08lx)\n",
              (ULONG)le32(event->generic.field[0]),
              (ULONG)le32(event->generic.field[1]),
@@ -259,15 +265,16 @@ static void ep_handle_default(struct usb_device *udev, struct ep_context *ep_ctx
 static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_context *ep_ctx, union xhci_trb *event)
 {
 
-    u32 flags = le32(event->trans_event.flags);
-    int ep_index = TRB_TO_EP_INDEX(flags);
-    u64 trb_addr = le64(event->trans_event.buffer);
-    xhci_comp_code comp = GET_COMP_CODE(le32(event->trans_event.transfer_len));
+    const u32 flags = le32(event->trans_event.flags);
+    const u8 ep_index = TRB_TO_EP_INDEX(flags);
+    const u64 trb_addr = le64(event->trans_event.buffer);
+    const u32 transfer_len = le32(event->trans_event.transfer_len);
+    const xhci_comp_code comp = GET_COMP_CODE(transfer_len);
 
 #ifdef DEBUG_CONTEXT
     KprintfH("event flags=%08lx xfer_len=%08lx buf=%08lx%08lx\n",
              (ULONG)flags,
-             (ULONG)le32(event->trans_event.transfer_len),
+             (ULONG)transfer_len,
              (ULONG)u64_hi32(trb_addr),
              (ULONG)u64_lo32(trb_addr));
     xhci_dump_slot_ctx("[xhci-event] ep_handle_receiving_generic:", udev, FALSE);
@@ -278,11 +285,11 @@ static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_conte
     if ((comp == COMP_UNDERRUN || comp == COMP_OVERRUN) && trb_addr == 0)
     {
         enum ep_state state = xhci_ep_get_state(ep_ctx);
-        Kprintf("Ring %s on addr %ld EP %ld state=%ld\n",
+        Kprintf("Ring %s on addr %lu EP %lu state=%lu\n",
                 (comp == COMP_UNDERRUN) ? "underrun" : "overrun",
-                (LONG)udev->virtual_address,
-                (LONG)ep_index,
-                (LONG)state);
+                (ULONG)udev->virtual_address,
+                (ULONG)ep_index,
+                (ULONG)state);
 
         if (state == USB_DEV_EP_STATE_RT_ISO_RUNNING)
             xhci_ep_schedule_rt_iso(ep_ctx);
@@ -290,15 +297,15 @@ static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_conte
         return;
     }
 
-    struct USBIORequest *req = xhci_ep_get_by_trb(ep_ctx, trb_addr);
+    struct USBIORequest *req = xhci_ep_get_by_trb(ep_ctx, (dma_addr_t)trb_addr);
     if (!req)
     {
-        Kprintf("No TD found for TRB %08lx%08lx  %08lx %08lx on EP %ld\n",
-                (ULONG)u64_hi32(trb_addr), (ULONG)u64_lo32(trb_addr), (ULONG)flags, (ULONG)le32(event->trans_event.transfer_len), (LONG)ep_index);
+        Kprintf("No TD found for TRB %08lx%08lx  %08lx %08lx on EP %lu\n",
+            (ULONG)u64_hi32(trb_addr), (ULONG)u64_lo32(trb_addr), (ULONG)flags, (ULONG)transfer_len, (ULONG)ep_index);
         return;
     }
 
-    ULONG act_len = req->data_buffer_length - EVENT_TRB_LEN(le32(event->trans_event.transfer_len));
+        u32 act_len = req->data_buffer_length - EVENT_TRB_LEN(transfer_len);
 
     BOOL is_rt_iso = req->req.io_Command == CMD_REGISTER_ISOCHRONOUS_HOOKS;
     if (is_rt_iso)
@@ -310,8 +317,8 @@ static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_conte
         return;
     }
 
-    ULONG status = translate_status(comp);
-    KprintfH("result status=%ld act_len=%ld comp=%ld\n", (LONG)status, (LONG)act_len, (LONG)comp);
+    s8 status = translate_status(comp);
+    KprintfH("result status=%ld act_len=%lu comp=%lu\n", (LONG)status, (ULONG)act_len, (ULONG)comp);
 
     /* Flag short IN transfers as runts unless explicitly allowed or expected (control). */
     if (status == ERR_NO_ERROR && act_len < req->data_buffer_length &&
@@ -336,7 +343,7 @@ static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_conte
         xhci_ep_set_idle(ep_ctx);
 }
 
-void ep_handle_rt_iso(struct USBIORequest *req, ULONG act_len, struct ep_context *ep_ctx, struct usb_device *udev)
+void ep_handle_rt_iso(struct USBIORequest *req, u32 act_len, struct ep_context *ep_ctx, struct usb_device *udev)
 {
     struct xhci_ctrl *ctrl = udev->controller;
 
@@ -378,12 +385,12 @@ static void ep_handle_aborting(struct usb_device *udev, struct ep_context *ep_ct
     u32 flags = le32(event->trans_event.flags);
     if (TRB_TO_SLOT_ID(flags) != udev->slot_id)
     {
-        Kprintf("Expected a TRB for slot %ld, got %ld\n", udev->slot_id, TRB_TO_SLOT_ID(flags));
+        Kprintf("Expected a TRB for slot %lu, got %lu\n", (ULONG)udev->slot_id, (ULONG)TRB_TO_SLOT_ID(flags));
         return;
     }
     if (GET_COMP_CODE(le32(event->trans_event.transfer_len)) != COMP_STOP)
     {
-        Kprintf("Expected a TRB with STOP, got %ld\n", GET_COMP_CODE(le32(event->trans_event.transfer_len)));
+        Kprintf("Expected a TRB with STOP, got %lu\n", (ULONG)GET_COMP_CODE(le32(event->trans_event.transfer_len)));
     }
 
     /* no state change - that is done by handle_abort_stop_ring */

--- a/xhci.device/src/xhci/xhci-events.c
+++ b/xhci.device/src/xhci/xhci-events.c
@@ -373,10 +373,7 @@ void ep_handle_rt_iso(struct USBIORequest *req, u32 act_len, u16 rt_frame, struc
         if (act_len > 0)
             xhci_ep_rt_iso_in(ep_ctx, req, act_len, rt_frame);
 
-        if (req->driver_private_flags & REQ_RT_IN_BUF_SLABBED)
-            slab_free(&ctrl->iso_in_staging_slab, req->data_buffer);
-        else
-            pool_free(ctrl->memoryPool, req->data_buffer);
+        xhci_ep_free_rt_iso_buffer(ep_ctx, req->data_buffer);
     }
     else
         xhci_ep_rt_iso_out(ep_ctx, req, act_len, rt_frame);

--- a/xhci.device/src/xhci/xhci-events.c
+++ b/xhci.device/src/xhci/xhci-events.c
@@ -49,7 +49,7 @@ typedef void (*ep_state_handler)(struct usb_device *udev, struct ep_context *ep_
 
 static void ep_handle_default(struct usb_device *udev, struct ep_context *ep_ctx, union xhci_trb *event);
 static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_context *ep_ctx, union xhci_trb *event);
-static void ep_handle_rt_iso(struct USBIORequest *req, u32 act_len, struct ep_context *ep_ctx, struct usb_device *udev);
+static void ep_handle_rt_iso(struct USBIORequest *req, u32 act_len, u16 rt_frame, struct ep_context *ep_ctx, struct usb_device *udev);
 static void ep_handle_receiving_control_short(struct usb_device *udev, struct ep_context *ep_ctx, union xhci_trb *event);
 static void ep_handle_aborting(struct usb_device *udev, struct ep_context *ep_ctx, union xhci_trb *event);
 
@@ -202,6 +202,11 @@ inline static s8 translate_status(xhci_comp_code comp)
     case COMP_SHORT_TX:
         status = ERR_NO_ERROR;
         break;
+    case COMP_UNDERRUN:
+    case COMP_OVERRUN:
+    case COMP_MISSED_INT:
+        status = ERR_NO_ERROR;
+        break;
     case COMP_STALL:
         KprintfH("Device stalled\n");
         status = ERR_DEVICE_STALL;
@@ -220,7 +225,6 @@ inline static s8 translate_status(xhci_comp_code comp)
         KprintfH("Babble detected\n");
         status = ERR_DEVICE_BABBLE;
         break;
-        // TODO more codes, e.g. underrun/overrun
     case COMP_BUFF_OVER:
         KprintfH("Isoc buffer overrun\n");
         status = ERR_ISOC_OVERRUN;
@@ -281,18 +285,20 @@ static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_conte
     xhci_dump_ep_ctx("[xhci-event] ep_handle_receiving_generic:", udev, ep_index);
 #endif
 
-    /* Isoch OUT rings signal underrun/overrun with null TRB pointers. Do not treat those as lost TDs. */
-    if ((comp == COMP_UNDERRUN || comp == COMP_OVERRUN) && trb_addr == 0)
+    /* RT ISO ring status events are controller/schedule feedback, not TD completion. */
+    if ((comp == COMP_UNDERRUN || comp == COMP_OVERRUN) &&
+        xhci_ep_get_state(ep_ctx) == USB_DEV_EP_STATE_RT_ISO_RUNNING)
     {
-        enum ep_state state = xhci_ep_get_state(ep_ctx);
-        Kprintf("Ring %s on addr %lu EP %lu state=%lu\n",
+        Kprintf("RT ISO ring %s addr=%lu ep=%lu flags=0x%08lx xfer=0x%08lx trb=%08lx%08lx\n",
                 (comp == COMP_UNDERRUN) ? "underrun" : "overrun",
                 (ULONG)udev->virtual_address,
                 (ULONG)ep_index,
-                (ULONG)state);
+                (ULONG)flags,
+                (ULONG)transfer_len,
+                (ULONG)u64_hi32(trb_addr),
+                (ULONG)u64_lo32(trb_addr));
 
-        if (state == USB_DEV_EP_STATE_RT_ISO_RUNNING)
-            xhci_ep_schedule_rt_iso(ep_ctx);
+        xhci_ep_schedule_rt_iso(ep_ctx);
 
         return;
     }
@@ -301,19 +307,29 @@ static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_conte
     if (!req)
     {
         Kprintf("No TD found for TRB %08lx%08lx  %08lx %08lx on EP %lu\n",
-            (ULONG)u64_hi32(trb_addr), (ULONG)u64_lo32(trb_addr), (ULONG)flags, (ULONG)transfer_len, (ULONG)ep_index);
+                (ULONG)u64_hi32(trb_addr), (ULONG)u64_lo32(trb_addr), (ULONG)flags, (ULONG)transfer_len, (ULONG)ep_index);
         return;
     }
 
-        u32 act_len = req->data_buffer_length - EVENT_TRB_LEN(transfer_len);
+    u32 act_len = req->data_buffer_length - EVENT_TRB_LEN(transfer_len);
 
     BOOL is_rt_iso = req->req.io_Command == CMD_REGISTER_ISOCHRONOUS_HOOKS;
     if (is_rt_iso)
     {
-        KprintfH("RT ISO complete dir=%s act_len=%lu\n",
-                 req->direction == DIRECTION_IN ? "IN" : "OUT",
-                 (ULONG)act_len);
-        ep_handle_rt_iso(req, act_len, ep_ctx, udev);
+        /* Recover the frame number from field3 of the completing TRB; we wrote it there at submit time. */
+        const struct xhci_generic_trb *completed_trb = (const struct xhci_generic_trb *)(uintptr_t)trb_addr;
+        u16 rt_frame = GET_TRB_FRAME_ID(le32(completed_trb->field[3]));
+
+        if (comp == COMP_MISSED_INT)
+            Kprintf("RT ISO missed-service addr=%lu ep=%lu frame=%lu len=%lu trb=%08lx%08lx\n",
+                    (ULONG)udev->virtual_address,
+                    (ULONG)ep_index,
+                    (ULONG)rt_frame,
+                    (ULONG)req->data_buffer_length,
+                    (ULONG)u64_hi32(trb_addr),
+                    (ULONG)u64_lo32(trb_addr));
+
+        ep_handle_rt_iso(req, act_len, rt_frame, ep_ctx, udev);
         return;
     }
 
@@ -343,14 +359,14 @@ static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_conte
         xhci_ep_set_idle(ep_ctx);
 }
 
-void ep_handle_rt_iso(struct USBIORequest *req, u32 act_len, struct ep_context *ep_ctx, struct usb_device *udev)
+void ep_handle_rt_iso(struct USBIORequest *req, u32 act_len, u16 rt_frame, struct ep_context *ep_ctx, struct usb_device *udev)
 {
     struct xhci_ctrl *ctrl = udev->controller;
 
     if (req->direction == DIRECTION_IN)
     {
         if (act_len > 0)
-            xhci_ep_rt_iso_in(ep_ctx, req, act_len);
+            xhci_ep_rt_iso_in(ep_ctx, req, act_len, rt_frame);
 
         if (req->driver_private_flags & REQ_RT_IN_BUF_SLABBED)
             slab_free(&ctrl->iso_in_staging_slab, req->data_buffer);
@@ -358,7 +374,7 @@ void ep_handle_rt_iso(struct USBIORequest *req, u32 act_len, struct ep_context *
             pool_free(ctrl->memoryPool, req->data_buffer);
     }
     else
-        xhci_ep_rt_iso_out(ep_ctx, req, act_len);
+        xhci_ep_rt_iso_out(ep_ctx, req, act_len, rt_frame);
 
     /* RT ISO TDs clone IO requests; free them after completion to avoid leaks. */
     slab_free(&ctrl->iso_clone_slab, req);

--- a/xhci.device/src/xhci/xhci-events.c
+++ b/xhci.device/src/xhci/xhci-events.c
@@ -170,6 +170,7 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
         /* Acknowledge only after the handler finishes reading this TRB. */
         xhci_ring_acknowledge_event(ctrl);
     }
+
     return activity;
 }
 

--- a/xhci.device/src/xhci/xhci-events.c
+++ b/xhci.device/src/xhci/xhci-events.c
@@ -19,10 +19,10 @@
 
 #include <debug.h>
 
-#include <emu_bits.h>
-#include <emu_byteorder.h>
-#include <emu_iomem.h>
-#include <emu_memory.h>
+#include <bits.h>
+#include <byteorder.h>
+#include <iomem.h>
+#include <memory.h>
 
 #include <devices/hcd_api.h>
 #include <xhci/xhci.h>
@@ -69,7 +69,7 @@ static const ep_state_handler ep_state_dispatch[] = {
  */
 static void dispatch_ep_event(struct usb_device *udev, union xhci_trb *event)
 {
-    UWORD ep_index = TRB_TO_EP_INDEX(LE32(event->trans_event.flags));
+    UWORD ep_index = TRB_TO_EP_INDEX(le32(event->trans_event.flags));
 
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
     if (!ep_ctx)
@@ -98,21 +98,21 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
     while ((event = xhci_ring_get_event_trb(ctrl->event_ring)))
     {
         activity = TRUE;
-        trb_type type = TRB_FIELD_TO_TYPE(LE32(event->event_cmd.flags));
+        trb_type type = TRB_FIELD_TO_TYPE(le32(event->event_cmd.flags));
         xhci_ring_acknowledge_event(ctrl);
 
         switch (type)
         {
         case TRB_TRANSFER:
         {
-            int slot = TRB_TO_SLOT_ID(LE32(event->trans_event.flags));
+            int slot = TRB_TO_SLOT_ID(le32(event->trans_event.flags));
             KprintfH("Transfer Event TRB detected: slot %ld ep %ld (%08lx %08lx %08lx %08lx)\n",
                      (LONG)slot,
-                     (LONG)TRB_TO_EP_INDEX(LE32(event->trans_event.flags)),
-                     (LONG)LE32(event->generic.field[0]),
-                     (LONG)LE32(event->generic.field[1]),
-                     (LONG)LE32(event->generic.field[2]),
-                     (LONG)LE32(event->generic.field[3]));
+                     (LONG)TRB_TO_EP_INDEX(le32(event->trans_event.flags)),
+                     (LONG)le32(event->generic.field[0]),
+                     (LONG)le32(event->generic.field[1]),
+                     (LONG)le32(event->generic.field[2]),
+                     (LONG)le32(event->generic.field[3]));
 
             struct usb_device *udev = ctrl->devices_by_slot_id[slot];
             if (!udev)
@@ -133,21 +133,21 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
         case TRB_PORT_STATUS:
         {
 #ifdef DEBUG_HIGH
-            const ULONG port_field = (ULONG)LE32(event->generic.field[0]);
-            const ULONG flags = (ULONG)LE32(event->generic.field[3]);
+            const ULONG port_field = (ULONG)le32(event->generic.field[0]);
+            const ULONG flags = (ULONG)le32(event->generic.field[3]);
             const ULONG port_id = (ULONG)GET_PORT_ID(port_field);
             ULONG portsc = 0;
 
             if (port_id > 0 && port_id <= MAX_HC_PORTS)
-                portsc = readl(&ctrl->hcor->portregs[port_id - 1].or_portsc);
+                portsc = mmio_read32(&ctrl->hcor->portregs[port_id - 1].or_portsc);
 
             Kprintf("Port Status Change Event port=%lu portsc=%08lx usbsts=%08lx trb=(%08lx %08lx %08lx %08lx)\n",
                     port_id,
                     portsc,
-                    (ULONG)readl(&ctrl->hcor->or_usbsts),
+                    (ULONG)mmio_read32(&ctrl->hcor->or_usbsts),
                     port_field,
-                    (ULONG)LE32(event->generic.field[1]),
-                    (ULONG)LE32(event->generic.field[2]),
+                    (ULONG)le32(event->generic.field[1]),
+                    (ULONG)le32(event->generic.field[2]),
                     flags);
 #endif
             xhci_roothub_complete_int_request(ctrl->root_hub);
@@ -156,10 +156,10 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
         default:
             Kprintf("Unexpected XHCI event type %ld, skipping... (%08lx %08lx %08lx %08lx)\n",
                     (ULONG)type,
-                    (ULONG)LE32(event->generic.field[0]),
-                    (ULONG)LE32(event->generic.field[1]),
-                    (ULONG)LE32(event->generic.field[2]),
-                    (ULONG)LE32(event->generic.field[3]));
+                    (ULONG)le32(event->generic.field[0]),
+                    (ULONG)le32(event->generic.field[1]),
+                    (ULONG)le32(event->generic.field[2]),
+                    (ULONG)le32(event->generic.field[3]));
             break;
         }
     }
@@ -250,26 +250,26 @@ static void ep_handle_default(struct usb_device *udev, struct ep_context *ep_ctx
     int ep_index = xhci_ep_get_ep_index(ep_ctx);
     Kprintf("No handler for endpoint %ld state %ld addr %ld\n", ep_index, state, udev->virtual_address);
     KprintfH("Event TRB: (%08lx %08lx %08lx %08lx)\n",
-             (ULONG)LE32(event->generic.field[0]),
-             (ULONG)LE32(event->generic.field[1]),
-             (ULONG)LE32(event->generic.field[2]),
-             (ULONG)LE32(event->generic.field[3]));
+             (ULONG)le32(event->generic.field[0]),
+             (ULONG)le32(event->generic.field[1]),
+             (ULONG)le32(event->generic.field[2]),
+             (ULONG)le32(event->generic.field[3]));
 }
 
 static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_context *ep_ctx, union xhci_trb *event)
 {
 
-    u32 flags = LE32(event->trans_event.flags);
+    u32 flags = le32(event->trans_event.flags);
     int ep_index = TRB_TO_EP_INDEX(flags);
-    u64 trb_addr = LE64(event->trans_event.buffer);
-    xhci_comp_code comp = GET_COMP_CODE(LE32(event->trans_event.transfer_len));
+    u64 trb_addr = le64(event->trans_event.buffer);
+    xhci_comp_code comp = GET_COMP_CODE(le32(event->trans_event.transfer_len));
 
 #ifdef DEBUG_CONTEXT
     KprintfH("event flags=%08lx xfer_len=%08lx buf=%08lx%08lx\n",
              (ULONG)flags,
-             (ULONG)LE32(event->trans_event.transfer_len),
-             (ULONG)upper_32_bits(trb_addr),
-             (ULONG)lower_32_bits(trb_addr));
+             (ULONG)le32(event->trans_event.transfer_len),
+             (ULONG)u64_hi32(trb_addr),
+             (ULONG)u64_lo32(trb_addr));
     xhci_dump_slot_ctx("[xhci-event] ep_handle_receiving_generic:", udev, FALSE);
     xhci_dump_ep_ctx("[xhci-event] ep_handle_receiving_generic:", udev, ep_index);
 #endif
@@ -294,11 +294,11 @@ static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_conte
     if (!req)
     {
         Kprintf("No TD found for TRB %08lx%08lx  %08lx %08lx on EP %ld\n",
-                (ULONG)upper_32_bits(trb_addr), (ULONG)lower_32_bits(trb_addr), (ULONG)flags, (ULONG)LE32(event->trans_event.transfer_len), (LONG)ep_index);
+                (ULONG)u64_hi32(trb_addr), (ULONG)u64_lo32(trb_addr), (ULONG)flags, (ULONG)le32(event->trans_event.transfer_len), (LONG)ep_index);
         return;
     }
 
-    ULONG act_len = req->data_buffer_length - EVENT_TRB_LEN(LE32(event->trans_event.transfer_len));
+    ULONG act_len = req->data_buffer_length - EVENT_TRB_LEN(le32(event->trans_event.transfer_len));
 
     BOOL is_rt_iso = req->req.io_Command == CMD_REGISTER_ISOCHRONOUS_HOOKS;
     if (is_rt_iso)
@@ -345,13 +345,13 @@ void ep_handle_rt_iso(struct USBIORequest *req, ULONG act_len, struct ep_context
         if (act_len > 0)
             xhci_ep_rt_iso_in(ep_ctx, req, act_len);
 
-        FreeVecPooled(ctrl->memoryPool, req->data_buffer);
+        pool_free(ctrl->memoryPool, req->data_buffer);
     }
     else
         xhci_ep_rt_iso_out(ep_ctx, req, act_len);
 
     /* RT ISO TDs clone IO requests; free them after completion to avoid leaks. */
-    FreeVecPooled(ctrl->memoryPool, req);
+    pool_free(ctrl->memoryPool, req);
 
     xhci_ep_schedule_rt_iso(ep_ctx);
 }
@@ -364,8 +364,8 @@ static void ep_handle_receiving_control_short(struct usb_device *udev, struct ep
 
     /* Short data stage, clear up additional status stage event */
     KprintfH("short-tx status event flags=%08lx status=%08lx\n",
-             (ULONG)LE32(event->generic.field[3]),
-             (ULONG)LE32(event->generic.field[2]));
+             (ULONG)le32(event->generic.field[3]),
+             (ULONG)le32(event->generic.field[2]));
 
     // no need to confirm slot and ep as this is done by event handler
     xhci_ep_set_idle(ep_ctx);
@@ -375,15 +375,15 @@ static void ep_handle_aborting(struct usb_device *udev, struct ep_context *ep_ct
 {
     (void)ep_ctx;
 
-    u32 flags = LE32(event->trans_event.flags);
+    u32 flags = le32(event->trans_event.flags);
     if (TRB_TO_SLOT_ID(flags) != udev->slot_id)
     {
         Kprintf("Expected a TRB for slot %ld, got %ld\n", udev->slot_id, TRB_TO_SLOT_ID(flags));
         return;
     }
-    if (GET_COMP_CODE(LE32(event->trans_event.transfer_len)) != COMP_STOP)
+    if (GET_COMP_CODE(le32(event->trans_event.transfer_len)) != COMP_STOP)
     {
-        Kprintf("Expected a TRB with STOP, got %ld\n", GET_COMP_CODE(LE32(event->trans_event.transfer_len)));
+        Kprintf("Expected a TRB with STOP, got %ld\n", GET_COMP_CODE(le32(event->trans_event.transfer_len)));
     }
 
     /* no state change - that is done by handle_abort_stop_ring */

--- a/xhci.device/src/xhci/xhci-events.c
+++ b/xhci.device/src/xhci/xhci-events.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * Based on xhci-ring.c from uboot
  * USB HOST XHCI Controller stack

--- a/xhci.device/src/xhci/xhci-events.c
+++ b/xhci.device/src/xhci/xhci-events.c
@@ -14,13 +14,15 @@
  *	    Vikas Sajjan <vikas.sajjan@samsung.com>
  */
 #ifdef __INTELLISENSE__
-#include <clib/utility_protos.h>
 #else
-#include <proto/utility.h>
 #endif
 
-#include <compat.h>
 #include <debug.h>
+
+#include <emu_bits.h>
+#include <emu_byteorder.h>
+#include <emu_iomem.h>
+#include <emu_memory.h>
 
 #include <devices/hcd_api.h>
 #include <xhci/xhci.h>

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -14,6 +14,7 @@
  */
 
 #include <debug.h>
+#include <emu_memory.h>
 
 #include <xhci/xhci-ring.h>
 

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -868,14 +868,14 @@ inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring,
 						io->req.io_Command == CMD_REQUEST_ISOCHRONOUS;
 
 	const u32 length = io->data_buffer_length;
-	const u32 isp_for_in = (io->direction == DIRECTION_IN) ? TRB_ISP : 0;
+	const u32 isp_for_in = (io->direction == DIRECTION_IN && !is_iso) ? TRB_ISP : 0;
+
 	/* xHCI 4.11.2.3: only the first TRB in an ISO TD carries the ISOC type and
 	 * iso-specific bits (Frame ID/SIA, TBC, TLBPC). Chain TRBs are NORMAL.
-	 * ISP applies to both ISOC and NORMAL TRBs for IN endpoints. */
+	 */
 	const u32 first_trb_type_bits = (is_iso ? (TRB_TYPE(TRB_ISOC) | iso_extra_bits)
-											: TRB_TYPE(TRB_NORMAL)) |
-									isp_for_in;
-	const u32 chain_trb_type_bits = TRB_TYPE(TRB_NORMAL) | isp_for_in;
+											: TRB_TYPE(TRB_NORMAL));
+	const u32 chain_trb_type_bits = TRB_TYPE(TRB_NORMAL); /* no ISP on chain TRBs */
 
 	u32 running_total = 0;
 	u32 td_trb_index = 0;
@@ -913,7 +913,10 @@ inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring,
 		 * Chain all the TRBs together; clear the chain bit in the last
 		 * TRB to indicate it's the last TRB in the chain.
 		 */
-		field3 |= (num_trbs > 1) ? TRB_CHAIN : TRB_IOC;
+		if (num_trbs > 1)
+			field3 |= TRB_CHAIN | isp_for_in;
+		else
+			field3 |= TRB_IOC;
 
 		/* Set the TRB length, TD size, and interrupter fields. */
 		u32 remainder = xhci_td_remainder(running_total, trb_buff_len,

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -672,6 +672,16 @@ inline static BOOL ring_has_room(struct xhci_ring *ring, struct ep_context *ep_c
 	return xhci_ep_get_active_trb_count(ep_ctx) + needed <= capacity;
 }
 
+BOOL xhci_ring_has_room(struct ep_context *ep_ctx, u32 needed_trbs)
+{
+	if (!ep_ctx)
+		return FALSE;
+	struct xhci_ring *ring = xhci_ep_get_ring(ep_ctx);
+	if (!ring)
+		return FALSE;
+	return ring_has_room(ring, ep_ctx, needed_trbs);
+}
+
 inline static void prime_first_trb(struct xhci_generic_trb *start_trb)
 {
 	start_trb->field[3] ^= le32(TRB_CYCLE);
@@ -715,7 +725,7 @@ inline static dma_addr_t xhci_dma_map(struct xhci_ctrl *ctrl, struct USBIOReques
 	if (!ctrl || !ctrl->memoryPool || !addr || size == 0)
 		return (dma_addr_t)addr;
 
-	if (likely(addr > (APTR)0x1FFFFF && (((uintptr_t)addr & DMA_ALIGN_MIN_MASK) == 0)))
+	if (unlikely(addr > (APTR)0x1FFFFF && (((uintptr_t)addr & DMA_ALIGN_MIN_MASK) == 0)))
 	{
 		xhci_flush_cache(addr, size);
 		return (dma_addr_t)addr;

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * USB HOST XHCI Controller stack
  *

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -14,7 +14,7 @@
  */
 
 #include <debug.h>
-#include <emu_memory.h>
+#include <memory.h>
 
 #include <xhci/xhci-ring.h>
 
@@ -34,6 +34,17 @@
 #undef KprintfH
 #define KprintfH(fmt, ...) PrintPistorm("[xhci-ring] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
+
+static inline void xhci_copy_to_bounce_buffer(CONST_APTR src, APTR dst, ULONG size)
+{
+	if ((((ULONG)src | (ULONG)dst | size) & (sizeof(ULONG) - 1)) == 0)
+	{
+		CopyMemQuick((ULONG *)src, (ULONG *)dst, size);
+		return;
+	}
+
+	CopyMem(src, dst, size);
+}
 
 struct xhci_segment
 {
@@ -73,10 +84,10 @@ struct xhci_ring
  */
 static void xhci_segment_free(struct xhci_ctrl *ctrl, struct xhci_segment *seg)
 {
-	memalign_free(ctrl->memoryPool, seg->trbs);
+	dma_free(ctrl->memoryPool, seg->trbs);
 	seg->trbs = NULL;
 
-	FreeVecPooled(ctrl->memoryPool, seg);
+	pool_free(ctrl->memoryPool, seg);
 }
 
 /**
@@ -103,7 +114,7 @@ void xhci_ring_free(struct xhci_ctrl *ctrl, struct xhci_ring *ring)
 	}
 	xhci_segment_free(ctrl, first_seg);
 
-	FreeVecPooled(ctrl->memoryPool, ring);
+	pool_free(ctrl->memoryPool, ring);
 }
 
 /**
@@ -126,16 +137,16 @@ static void xhci_link_segments(struct xhci_segment *prev,
 	if (link_trbs)
 	{
 		prev->trbs[TRBS_PER_SEGMENT - 1].link.segment_ptr =
-			LE64((dma_addr_t)next->trbs);
+			le64((dma_addr_t)next->trbs);
 
 		/*
 		 * Set the last TRB in the segment to
 		 * have a TRB type ID of Link TRB
 		 */
-		u32 val = LE32(prev->trbs[TRBS_PER_SEGMENT - 1].link.control);
+		u32 val = le32(prev->trbs[TRBS_PER_SEGMENT - 1].link.control);
 		val &= ~TRB_TYPE_BITMASK;
 		val |= TRB_TYPE(TRB_LINK);
-		prev->trbs[TRBS_PER_SEGMENT - 1].link.control = LE32(val);
+		prev->trbs[TRBS_PER_SEGMENT - 1].link.control = le32(val);
 	}
 }
 
@@ -177,16 +188,15 @@ static void xhci_initialize_ring_info(struct xhci_ring *ring)
  */
 static struct xhci_segment *xhci_segment_alloc(struct xhci_ctrl *ctrl)
 {
-	struct xhci_segment *seg = AllocVecPooled(ctrl->memoryPool, sizeof(struct xhci_segment));
+	struct xhci_segment *seg = pool_zalloc(ctrl->memoryPool, sizeof(struct xhci_segment));
 	if (!seg)
 	{
-		Kprintf("AllocVecPooled failed for size %lu\n",
+		Kprintf("pool_zalloc failed for size %lu\n",
 				(ULONG)sizeof(struct xhci_segment));
 		return NULL;
 	}
 
 	seg->trbs = xhci_malloc(ctrl, SEGMENT_SIZE);
-	seg->next = NULL;
 
 	return seg;
 }
@@ -215,14 +225,13 @@ struct xhci_ring *xhci_ring_alloc(struct xhci_ctrl *ctrl, unsigned int num_segs,
 {
 	unsigned int remaining = num_segs;
 
-	struct xhci_ring *ring = AllocVecPooled(ctrl->memoryPool, sizeof(struct xhci_ring));
+	struct xhci_ring *ring = pool_zalloc(ctrl->memoryPool, sizeof(struct xhci_ring));
 	if (!ring)
 	{
-		Kprintf("AllocVecPooled failed for size %lu\n",
+		Kprintf("pool_zalloc failed for size %lu\n",
 				(ULONG)sizeof(struct xhci_ring));
 		return NULL;
 	}
-	_memset(ring, 0, sizeof(struct xhci_ring));
 	ring->num_segs = num_segs;
 	ring->is_event_ring = is_event_ring;
 	ring->memoryPool = ctrl->memoryPool;
@@ -235,7 +244,7 @@ struct xhci_ring *xhci_ring_alloc(struct xhci_ctrl *ctrl, unsigned int num_segs,
 	if (!ring->first_seg)
 	{
 		Kprintf("xhci_segment_alloc failed\n");
-		FreeVecPooled(ctrl->memoryPool, ring);
+		pool_free(ctrl->memoryPool, ring);
 		return NULL;
 	}
 
@@ -264,7 +273,7 @@ struct xhci_ring *xhci_ring_alloc(struct xhci_ctrl *ctrl, unsigned int num_segs,
 	{
 		/* See section 4.9.2.1 and 6.4.4.1 */
 		prev->trbs[TRBS_PER_SEGMENT - 1].link.control |=
-			LE32(LINK_TOGGLE);
+			le32(LINK_TOGGLE);
 	}
 	xhci_initialize_ring_info(ring);
 
@@ -282,8 +291,8 @@ void xhci_ring_setup_erst(struct xhci_ring *ring, struct xhci_erst *erst, struct
 		 val++)
 	{
 		struct xhci_erst_entry *entry = &erst->entries[val];
-		entry->seg_addr = LE64((dma_addr_t)seg->trbs);
-		entry->seg_size = LE32(TRBS_PER_SEGMENT);
+		entry->seg_addr = le64((dma_addr_t)seg->trbs);
+		entry->seg_size = le32(TRBS_PER_SEGMENT);
 		entry->rsvd = 0;
 		seg = seg->next;
 	}
@@ -294,10 +303,10 @@ void xhci_ring_setup_erst(struct xhci_ring *ring, struct xhci_erst *erst, struct
 				(u64)(uintptr_t)ring->dequeue & (u64)~ERST_PTR_MASK);
 
 	/* set ERST count with the number of entries in the segment table */
-	val = readl(&ir_set->erst_size);
+	val = mmio_read32(&ir_set->erst_size);
 	val &= ERST_SIZE_MASK;
 	val |= ERST_NUM_SEGS;
-	writel(val, &ir_set->erst_size);
+	mmio_write32(val, &ir_set->erst_size);
 
 	/* this is the event ring segment table pointer */
 	u64 val_64 = xhci_readq(&ir_set->erst_base);
@@ -343,7 +352,7 @@ inline static BOOL last_trb_on_last_seg(struct xhci_ring *ring,
 		return ((trb == &seg->trbs[TRBS_PER_SEGMENT]) &&
 				(seg->next == ring->first_seg));
 	else
-		return LE32(trb->link.control) & LINK_TOGGLE;
+		return le32(trb->link.control) & LINK_TOGGLE;
 }
 
 /**
@@ -369,7 +378,7 @@ inline static BOOL last_trb_on_last_seg(struct xhci_ring *ring,
  */
 inline static void inc_enq(struct xhci_ring *ring, BOOL more_trbs_coming)
 {
-	u32 chain = LE32(ring->enqueue->generic.field[3]) & TRB_CHAIN;
+	u32 chain = le32(ring->enqueue->generic.field[3]) & TRB_CHAIN;
 	union xhci_trb *next = ++(ring->enqueue);
 
 	/*
@@ -397,10 +406,10 @@ inline static void inc_enq(struct xhci_ring *ring, BOOL more_trbs_coming)
 			 * carry over the chain bit of the previous TRB
 			 * (which may mean the chain bit is cleared).
 			 */
-			next->link.control &= LE32(~TRB_CHAIN);
-			next->link.control |= LE32(chain);
+			next->link.control &= le32(~TRB_CHAIN);
+			next->link.control |= le32(chain);
 
-			next->link.control ^= LE32(TRB_CYCLE);
+			next->link.control ^= le32(TRB_CYCLE);
 			xhci_flush_cache(next,
 							 sizeof(union xhci_trb));
 		}
@@ -465,10 +474,10 @@ inline static dma_addr_t xhci_ring_enqueue_trb(struct xhci_ring *ring,
 {
 	struct xhci_generic_trb *trb = &ring->enqueue->generic;
 
-	trb->field[0] = LE32(field0);
-	trb->field[1] = LE32(field1);
-	trb->field[2] = LE32(field2);
-	trb->field[3] = LE32(field3);
+	trb->field[0] = le32(field0);
+	trb->field[1] = le32(field1);
+	trb->field[2] = le32(field2);
+	trb->field[3] = le32(field3);
 
 	xhci_flush_cache(trb, sizeof(struct xhci_generic_trb));
 
@@ -494,9 +503,9 @@ inline static void prepare_ring(struct xhci_ring *ep_ring)
 		 * If we're not dealing with 0.95 hardware or isoc rings
 		 * on AMD 0.96 host, clear the chain bit.
 		 */
-		next->link.control &= LE32(~TRB_CHAIN);
+		next->link.control &= le32(~TRB_CHAIN);
 
-		next->link.control ^= LE32(TRB_CYCLE);
+		next->link.control ^= le32(TRB_CYCLE);
 
 		xhci_flush_cache(next, sizeof(union xhci_trb));
 
@@ -521,7 +530,7 @@ union xhci_trb *xhci_ring_get_event_trb(struct xhci_ring *ring)
 	union xhci_trb *event = ring->dequeue;
 
 	/* Does the HC or OS own the TRB? */
-	if ((LE32(event->event_cmd.flags) & TRB_CYCLE) != ring->cycle_state)
+	if ((le32(event->event_cmd.flags) & TRB_CYCLE) != ring->cycle_state)
 		return NULL;
 
 	return event;
@@ -557,7 +566,7 @@ u32 xhci_ring_get_deq_ptr_for_trb(dma_addr_t trb_addr)
 
 	union xhci_trb *trb = (union xhci_trb *)(uintptr_t)trb_addr;
 	xhci_inval_cache(trb, sizeof(*trb));
-	return trb_addr | (LE32(trb->generic.field[3]) & TRB_CYCLE);
+	return trb_addr | (le32(trb->generic.field[3]) & TRB_CYCLE);
 }
 
 void xhci_ring_patch_trbs_to_noop(dma_addr_t *trb_addrs, UWORD trb_count, UWORD start_index)
@@ -572,11 +581,11 @@ void xhci_ring_patch_trbs_to_noop(dma_addr_t *trb_addrs, UWORD trb_count, UWORD 
 			return;
 
 		xhci_inval_cache(trb, sizeof(*trb));
-		u32 cycle = LE32(trb->generic.field[3]) & TRB_CYCLE;
+		u32 cycle = le32(trb->generic.field[3]) & TRB_CYCLE;
 		trb->generic.field[0] = 0;
 		trb->generic.field[1] = 0;
 		trb->generic.field[2] = 0;
-		trb->generic.field[3] = LE32(TRB_TYPE(TRB_TR_NOOP) | cycle);
+		trb->generic.field[3] = le32(TRB_TYPE(TRB_TR_NOOP) | cycle);
 		xhci_flush_cache(trb, sizeof(*trb));
 	}
 }
@@ -605,8 +614,8 @@ dma_addr_t xhci_ring_enqueue_command(struct xhci_ring *ring, u64 address, u32 sl
 		field3 |= EP_ID_FOR_TRB(ep_index);
 
 	dma_addr_t trb_dma = xhci_ring_enqueue_trb(ring, FALSE,
-											   lower_32_bits(address), /* field0 */
-											   upper_32_bits(address), /* field1 */
+									   u64_lo32(address), /* field0 */
+									   u64_hi32(address), /* field1 */
 											   0,					   /* field2 */
 											   field3);				   /* field3 */
 	return trb_dma;
@@ -617,7 +626,7 @@ dma_addr_t xhci_ring_enqueue_command(struct xhci_ring *ring, u64 address, u32 sl
  * packets remaining in the TD (*not* including this TRB).
  *
  * Total TD packet count = total_packet_count =
- *     DIV_ROUND_UP(TD size in bytes / wMaxPacketSize)
+ *     ceil(TD size in bytes / wMaxPacketSize)
  *
  * Packets transferred up to and including this TRB = packets_transferred =
  *     rounddown(total bytes transferred including this TRB / wMaxPacketSize)
@@ -649,7 +658,7 @@ inline static u32 xhci_td_remainder(int transferred,
 		trb_buff_len == td_total_len)
 		return 0;
 
-	u32 total_packet_count = DIV_ROUND_UP(td_total_len, maxp);
+	u32 total_packet_count = DIV_CEIL(td_total_len, maxp);
 
 	/* Queueing functions don't count the current TRB into transferred */
 	return (total_packet_count - ((transferred + trb_buff_len) / maxp));
@@ -665,7 +674,7 @@ inline static int ring_has_room(struct xhci_ring *ring, struct ep_context *ep_ct
 
 inline static void prime_first_trb(struct xhci_generic_trb *start_trb)
 {
-	start_trb->field[3] ^= LE32(TRB_CYCLE);
+	start_trb->field[3] ^= le32(TRB_CYCLE);
 	xhci_flush_cache(start_trb, sizeof(struct xhci_generic_trb));
 }
 
@@ -677,7 +686,7 @@ inline static void giveback_first_trb(struct usb_device *udev, int ep_index,
 	prime_first_trb(start_trb);
 
 	/* Ringing EP doorbell here */
-	writel(DB_VALUE(ep_index, 0), &ctrl->dba->doorbell[udev->slot_id]);
+	mmio_write32(DB_VALUE(ep_index, 0), &ctrl->dba->doorbell[udev->slot_id]);
 
 	return;
 }
@@ -706,14 +715,14 @@ inline static dma_addr_t xhci_dma_map(struct xhci_ctrl *ctrl, struct USBIOReques
 	if (!ctrl || !ctrl->memoryPool || !addr || size == 0)
 		return (dma_addr_t)addr;
 
-	if (likely(addr > (APTR)0x1FFFFF) && ((ULONG)addr & ARCH_DMA_MINALIGN_MASK) == 0)
+	if (likely(addr > (APTR)0x1FFFFF && ((ULONG)addr & DMA_ALIGN_MIN_MASK) == 0))
 	{
 		xhci_flush_cache(addr, size);
 		return (dma_addr_t)addr;
 	}
 
-	ULONG alloc_len = ALIGN(size, ARCH_DMA_MINALIGN);
-	void *aligned = memalign(ctrl->memoryPool, ARCH_DMA_MINALIGN, alloc_len);
+	ULONG alloc_len = ALIGN_UP(size, DMA_ALIGN_MIN);
+	void *aligned = dma_alloc(ctrl->memoryPool, DMA_ALIGN_MIN, alloc_len);
 	if (!aligned)
 	{
 		Kprintf("failed to allocate bounce buffer for %lx len=%ld\n", (ULONG)addr, (LONG)size);
@@ -724,7 +733,7 @@ inline static dma_addr_t xhci_dma_map(struct xhci_ctrl *ctrl, struct USBIOReques
 
 	if (copy)
 	{
-		CopyMem(addr, aligned, size);
+		xhci_copy_to_bounce_buffer(addr, aligned, size);
 	}
 	xhci_flush_cache(aligned, alloc_len);
 
@@ -754,8 +763,8 @@ inline static dma_addr_t xhci_ring_enqueue_setup_trb(struct xhci_ring *ep_ring, 
 	}
 
 	return xhci_ring_enqueue_trb(ep_ring, TRUE,
-								 io->setup.bmRequestType | io->setup.bRequest << 8 | LE16(io->setup.wValue) << 16, /* field 0 */
-								 LE16(io->setup.wIndex) | LE16(io->setup.wLength) << 16,						   /* field 1 */
+								 io->setup.bmRequestType | io->setup.bRequest << 8 | le16(io->setup.wValue) << 16, /* field 0 */
+								 le16(io->setup.wIndex) | le16(io->setup.wLength) << 16,						   /* field 1 */
 								 TRB_LEN(8) | TRB_INTR_TARGET(0),												   /* field 2 */
 								 field3);																		   /* field 3 */
 }
@@ -779,8 +788,8 @@ inline static dma_addr_t xhci_ring_enqueue_data_trb(struct xhci_ctrl *ctrl, stru
 	field3 |= ep_ring->cycle_state;
 
 	return xhci_ring_enqueue_trb(ep_ring, TRUE,
-								 lower_32_bits(buf_64), /* field 0 */
-								 upper_32_bits(buf_64), /* field 1 */
+								 u64_lo32(buf_64), /* field 0 */
+								 u64_hi32(buf_64), /* field 1 */
 								 length_field,			/* field 2 */
 								 field3);				/* field 3 */
 }
@@ -880,8 +889,8 @@ inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring,
 		u32 length_field = (TRB_LEN(trb_buff_len) | TRB_TD_SIZE(remainder) | TRB_INTR_TARGET(0));
 
 		dma_addr_t last_transfer_trb_addr = xhci_ring_enqueue_trb(ep_ring, (num_trbs > 1),
-																  lower_32_bits(addr), /* field 0 */
-																  upper_32_bits(addr), /* field 1 */
+											  u64_lo32(addr), /* field 0 */
+											  u64_hi32(addr), /* field 1 */
 																  length_field,		   /* field 2 */
 																  field3);			   /* field 3 */
 		td_trb_addrs[td_trb_index++] = last_transfer_trb_addr;
@@ -924,7 +933,7 @@ inline static u32 xhci_ring_calc_num_trbs(struct xhci_ctrl *ctrl, struct USBIORe
 	 * XHCI Spec (Table 49 / 6.4.1) requires we avoid spanning that boundary, so
 	 * we may need several chained TRBs if the buffer crosses it.
 	 */
-	u32 running_total = TRB_MAX_BUFF_SIZE - (lower_32_bits(*addr) & (TRB_MAX_BUFF_SIZE - 1));
+	u32 running_total = TRB_MAX_BUFF_SIZE - (u64_lo32(*addr) & (TRB_MAX_BUFF_SIZE - 1));
 	*trb_buff_len = running_total;
 	running_total &= TRB_MAX_BUFF_SIZE - 1;
 
@@ -936,7 +945,7 @@ inline static u32 xhci_ring_calc_num_trbs(struct xhci_ctrl *ctrl, struct USBIORe
 		num_trbs++;
 
 	/* Account for remaining 64KB windows, adding more TRBs as needed. */
-	num_trbs += DIV_ROUND_UP(io->data_buffer_length - running_total, TRB_MAX_BUFF_SIZE);
+	num_trbs += DIV_CEIL(io->data_buffer_length - running_total, TRB_MAX_BUFF_SIZE);
 	return num_trbs;
 }
 
@@ -959,8 +968,8 @@ void xhci_dump_request(const char *tag, const struct USBIORequest *req)
 	if (req->req.io_Command == CMD_REQUEST_CONTROL)
 		Kprintf("%s  SetupData: bmRequestType=0x%02lx bRequest=0x%02lx wValue=0x%04lx wIndex=0x%04lx wLength=%lu\n",
 				pfx, (ULONG)req->setup.bmRequestType, (ULONG)req->setup.bRequest,
-				(ULONG)LE16(req->setup.wValue), (ULONG)LE16(req->setup.wIndex),
-				(ULONG)LE16(req->setup.wLength));
+				(ULONG)le16(req->setup.wValue), (ULONG)le16(req->setup.wIndex),
+				(ULONG)le16(req->setup.wLength));
 }
 
 int xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, unsigned int timeout_ms, BOOL defer_doorbell)
@@ -1012,7 +1021,7 @@ int xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, unsig
 		return ERR_NO_ERROR;
 	}
 
-	dma_addr_t *td_trb_addrs = AllocVecPooled(ctrl->memoryPool, num_trbs * sizeof(dma_addr_t));
+	dma_addr_t *td_trb_addrs = pool_alloc(ctrl->memoryPool, num_trbs * sizeof(dma_addr_t));
 	if (!td_trb_addrs)
 	{
 		Kprintf("Failed to alloc TD TRB list\n");

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -203,10 +203,6 @@ static struct xhci_segment *xhci_segment_alloc(struct xhci_ctrl *ctrl)
 
 /**
  * Create a new ring with zero or more segments.
- * TODO: current code only uses one-time-allocated single-segment rings
- * of 1KB anyway, so we might as well get rid of all the segment and
- * linking code (and maybe increase the size a bit, e.g. 4KB).
- *
  *
  * Link each segment together into a ring.
  * Set the end flag and the cycle toggle bit on the last segment.

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -873,6 +873,8 @@ inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring,
 		u32 remainder = xhci_td_remainder(running_total, trb_buff_len,
 										  length, ep_ring->max_packet_size,
 										  num_trbs > 1);
+		//TODO TBC in isoch - length_field. set ETE=1. 4.11.2.3
+		//TODO TLBPC in isoch - field3
 
 		u32 length_field = (TRB_LEN(trb_buff_len) | TRB_TD_SIZE(remainder) | TRB_INTR_TARGET(0));
 

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -872,9 +872,14 @@ inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring,
 						io->req.io_Command == CMD_REQUEST_ISOCHRONOUS;
 
 	const u32 length = io->data_buffer_length;
-	const u32 enable_short_packet = (!is_iso && (io->direction == DIRECTION_IN)) ? TRB_ISP : 0;
-	const u32 trb_type_bits = is_iso ? (TRB_TYPE(TRB_ISOC) | iso_extra_bits)
-									 : (TRB_TYPE(TRB_NORMAL) | enable_short_packet);
+	const u32 isp_for_in = (io->direction == DIRECTION_IN) ? TRB_ISP : 0;
+	/* xHCI 4.11.2.3: only the first TRB in an ISO TD carries the ISOC type and
+	 * iso-specific bits (Frame ID/SIA, TBC, TLBPC). Chain TRBs are NORMAL.
+	 * ISP applies to both ISOC and NORMAL TRBs for IN endpoints. */
+	const u32 first_trb_type_bits = (is_iso ? (TRB_TYPE(TRB_ISOC) | iso_extra_bits)
+											: TRB_TYPE(TRB_NORMAL)) |
+									isp_for_in;
+	const u32 chain_trb_type_bits = TRB_TYPE(TRB_NORMAL) | isp_for_in;
 
 	u32 running_total = 0;
 	u32 td_trb_index = 0;
@@ -894,17 +899,18 @@ inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring,
 	/* Queue the first TRB, even if it's zero-length. */
 	do
 	{
-		u32 field3 = trb_type_bits;
+		u32 field3;
 		/* Don't change the cycle bit of the first TRB until later */
 		if (first_trb)
 		{
+			field3 = first_trb_type_bits;
 			first_trb = FALSE;
 			if (ep_ring->cycle_state == 0)
 				field3 |= TRB_CYCLE;
 		}
 		else
 		{
-			field3 |= ep_ring->cycle_state;
+			field3 = chain_trb_type_bits | ep_ring->cycle_state;
 		}
 
 		/*

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -865,7 +865,7 @@ inline static void xhci_ring_enqueue_control_trbs(struct xhci_ctrl *ctrl, struct
 	td_trb_addrs[td_trb_index++] = status_trb;
 }
 
-inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring, struct USBIORequest *io, u64 addr, u32 num_trbs, u32 trb_buff_len, dma_addr_t *td_trb_addrs)
+inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring, struct USBIORequest *io, u64 addr, u32 num_trbs, u32 trb_buff_len, dma_addr_t *td_trb_addrs, u32 iso_extra_bits)
 {
 	// KprintfH("num_trbs = %lu, trb_buff_len = %lu\n", (ULONG)num_trbs, (ULONG)trb_buff_len);
 	const BOOL is_iso = io->req.io_Command == CMD_REGISTER_ISOCHRONOUS_HOOKS ||
@@ -873,7 +873,8 @@ inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring,
 
 	const u32 length = io->data_buffer_length;
 	const u32 enable_short_packet = (!is_iso && (io->direction == DIRECTION_IN)) ? TRB_ISP : 0;
-	const u32 trb_type_bits = is_iso ? (TRB_TYPE(TRB_ISOC) | TRB_SIA) : (TRB_TYPE(TRB_NORMAL) | enable_short_packet);
+	const u32 trb_type_bits = is_iso ? (TRB_TYPE(TRB_ISOC) | iso_extra_bits)
+									 : (TRB_TYPE(TRB_NORMAL) | enable_short_packet);
 
 	u32 running_total = 0;
 	u32 td_trb_index = 0;
@@ -1005,7 +1006,7 @@ static void __attribute__((unused)) xhci_dump_request(const char *tag, const str
 				(ULONG)le16(req->setup.wLength));
 }
 
-s8 xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell)
+inline static s8 enqueue_td_internal(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell, u32 iso_extra_bits)
 {
 	// #ifdef DEBUG_HIGH
 	// 	xhci_dump_request("[xhci-ring] xhci_ring_enqueue_td: ", io);
@@ -1076,10 +1077,21 @@ s8 xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, u32 ti
 	if (io->req.io_Command == CMD_REQUEST_CONTROL)
 		xhci_ring_enqueue_control_trbs(ctrl, ep_ring, io, td_trb_addrs);
 	else
-		xhci_ring_enqueue_non_control_trbs(ep_ring, io, addr, num_trbs, trb_buff_len, td_trb_addrs);
+		xhci_ring_enqueue_non_control_trbs(ep_ring, io, addr, num_trbs, trb_buff_len, td_trb_addrs, iso_extra_bits);
 
 	xhci_ep_set_receiving(udev_ep_ctx, io, td_trb_addrs, timeout_ms, num_trbs);
 	xhci_ring_finalize_first_trb(udev, ep_index, ep_ring, (struct xhci_generic_trb *)td_trb_addrs[0], defer_doorbell);
 
 	return ERR_NO_ERROR;
+}
+
+s8 xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell)
+{
+	/* ISO transfers scheduled here use SIA; RT ISO callers go through xhci_ring_enqueue_td_at_frame. */
+	return enqueue_td_internal(udev, io, timeout_ms, defer_doorbell, TRB_SIA);
+}
+
+s8 xhci_ring_enqueue_td_at_frame(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell, u16 frame)
+{
+	return enqueue_td_internal(udev, io, timeout_ms, defer_doorbell, TRB_FRAME_ID(frame));
 }

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -917,8 +917,6 @@ inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring,
 		u32 remainder = xhci_td_remainder(running_total, trb_buff_len,
 										  length, ep_ring->max_packet_size,
 										  num_trbs > 1);
-		// TODO TBC in isoch - length_field. set ETE=1. 4.11.2.3
-		// TODO TLBPC in isoch - field3
 
 		u32 length_field = TRB_LEN(trb_buff_len) | TRB_TD_SIZE(remainder) | TRB_INTR_TARGET(0);
 
@@ -1006,6 +1004,36 @@ static void __attribute__((unused)) xhci_dump_request(const char *tag, const str
 				(ULONG)le16(req->setup.wLength));
 }
 
+/*
+ * xHCI 4.11.2.3: compute TBC and TLBPC for an ISO TD.
+ * Pre-1.0 controllers leave both fields RsvdZ; older controllers can't burst anyway.
+ */
+static inline u32 iso_burst_bits(struct xhci_ctrl *ctrl, struct usb_device *udev,
+								 struct ep_context *ep_ctx, u32 td_length)
+{
+	if (ctrl->hci_version < 0x100)
+		return 0;
+
+	u32 max_packet = xhci_ep_get_max_packet_size(ep_ctx);
+	if (max_packet == 0)
+		max_packet = 1;
+	u32 total_pkts = (td_length + max_packet - 1) / max_packet;
+	if (total_pkts == 0)
+		total_pkts = 1;
+
+	if (udev->speed >= USB_SPEED_SUPER)
+	{
+		const u32 max_burst = xhci_ep_get_max_burst(ep_ctx);
+		const u32 burst = max_burst + 1U;
+		const u32 tbc = ((total_pkts + burst - 1) / burst) - 1;
+		const u32 residue = total_pkts % burst;
+		const u32 tlbpc = (residue == 0) ? max_burst : (residue - 1);
+		return TRB_TBC(tbc) | TRB_TLBPC(tlbpc);
+	}
+	/* USB 2.0 / 1.1: one burst per service interval; TLBPC = total_pkts - 1. */
+	return TRB_TBC(total_pkts - 1);
+}
+
 inline static s8 enqueue_td_internal(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell, u32 iso_extra_bits)
 {
 	// #ifdef DEBUG_HIGH
@@ -1077,7 +1105,12 @@ inline static s8 enqueue_td_internal(struct usb_device *udev, struct USBIOReques
 	if (io->req.io_Command == CMD_REQUEST_CONTROL)
 		xhci_ring_enqueue_control_trbs(ctrl, ep_ring, io, td_trb_addrs);
 	else
+	{
+		if (io->req.io_Command == CMD_REQUEST_ISOCHRONOUS ||
+			io->req.io_Command == CMD_REGISTER_ISOCHRONOUS_HOOKS)
+			iso_extra_bits |= iso_burst_bits(ctrl, udev, udev_ep_ctx, io->data_buffer_length);
 		xhci_ring_enqueue_non_control_trbs(ep_ring, io, addr, num_trbs, trb_buff_len, td_trb_addrs, iso_extra_bits);
+	}
 
 	xhci_ep_set_receiving(udev_ep_ctx, io, td_trb_addrs, timeout_ms, num_trbs);
 	xhci_ring_finalize_first_trb(udev, ep_index, ep_ring, (struct xhci_generic_trb *)td_trb_addrs[0], defer_doorbell);

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -35,9 +35,9 @@
 #define KprintfH(fmt, ...) PrintPistorm("[xhci-ring] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-static inline void xhci_copy_to_bounce_buffer(CONST_APTR src, APTR dst, ULONG size)
+static inline void xhci_copy_to_bounce_buffer(CONST_APTR src, APTR dst, u32 size)
 {
-	if ((((ULONG)src | (ULONG)dst | size) & (sizeof(ULONG) - 1)) == 0)
+	if ((((uintptr_t)src | (uintptr_t)dst | size) & (sizeof(ULONG) - 1)) == 0)
 	{
 		CopyMemQuick((ULONG *)src, (ULONG *)dst, size);
 		return;
@@ -56,9 +56,9 @@ struct xhci_segment
 struct xhci_ring
 {
 	BOOL is_event_ring;
-	int ep_index; /* for transfer rings, the endpoint index this ring is associated with. For event rings, unused and set to 0. */
-	unsigned int num_segs;
-	int max_packet_size;
+	u8 ep_index; /* for transfer rings, the endpoint index this ring is associated with. For event rings, unused and set to 0. */
+	u32 num_segs;
+	u32 max_packet_size;
 	APTR memoryPool;
 
 	struct xhci_segment *first_seg;
@@ -144,7 +144,7 @@ static void xhci_link_segments(struct xhci_segment *prev,
 		 * have a TRB type ID of Link TRB
 		 */
 		u32 val = le32(prev->trbs[TRBS_PER_SEGMENT - 1].link.control);
-		val &= ~TRB_TYPE_BITMASK;
+		val &= (u32)~TRB_TYPE_BITMASK;
 		val |= TRB_TYPE(TRB_LINK);
 		prev->trbs[TRBS_PER_SEGMENT - 1].link.control = le32(val);
 	}
@@ -220,10 +220,10 @@ static struct xhci_segment *xhci_segment_alloc(struct xhci_ctrl *ctrl)
  * @param maxpacketsize maximum packet size for the endpoint, unused for event rings
  * Return: pointer to the newly created RING
  */
-struct xhci_ring *xhci_ring_alloc(struct xhci_ctrl *ctrl, unsigned int num_segs,
-								  BOOL link_trbs, BOOL is_event_ring, int ep_index, int max_packet_size)
+struct xhci_ring *xhci_ring_alloc(struct xhci_ctrl *ctrl, u32 num_segs,
+								  BOOL link_trbs, BOOL is_event_ring, u8 ep_index, u32 max_packet_size)
 {
-	unsigned int remaining = num_segs;
+	u32 remaining = num_segs;
 
 	struct xhci_ring *ring = pool_zalloc(ctrl->memoryPool, sizeof(struct xhci_ring));
 	if (!ring)
@@ -282,7 +282,7 @@ struct xhci_ring *xhci_ring_alloc(struct xhci_ctrl *ctrl, unsigned int num_segs,
 
 void xhci_ring_setup_erst(struct xhci_ring *ring, struct xhci_erst *erst, struct xhci_intr_reg *ir_set)
 {
-	uint32_t val;
+	u32 val;
 	struct xhci_segment *seg;
 	erst->num_entries = ERST_NUM_SEGS;
 
@@ -311,7 +311,7 @@ void xhci_ring_setup_erst(struct xhci_ring *ring, struct xhci_erst *erst, struct
 	/* this is the event ring segment table pointer */
 	u64 val_64 = xhci_readq(&ir_set->erst_base);
 	val_64 &= ERST_PTR_MASK;
-	val_64 |= (dma_addr_t)erst->entries & ~ERST_PTR_MASK;
+	val_64 |= ((dma_addr_t)erst->entries & ~ERST_PTR_MASK);
 
 	xhci_writeq(&ir_set->erst_base, val_64);
 }
@@ -551,7 +551,7 @@ void xhci_ring_acknowledge_event(struct xhci_ctrl *ctrl)
 	inc_deq(ctrl->event_ring);
 
 	/* Inform the hardware */
-	xhci_writeq(&ctrl->ir_set->erst_dequeue, (dma_addr_t)ctrl->event_ring->dequeue | ERST_EHB);
+	xhci_writeq(&ctrl->ir_set->erst_dequeue, ((dma_addr_t)ctrl->event_ring->dequeue) | ERST_EHB);
 }
 
 u32 xhci_ring_get_new_dequeue_ptr(struct xhci_ring *ring)
@@ -569,12 +569,12 @@ u32 xhci_ring_get_deq_ptr_for_trb(dma_addr_t trb_addr)
 	return trb_addr | (le32(trb->generic.field[3]) & TRB_CYCLE);
 }
 
-void xhci_ring_patch_trbs_to_noop(dma_addr_t *trb_addrs, UWORD trb_count, UWORD start_index)
+void xhci_ring_patch_trbs_to_noop(dma_addr_t *trb_addrs, u32 trb_count, u32 start_index)
 {
 	if (!trb_addrs || start_index >= trb_count)
 		return;
 
-	for (UWORD index = start_index; index < trb_count; ++index)
+	for (u32 index = start_index; index < trb_count; ++index)
 	{
 		union xhci_trb *trb = (union xhci_trb *)(uintptr_t)trb_addrs[index];
 		if (!trb)
@@ -590,17 +590,17 @@ void xhci_ring_patch_trbs_to_noop(dma_addr_t *trb_addrs, UWORD trb_count, UWORD 
 	}
 }
 
-int xhci_ring_get_max_packet_size(struct xhci_ring *ring)
+u32 xhci_ring_get_max_packet_size(struct xhci_ring *ring)
 {
 	return ring->max_packet_size;
 }
 
-void xhci_ring_set_max_packet_size(struct xhci_ring *ring, int max_packet_size)
+void xhci_ring_set_max_packet_size(struct xhci_ring *ring, u32 max_packet_size)
 {
 	ring->max_packet_size = max_packet_size;
 }
 
-dma_addr_t xhci_ring_enqueue_command(struct xhci_ring *ring, u64 address, u32 slot_id, u32 ep_index, trb_type cmd)
+dma_addr_t xhci_ring_enqueue_command(struct xhci_ring *ring, u64 address, u32 slot_id, u8 ep_index, trb_type cmd)
 {
 	prepare_ring(ring);
 
@@ -614,10 +614,10 @@ dma_addr_t xhci_ring_enqueue_command(struct xhci_ring *ring, u64 address, u32 sl
 		field3 |= EP_ID_FOR_TRB(ep_index);
 
 	dma_addr_t trb_dma = xhci_ring_enqueue_trb(ring, FALSE,
-									   u64_lo32(address), /* field0 */
-									   u64_hi32(address), /* field1 */
-											   0,					   /* field2 */
-											   field3);				   /* field3 */
+											   u64_lo32(address), /* field0 */
+											   u64_hi32(address), /* field1 */
+											   0,				  /* field2 */
+											   field3);			  /* field3 */
 	return trb_dma;
 }
 
@@ -649,9 +649,9 @@ dma_addr_t xhci_ring_enqueue_command(struct xhci_ring *ring, u64 address, u32 sl
  * @param more_trbs_coming	indicate last trb in TD
  * Return: remainder
  */
-inline static u32 xhci_td_remainder(int transferred,
-									unsigned int trb_buff_len, unsigned int td_total_len,
-									int maxp, BOOL more_trbs_coming)
+inline static u32 xhci_td_remainder(u32 transferred,
+									u32 trb_buff_len, u32 td_total_len,
+									u32 maxp, BOOL more_trbs_coming)
 {
 	/* One TRB with a zero-length data packet. */
 	if (!more_trbs_coming || (transferred == 0 && trb_buff_len == 0) ||
@@ -664,11 +664,11 @@ inline static u32 xhci_td_remainder(int transferred,
 	return (total_packet_count - ((transferred + trb_buff_len) / maxp));
 }
 
-inline static int ring_has_room(struct xhci_ring *ring, struct ep_context *ep_ctx, unsigned int needed)
+inline static BOOL ring_has_room(struct xhci_ring *ring, struct ep_context *ep_ctx, u32 needed)
 {
-	unsigned int capacity = ring->num_segs * (TRBS_PER_SEGMENT - 1);
+	u32 capacity = ring->num_segs * (TRBS_PER_SEGMENT - 1);
 	if (capacity == 0)
-		return 0;
+		return FALSE;
 	return xhci_ep_get_active_trb_count(ep_ctx) + needed <= capacity;
 }
 
@@ -678,7 +678,7 @@ inline static void prime_first_trb(struct xhci_generic_trb *start_trb)
 	xhci_flush_cache(start_trb, sizeof(struct xhci_generic_trb));
 }
 
-inline static void giveback_first_trb(struct usb_device *udev, int ep_index,
+inline static void giveback_first_trb(struct usb_device *udev, u8 ep_index,
 									  struct xhci_generic_trb *start_trb)
 {
 	struct xhci_ctrl *ctrl = udev->controller;
@@ -710,22 +710,22 @@ inline static dma_addr_t xhci_dma_map(struct xhci_ctrl *ctrl, struct USBIOReques
 		return NULL;
 
 	APTR addr = req->data_buffer;
-	ULONG size = req->data_buffer_length;
+	u32 size = req->data_buffer_length;
 
 	if (!ctrl || !ctrl->memoryPool || !addr || size == 0)
 		return (dma_addr_t)addr;
 
-	if (likely(addr > (APTR)0x1FFFFF && ((ULONG)addr & DMA_ALIGN_MIN_MASK) == 0))
+	if (likely(addr > (APTR)0x1FFFFF && (((uintptr_t)addr & DMA_ALIGN_MIN_MASK) == 0)))
 	{
 		xhci_flush_cache(addr, size);
 		return (dma_addr_t)addr;
 	}
 
-	ULONG alloc_len = ALIGN_UP(size, DMA_ALIGN_MIN);
+	u32 alloc_len = ALIGN_UP(size, DMA_ALIGN_MIN);
 	void *aligned = dma_alloc(ctrl->memoryPool, DMA_ALIGN_MIN, alloc_len);
 	if (!aligned)
 	{
-		Kprintf("failed to allocate bounce buffer for %lx len=%ld\n", (ULONG)addr, (LONG)size);
+		Kprintf("failed to allocate bounce buffer for %lx len=%lu\n", (ULONG)addr, (ULONG)size);
 		return (dma_addr_t)addr;
 	}
 
@@ -763,10 +763,10 @@ inline static dma_addr_t xhci_ring_enqueue_setup_trb(struct xhci_ring *ep_ring, 
 	}
 
 	return xhci_ring_enqueue_trb(ep_ring, TRUE,
-								 io->setup.bmRequestType | io->setup.bRequest << 8 | le16(io->setup.wValue) << 16, /* field 0 */
-								 le16(io->setup.wIndex) | le16(io->setup.wLength) << 16,						   /* field 1 */
-								 TRB_LEN(8) | TRB_INTR_TARGET(0),												   /* field 2 */
-								 field3);																		   /* field 3 */
+								 io->setup.bmRequestType | ((u32)io->setup.bRequest << 8) | ((u32)le16(io->setup.wValue) << 16), /* field 0 */
+								 le16(io->setup.wIndex) | ((u32)le16(io->setup.wLength) << 16),									 /* field 1 */
+								 TRB_LEN(8) | TRB_INTR_TARGET(0),																 /* field 2 */
+								 field3);																						 /* field 3 */
 }
 
 inline static dma_addr_t xhci_ring_enqueue_data_trb(struct xhci_ctrl *ctrl, struct xhci_ring *ep_ring, struct USBIORequest *io)
@@ -790,8 +790,8 @@ inline static dma_addr_t xhci_ring_enqueue_data_trb(struct xhci_ctrl *ctrl, stru
 	return xhci_ring_enqueue_trb(ep_ring, TRUE,
 								 u64_lo32(buf_64), /* field 0 */
 								 u64_hi32(buf_64), /* field 1 */
-								 length_field,			/* field 2 */
-								 field3);				/* field 3 */
+								 length_field,	   /* field 2 */
+								 field3);		   /* field 3 */
 }
 
 inline static dma_addr_t xhci_ring_enqueue_status_trb(struct xhci_ring *ep_ring, struct USBIORequest *io)
@@ -816,8 +816,8 @@ inline static dma_addr_t xhci_ring_enqueue_status_trb(struct xhci_ring *ep_ring,
 
 inline static void xhci_ring_enqueue_control_trbs(struct xhci_ctrl *ctrl, struct xhci_ring *ep_ring, struct USBIORequest *io, dma_addr_t *td_trb_addrs)
 {
-	unsigned int td_trb_index = 0;
-	const unsigned int length = io->data_buffer_length;
+	u32 td_trb_index = 0;
+	const u32 length = io->data_buffer_length;
 
 	dma_addr_t setup_trb = xhci_ring_enqueue_setup_trb(ep_ring, io);
 	td_trb_addrs[td_trb_index++] = setup_trb;
@@ -840,7 +840,7 @@ inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring,
 
 	const u32 length = io->data_buffer_length;
 	const u32 enable_short_packet = (!is_iso && (io->direction == DIRECTION_IN)) ? TRB_ISP : 0;
-	const u32 trb_type_bits = (is_iso) ? ((u32)TRB_TYPE(TRB_ISOC) | TRB_SIA) : (TRB_TYPE(TRB_NORMAL) | enable_short_packet);
+	const u32 trb_type_bits = is_iso ? (TRB_TYPE(TRB_ISOC) | TRB_SIA) : (TRB_TYPE(TRB_NORMAL) | enable_short_packet);
 
 	u32 running_total = 0;
 	u32 td_trb_index = 0;
@@ -883,27 +883,27 @@ inline static void xhci_ring_enqueue_non_control_trbs(struct xhci_ring *ep_ring,
 		u32 remainder = xhci_td_remainder(running_total, trb_buff_len,
 										  length, ep_ring->max_packet_size,
 										  num_trbs > 1);
-		//TODO TBC in isoch - length_field. set ETE=1. 4.11.2.3
-		//TODO TLBPC in isoch - field3
+		// TODO TBC in isoch - length_field. set ETE=1. 4.11.2.3
+		// TODO TLBPC in isoch - field3
 
-		u32 length_field = (TRB_LEN(trb_buff_len) | TRB_TD_SIZE(remainder) | TRB_INTR_TARGET(0));
+		u32 length_field = TRB_LEN(trb_buff_len) | TRB_TD_SIZE(remainder) | TRB_INTR_TARGET(0);
 
 		dma_addr_t last_transfer_trb_addr = xhci_ring_enqueue_trb(ep_ring, (num_trbs > 1),
-											  u64_lo32(addr), /* field 0 */
-											  u64_hi32(addr), /* field 1 */
-																  length_field,		   /* field 2 */
-																  field3);			   /* field 3 */
+																  u64_lo32(addr), /* field 0 */
+																  u64_hi32(addr), /* field 1 */
+																  length_field,	  /* field 2 */
+																  field3);		  /* field 3 */
 		td_trb_addrs[td_trb_index++] = last_transfer_trb_addr;
 		--num_trbs;
 		running_total += trb_buff_len;
 
 		/* Calculate length for next transfer */
 		addr += trb_buff_len;
-		trb_buff_len = min((length - running_total), TRB_MAX_BUFF_SIZE);
+		trb_buff_len = (length - running_total < TRB_MAX_BUFF_SIZE) ? (length - running_total) : TRB_MAX_BUFF_SIZE;
 	} while (running_total < length);
 }
 
-inline static void xhci_ring_finalize_first_trb(struct usb_device *udev, int ep_index, struct xhci_ring *ep_ring, struct xhci_generic_trb *start_trb, BOOL defer_doorbell)
+inline static void xhci_ring_finalize_first_trb(struct usb_device *udev, u8 ep_index, struct xhci_ring *ep_ring, struct xhci_generic_trb *start_trb, BOOL defer_doorbell)
 {
 	/* Hand the first TRB back to the controller once the TD is ready. */
 	if (defer_doorbell)
@@ -949,7 +949,7 @@ inline static u32 xhci_ring_calc_num_trbs(struct xhci_ctrl *ctrl, struct USBIORe
 	return num_trbs;
 }
 
-void xhci_dump_request(const char *tag, const struct USBIORequest *req)
+static void __attribute__((unused)) xhci_dump_request(const char *tag, const struct USBIORequest *req)
 {
 	if (!req)
 		return;
@@ -972,14 +972,14 @@ void xhci_dump_request(const char *tag, const struct USBIORequest *req)
 				(ULONG)le16(req->setup.wLength));
 }
 
-int xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, unsigned int timeout_ms, BOOL defer_doorbell)
+s8 xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell)
 {
 	// #ifdef DEBUG_HIGH
 	// 	xhci_dump_request("[xhci-ring] xhci_ring_enqueue_td: ", io);
 	// #endif
 	struct xhci_ctrl *ctrl = udev->controller;
 
-	const int ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
+	const u8 ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
 	struct ep_context *udev_ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
 	if (!udev_ep_ctx)
 	{

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -732,14 +732,32 @@ inline static dma_addr_t xhci_dma_map(struct xhci_ctrl *ctrl, struct USBIOReques
 	}
 
 	u32 alloc_len = ALIGN_UP(size, DMA_ALIGN_MIN);
-	void *aligned = dma_alloc(ctrl->memoryPool, DMA_ALIGN_MIN, alloc_len);
+
+	void *aligned = NULL;
+	u32 bounce_class = REQ_BOUNCE_CLASS_NONE;
+	if (alloc_len <= XHCI_BOUNCE_SMALL_SIZE) {
+		aligned = slab_alloc(&ctrl->bounce_small);
+		bounce_class = REQ_BOUNCE_CLASS_SMALL;
+	} else if (alloc_len <= XHCI_BOUNCE_MED_SIZE) {
+		aligned = slab_alloc(&ctrl->bounce_med);
+		bounce_class = REQ_BOUNCE_CLASS_MED;
+	} else if (alloc_len <= XHCI_BOUNCE_LARGE_SIZE) {
+		aligned = slab_alloc(&ctrl->bounce_large);
+		bounce_class = REQ_BOUNCE_CLASS_LARGE;
+	}
+	if (!aligned) {
+		aligned = dma_alloc(ctrl->memoryPool, DMA_ALIGN_MIN, alloc_len);
+		bounce_class = REQ_BOUNCE_CLASS_NONE;
+	}
 	if (!aligned)
 	{
 		Kprintf("failed to allocate bounce buffer for %lx len=%lu\n", (ULONG)addr, (ULONG)size);
 		return (dma_addr_t)addr;
 	}
 
-	req->driver_private_flags |= REQ_DMA_MAPPED;
+	req->driver_private_flags = (req->driver_private_flags & ~REQ_BOUNCE_CLASS_MASK)
+		| (bounce_class << REQ_BOUNCE_CLASS_SHIFT)
+		| REQ_DMA_MAPPED;
 
 	if (copy)
 	{
@@ -1031,7 +1049,11 @@ s8 xhci_ring_enqueue_td(struct usb_device *udev, struct USBIORequest *io, u32 ti
 		return ERR_NO_ERROR;
 	}
 
-	dma_addr_t *td_trb_addrs = pool_alloc(ctrl->memoryPool, num_trbs * sizeof(dma_addr_t));
+	dma_addr_t *td_trb_addrs;
+	if (likely(num_trbs <= XHCI_TD_SMALL_TRBS))
+		td_trb_addrs = slab_alloc(&ctrl->trb_addr_slab);
+	else
+		td_trb_addrs = pool_alloc(ctrl->memoryPool, num_trbs * sizeof(dma_addr_t));
 	if (!td_trb_addrs)
 	{
 		Kprintf("Failed to alloc TD TRB list\n");

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -13,6 +13,7 @@
  *	    Vikas Sajjan <vikas.sajjan@samsung.com>
  */
 
+#include <config.h>
 #include <debug.h>
 #include <memory.h>
 
@@ -202,6 +203,113 @@ static struct xhci_segment *xhci_segment_alloc(struct xhci_ctrl *ctrl)
 }
 
 /**
+ * Dynamically grow a transfer ring by inserting num_new_segs new segments
+ * immediately after ring->enq_seg.
+ * the hardware will follow the updated Link TRB once it drains the current
+ * enq_seg.
+ *
+ * @param ctrl         pointer to the xhci controller
+ * @param ring         the transfer ring to grow
+ * @param num_new_segs number of segments to add
+ * Return: TRUE on success, FALSE if the ring is already at its maximum size
+ *         or allocation fails (ring is left unmodified in that case).
+ */
+BOOL xhci_ring_grow(struct xhci_ctrl *ctrl, struct xhci_ring *ring, u32 num_new_segs)
+{
+	if (!ring || num_new_segs == 0 ||
+	    ring->num_segs + num_new_segs > XHCI_MAX_SEGMENTS_PER_RING)
+		return FALSE;
+
+	/*
+	 * Allocate and link the new segments as a linear chain.
+	 * xhci_link_segments sets seg->next and the Link TRB for each pair.
+	 * Each Link TRB is flushed immediately so the hardware will see the
+	 * correct pointer once we splice the chain into the ring.
+	 */
+	struct xhci_segment *new_first = NULL, *new_last = NULL, *prev = NULL;
+	for (u32 i = 0; i < num_new_segs; ++i)
+	{
+		struct xhci_segment *seg = xhci_segment_alloc(ctrl);
+		if (!seg)
+		{
+			/* Free already-allocated segments via the ->next chain */
+			struct xhci_segment *s = new_first;
+			while (s)
+			{
+				struct xhci_segment *nxt = s->next;
+				xhci_segment_free(ctrl, s);
+				s = nxt;
+			}
+			return FALSE;
+		}
+		seg->next = NULL;
+		if (prev)
+		{
+			xhci_link_segments(prev, seg, TRUE);
+			xhci_flush_cache(&prev->trbs[TRBS_PER_SEGMENT - 1], sizeof(union xhci_trb));
+		}
+		else
+			new_first = seg;
+		prev = seg;
+		new_last = seg;
+	}
+
+	/*
+	 * xhci_malloc zeroes TRBs (cycle=0).  When ring->cycle_state==0 the
+	 * HC treats cycle=0 as valid — pre-set data TRBs to cycle=1 so the HC
+	 * won't process empty slots if it follows the new chain before we have
+	 * written real TRBs.  The Link TRB (last slot) is managed separately.
+	 */
+	if (ring->cycle_state == 0)
+	{
+		struct xhci_segment *seg = new_first;
+		while (seg)
+		{
+			for (u32 j = 0; j < TRBS_PER_SEGMENT - 1; ++j)
+				seg->trbs[j].generic.field[3] |= le32(TRB_CYCLE);
+			seg = seg->next;
+		}
+	}
+
+	/*
+	 * Splice the new chain between ring->enq_seg and its current successor.
+	 *
+	 *   1. Link new_last → old_next (HC cannot reach here yet)
+	 *   2. Transfer LINK_TOGGLE from enq_seg to new_last
+	 *   3. Re-point enq_seg Link TRB → new_first (HC now enters new chain)
+	 *   4. Update the software ->next pointer for enq_seg
+	 */
+	struct xhci_segment *old_next = ring->enq_seg->next;
+
+	/* Step 1 */
+	xhci_link_segments(new_last, old_next, TRUE);
+	xhci_flush_cache(&new_last->trbs[TRBS_PER_SEGMENT - 1], sizeof(union xhci_trb));
+
+	/* Step 2 */
+	u32 enq_ctrl = le32(ring->enq_seg->trbs[TRBS_PER_SEGMENT - 1].link.control);
+	if (enq_ctrl & LINK_TOGGLE)
+	{
+		enq_ctrl &= ~(u32)LINK_TOGGLE;
+		ring->enq_seg->trbs[TRBS_PER_SEGMENT - 1].link.control = le32(enq_ctrl);
+		u32 last_ctrl = le32(new_last->trbs[TRBS_PER_SEGMENT - 1].link.control);
+		last_ctrl |= LINK_TOGGLE;
+		new_last->trbs[TRBS_PER_SEGMENT - 1].link.control = le32(last_ctrl);
+		xhci_flush_cache(&new_last->trbs[TRBS_PER_SEGMENT - 1], sizeof(union xhci_trb));
+	}
+
+	/* Step 3 */
+	ring->enq_seg->trbs[TRBS_PER_SEGMENT - 1].link.segment_ptr =
+		le64((dma_addr_t)new_first->trbs);
+	xhci_flush_cache(&ring->enq_seg->trbs[TRBS_PER_SEGMENT - 1], sizeof(union xhci_trb));
+
+	/* Step 4 */
+	ring->enq_seg->next = new_first;
+
+	ring->num_segs += num_new_segs;
+	return TRUE;
+}
+
+/**
  * Create a new ring with zero or more segments.
  *
  * Link each segment together into a ring.
@@ -280,10 +388,10 @@ void xhci_ring_setup_erst(struct xhci_ring *ring, struct xhci_erst *erst, struct
 {
 	u32 val;
 	struct xhci_segment *seg;
-	erst->num_entries = ERST_NUM_SEGS;
+	erst->num_entries = XHCI_INITIAL_SEGS_PER_EVENT_RING;
 
 	for (val = 0, seg = ring->first_seg;
-		 val < ERST_NUM_SEGS;
+		 val < XHCI_INITIAL_SEGS_PER_EVENT_RING;
 		 val++)
 	{
 		struct xhci_erst_entry *entry = &erst->entries[val];
@@ -292,7 +400,7 @@ void xhci_ring_setup_erst(struct xhci_ring *ring, struct xhci_erst *erst, struct
 		entry->rsvd = 0;
 		seg = seg->next;
 	}
-	xhci_flush_cache(erst->entries, ERST_NUM_SEGS * sizeof(struct xhci_erst_entry));
+	xhci_flush_cache(erst->entries, XHCI_INITIAL_SEGS_PER_EVENT_RING * sizeof(struct xhci_erst_entry));
 
 	/* Update HC event ring dequeue pointer */
 	xhci_writeq(&ir_set->erst_dequeue,
@@ -301,7 +409,7 @@ void xhci_ring_setup_erst(struct xhci_ring *ring, struct xhci_erst *erst, struct
 	/* set ERST count with the number of entries in the segment table */
 	val = mmio_read32(&ir_set->erst_size);
 	val &= ERST_SIZE_MASK;
-	val |= ERST_NUM_SEGS;
+	val |= XHCI_INITIAL_SEGS_PER_EVENT_RING;
 	mmio_write32(val, &ir_set->erst_size);
 
 	/* this is the event ring segment table pointer */
@@ -1083,9 +1191,18 @@ inline static s8 enqueue_td_internal(struct usb_device *udev, struct USBIOReques
 
 	if (!ring_has_room(ep_ring, udev_ep_ctx, num_trbs + 1))
 	{
-		KprintfH("Ring full ep=%lu needed %lu TRBs\n", (ULONG)ep_index, (ULONG)num_trbs);
-		xhci_ep_enqueue(udev_ep_ctx, io);
-		return ERR_NO_ERROR;
+		KprintfH("Ring full ep=%lu needed %lu TRBs, attempting grow\n", (ULONG)ep_index, (ULONG)num_trbs);
+		if (!xhci_ring_grow(ctrl, ep_ring, XHCI_SEGMENTS_PER_RING)) {
+			KprintfH("Ring grow failed, queueing request\n");
+			xhci_ep_enqueue(udev_ep_ctx, io);
+			return ERR_NO_ERROR;
+		}
+		KprintfH("Ring grew, retrying room check\n");
+		if (!ring_has_room(ep_ring, udev_ep_ctx, num_trbs + 1)) {
+			KprintfH("Still no room after grow, queueing\n");
+			xhci_ep_enqueue(udev_ep_ctx, io);
+			return ERR_NO_ERROR;
+		}
 	}
 
 	dma_addr_t *td_trb_addrs;

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -725,6 +725,7 @@ inline static dma_addr_t xhci_dma_map(struct xhci_ctrl *ctrl, struct USBIOReques
 	if (!ctrl || !ctrl->memoryPool || !addr || size == 0)
 		return (dma_addr_t)addr;
 
+	/* TODO this should also check if the memory region is on Pistorm RAM */
 	if (unlikely(addr > (APTR)0x1FFFFF && (((uintptr_t)addr & DMA_ALIGN_MIN_MASK) == 0)))
 	{
 		xhci_flush_cache(addr, size);
@@ -735,17 +736,23 @@ inline static dma_addr_t xhci_dma_map(struct xhci_ctrl *ctrl, struct USBIOReques
 
 	void *aligned = NULL;
 	u32 bounce_class = REQ_BOUNCE_CLASS_NONE;
-	if (alloc_len <= XHCI_BOUNCE_SMALL_SIZE) {
+	if (alloc_len <= XHCI_BOUNCE_SMALL_SIZE)
+	{
 		aligned = slab_alloc(&ctrl->bounce_small);
 		bounce_class = REQ_BOUNCE_CLASS_SMALL;
-	} else if (alloc_len <= XHCI_BOUNCE_MED_SIZE) {
+	}
+	else if (alloc_len <= XHCI_BOUNCE_MED_SIZE)
+	{
 		aligned = slab_alloc(&ctrl->bounce_med);
 		bounce_class = REQ_BOUNCE_CLASS_MED;
-	} else if (alloc_len <= XHCI_BOUNCE_LARGE_SIZE) {
+	}
+	else if (alloc_len <= XHCI_BOUNCE_LARGE_SIZE)
+	{
 		aligned = slab_alloc(&ctrl->bounce_large);
 		bounce_class = REQ_BOUNCE_CLASS_LARGE;
 	}
-	if (!aligned) {
+	if (!aligned)
+	{
 		aligned = dma_alloc(ctrl->memoryPool, DMA_ALIGN_MIN, alloc_len);
 		bounce_class = REQ_BOUNCE_CLASS_NONE;
 	}
@@ -755,9 +762,7 @@ inline static dma_addr_t xhci_dma_map(struct xhci_ctrl *ctrl, struct USBIOReques
 		return (dma_addr_t)addr;
 	}
 
-	req->driver_private_flags = (req->driver_private_flags & ~REQ_BOUNCE_CLASS_MASK)
-		| (bounce_class << REQ_BOUNCE_CLASS_SHIFT)
-		| REQ_DMA_MAPPED;
+	req->driver_private_flags = (req->driver_private_flags & ~REQ_BOUNCE_CLASS_MASK) | (bounce_class << REQ_BOUNCE_CLASS_SHIFT) | REQ_DMA_MAPPED;
 
 	if (copy)
 	{

--- a/xhci.device/src/xhci/xhci-root-hub.c
+++ b/xhci.device/src/xhci/xhci-root-hub.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * USB HOST XHCI Controller stack
  *

--- a/xhci.device/src/xhci/xhci-root-hub.c
+++ b/xhci.device/src/xhci/xhci-root-hub.c
@@ -23,6 +23,8 @@
 #include <clib/exec_protos.h>
 #include <clib/timer_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
 #include <proto/timer.h>
 #endif
@@ -31,6 +33,7 @@
 #include <exec/errors.h>
 
 #include <debug.h>
+#include <emu_memory.h>
 #include <xhci/ch9.h>
 #include <xhci/usb_defs.h>
 #include <xhci/xhci.h>

--- a/xhci.device/src/xhci/xhci-root-hub.c
+++ b/xhci.device/src/xhci/xhci-root-hub.c
@@ -767,7 +767,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 	const u16 wIndex = le16(req->setup.wIndex); // selector | port
 	const u8 portNo = wIndex & 0xffU;
 #ifdef DEBUG_HIGH
-	xhci_roothub_debug_port(rh, portNo - 1);
+	xhci_roothub_debug_port(rh, portNo - 1u);
 #endif
 
 	struct xhci_hcor_port_regs *port = xhci_roothub_get_port(rh, req);
@@ -916,7 +916,7 @@ static void xhci_roothub_handle_port_get_status(struct xhci_root_hub *rh, struct
 	}
 
 #ifdef DEBUG_HIGH
-	xhci_roothub_debug_port(rh, portNo - 1);
+	xhci_roothub_debug_port(rh, portNo - 1u);
 #endif
 
 	struct xhci_hcor_port_regs *port = xhci_roothub_get_port(rh, req);
@@ -1031,7 +1031,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 	const u8 portNo = wIndex & 0xffU;
 
 #ifdef DEBUG_HIGH
-	xhci_roothub_debug_port(rh, portNo - 1);
+	xhci_roothub_debug_port(rh, portNo - 1u);
 #endif
 
 	struct xhci_hcor_port_regs *port = xhci_roothub_get_port(rh, req);
@@ -1098,10 +1098,6 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 					Kprintf("SS port %lu warm reset completed in %ld0ms "
 							"(portsc=%08lx)\n",
 							(ULONG)portNo, (LONG)attempts, (ULONG)temp);
-
-					/* Allow the link partner to stabilise before
-					 * the stack tries ADDRESS_DEVICE. */
-					xhci_roothub_delay_ms(50);
 				}
 			}
 		}
@@ -1111,6 +1107,10 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 			reg |= PORT_RESET;
 			mmio_write32(reg, &port->or_portsc);
 		}
+
+		/* Allow the link partner to stabilise before
+		 * the stack tries ADDRESS_DEVICE. */
+		xhci_roothub_delay_ms(50);
 		break;
 	}
 	case USB_PORT_FEAT_POWER:

--- a/xhci.device/src/xhci/xhci-root-hub.c
+++ b/xhci.device/src/xhci/xhci-root-hub.c
@@ -33,7 +33,7 @@
 #include <exec/errors.h>
 
 #include <debug.h>
-#include <emu_memory.h>
+#include <memory.h>
 #include <xhci/ch9.h>
 #include <xhci/usb_defs.h>
 #include <xhci/xhci.h>
@@ -71,13 +71,13 @@ static struct descriptor
 		.bLength = 12,
 		.bDescriptorType = USB_DT_SS_HUB, /* hub descriptor */
 		.bNbrPorts = 2,					  /* patched to real port count during init */
-		.wHubCharacteristics = cpu_to_le16(HUB_CHAR_INDV_PORT_LPSM |
+		.wHubCharacteristics = le16(HUB_CHAR_INDV_PORT_LPSM |
 										   HUB_CHAR_INDV_PORT_OCPM), /* per-port power + OC */
 		.bPwrOn2PwrGood = 10,										 /* 20 ms between power on and usable */
 		.bHubContrCurrent = 0,										 /* self-powered: no bus draw */
 		.u.ss = {
 			.bHubHdrDecLat = 0,			 /* no hub delay */
-			.wHubDelay = cpu_to_le16(0), /* no hub delay */
+			.wHubDelay = le16(0), /* no hub delay */
 			.DeviceRemovable = 0,		 /* all ports permanently wired */
 		},
 	},
@@ -85,7 +85,7 @@ static struct descriptor
 		.bLength = 9,
 		.bDescriptorType = USB_DT_HUB,														   /* hub descriptor */
 		.bNbrPorts = 2,																		   /* patched to real port count during init */
-		.wHubCharacteristics = cpu_to_le16(HUB_CHAR_INDV_PORT_LPSM | HUB_CHAR_INDV_PORT_OCPM), /* per-port power + OC */
+		.wHubCharacteristics = le16(HUB_CHAR_INDV_PORT_LPSM | HUB_CHAR_INDV_PORT_OCPM), /* per-port power + OC */
 		.bPwrOn2PwrGood = 10,																   /* 20 ms between power on and usable */
 		.bHubContrCurrent = 0,																   /* self-powered: no bus draw */
 		.u.hs = {
@@ -96,14 +96,14 @@ static struct descriptor
 	.device_30 = {
 		.bLength = sizeof(struct usb_device_descriptor), /* size of device descriptor */
 		.bDescriptorType = USB_DT_DEVICE,				 /* device descriptor */
-		.bcdUSB = cpu_to_le16(0x0310),					 /* advertise as USB 3.2 */
+		.bcdUSB = le16(0x0310),					 /* advertise as USB 3.2 */
 		.bDeviceClass = USB_CLASS_HUB,					 /* hub */
 		.bDeviceSubClass = 0,							 /* no subclass */
 		.bDeviceProtocol = USB_HUB_PR_SS,				 /* super-speed hub */
 		.bMaxPacketSize0 = 9,							 /* control endpoint max packet */
 		.idVendor = 0x0000,								 /* virtual root hub: leave VID zero */
 		.idProduct = 0x0000,							 /* virtual root hub: leave PID zero */
-		.bcdDevice = cpu_to_le16(0x0200),				 /* device revision */
+		.bcdDevice = le16(0x0200),				 /* device revision */
 		.iManufacturer = 1,								 /* string index */
 		.iProduct = 2,									 /* string index */
 		.iSerialNumber = 0,								 /* no serial */
@@ -112,14 +112,14 @@ static struct descriptor
 	.device_20 = {
 		.bLength = sizeof(struct usb_device_descriptor), /* size of device descriptor */
 		.bDescriptorType = USB_DT_DEVICE,				 /* device descriptor */
-		.bcdUSB = cpu_to_le16(0x0200),					 /* advertise as USB 2.0 */
+		.bcdUSB = le16(0x0200),					 /* advertise as USB 2.0 */
 		.bDeviceClass = USB_CLASS_HUB,					 /* hub */
 		.bDeviceSubClass = 0,
 		.bDeviceProtocol = USB_HUB_PR_HS_SINGLE_TT, /* high-speed hub */
 		.bMaxPacketSize0 = 64,						/* control endpoint max packet */
 		.idVendor = 0x0000,							/* virtual root hub: leave VID zero */
 		.idProduct = 0x0000,						/* virtual root hub: leave PID zero */
-		.bcdDevice = cpu_to_le16(0x0200),			/* device revision */
+		.bcdDevice = le16(0x0200),			/* device revision */
 		.iManufacturer = 1,							/* string index */
 		.iProduct = 2,								/* string index */
 		.iSerialNumber = 0,							/* no serial */
@@ -128,7 +128,7 @@ static struct descriptor
 	.config = {
 		.bLength = sizeof(struct usb_config_descriptor),																																				 /* size of configuration descriptor */
 		.bDescriptorType = USB_DT_CONFIG,																																								 /* configuration descriptor */
-		.wTotalLength = cpu_to_le16(sizeof(struct usb_config_descriptor) + sizeof(struct usb_interface_descriptor) + sizeof(struct usb_endpoint_descriptor) + sizeof(struct usb_ss_ep_comp_descriptor)), /* config + interface + endpoint + ss companion */
+		.wTotalLength = le16(sizeof(struct usb_config_descriptor) + sizeof(struct usb_interface_descriptor) + sizeof(struct usb_endpoint_descriptor) + sizeof(struct usb_ss_ep_comp_descriptor)), /* config + interface + endpoint + ss companion */
 		.bNumInterfaces = 1,																																											 /* single interface */
 		.bConfigurationValue = 1,																																										 /* configuration ID */
 		.iConfiguration = 0,																																											 /* no string descriptor */
@@ -151,7 +151,7 @@ static struct descriptor
 		.bDescriptorType = USB_DT_ENDPOINT,										/* endpoint descriptor */
 		.bEndpointAddress = (USB_DIR_IN | 1),									/* INT IN endpoint 1 */
 		.bmAttributes = USB_ENDPOINT_XFER_INT | USB_ENDPOINT_INTR_NOTIFICATION, /* interrupt */
-		.wMaxPacketSize = cpu_to_le16(STATUS_CHANGE_BITMAP_LENGTH),
+		.wMaxPacketSize = le16(STATUS_CHANGE_BITMAP_LENGTH),
 		.bInterval = 8,
 	},
 	.ss_ep_comp = {
@@ -159,29 +159,29 @@ static struct descriptor
 		.bDescriptorType = USB_DT_SS_ENDPOINT_COMP,			 /* SS endpoint companion descriptor */
 		.bMaxBurst = 0,										 /* no bursting */
 		.bmAttributes = 0,									 /* no streams */
-		.wBytesPerInterval = cpu_to_le16(STATUS_CHANGE_BITMAP_LENGTH),
+		.wBytesPerInterval = le16(STATUS_CHANGE_BITMAP_LENGTH),
 	},
 	.bos = {
 		.bLength = sizeof(struct usb_bos_descriptor),																																														  /* size of BOS descriptor */
 		.bDescriptorType = USB_DT_BOS,																																																		  /* BOS descriptor */
-		.wTotalLength = cpu_to_le16(sizeof(struct usb_bos_descriptor) + sizeof(struct usb_2_0_extension_capability_descriptor) + sizeof(struct usb_ss_device_capability_descriptor) + sizeof(struct usb_container_id_capability_descriptor)), /* total length of all BOS descriptors */
+		.wTotalLength = le16(sizeof(struct usb_bos_descriptor) + sizeof(struct usb_2_0_extension_capability_descriptor) + sizeof(struct usb_ss_device_capability_descriptor) + sizeof(struct usb_container_id_capability_descriptor)), /* total length of all BOS descriptors */
 		.bNumDeviceCaps = 3,																																																				  /* number of device capability descriptors */
 	},
 	.ext_cap = {
 		.bLength = sizeof(struct usb_2_0_extension_capability_descriptor), /* size of USB 2.0 extension descriptor */
 		.bDescriptorType = USB_DT_DEVICE_CAPABILITY,					   /* device capability descriptor */
 		.bDevCapabilityType = USB_CAP_DESC_USB20_EXTENSION,				   /* USB 2.0 extension capability */
-		.bmAttributes = cpu_to_le32(0),
+		.bmAttributes = le32(0),
 	},
 	.ss_dev_cap = {
 		.bLength = sizeof(struct usb_ss_device_capability_descriptor), /* size of SuperSpeed USB device capability descriptor */
 		.bDescriptorType = USB_DT_DEVICE_CAPABILITY,				   /* device capability descriptor */
 		.bDevCapabilityType = USB_CAP_DESC_SS_USB_DEVICE,			   /* SuperSpeed USB device capability */
 		.bmAttributes = 0,
-		.wSpeedsSupported = cpu_to_le16(USB_SS_DEVICE_LOWSPEED_SUPPORT | USB_SS_DEVICE_FULLSPEED_SUPPORT | USB_SS_DEVICE_HIGHSPEED_SUPPORT | USB_SS_DEVICE_SUPERSPEED_SUPPORT), /* supports all speeds */
+		.wSpeedsSupported = le16(USB_SS_DEVICE_LOWSPEED_SUPPORT | USB_SS_DEVICE_FULLSPEED_SUPPORT | USB_SS_DEVICE_HIGHSPEED_SUPPORT | USB_SS_DEVICE_SUPERSPEED_SUPPORT), /* supports all speeds */
 		.bFunctionalitySupport = 1,																																				/* lowest speed is 1 (low speed) */
 		.bU1DevExitLat = 0,																																						/* no U1 exit latency */
-		.wU2DevExitLat = cpu_to_le16(0),																																		/* no U2 exit latency */
+		.wU2DevExitLat = le16(0),																																		/* no U2 exit latency */
 	},
 	.container_id_cap = {
 		.bLength = sizeof(struct usb_container_id_capability_descriptor), /* size of Container ID capability descriptor */
@@ -224,7 +224,7 @@ struct xhci_root_hub
 static void xhci_roothub_debug_port(struct xhci_root_hub *rh, int port)
 {
 	struct xhci_ctrl *ctrl = rh->udev->controller;
-	u32 portsc = readl(&ctrl->hcor->portregs[port].or_portsc);
+	u32 portsc = mmio_read32(&ctrl->hcor->portregs[port].or_portsc);
 	KprintfH("port %ld status: 0x%08lx\n", (LONG)port + 1, portsc);
 
 	if (portsc & PORT_CONNECT) // ROS
@@ -340,7 +340,7 @@ static void xhci_roothub_debug_port(struct xhci_root_hub *rh, int port)
 struct xhci_root_hub *xhci_roothub_create(struct usb_device *udev, io_reply_data_fn io_reply_data)
 {
 	struct xhci_ctrl *ctrl = udev->controller;
-	struct xhci_root_hub *rh = AllocVecPooled(ctrl->memoryPool, sizeof(struct xhci_root_hub));
+	struct xhci_root_hub *rh = pool_zalloc(ctrl->memoryPool, sizeof(struct xhci_root_hub));
 	if (!rh)
 		return NULL;
 
@@ -349,15 +349,15 @@ struct xhci_root_hub *xhci_roothub_create(struct usb_device *udev, io_reply_data
 
 	CopyMem(&prototype_descriptor, &rh->descriptor, sizeof(prototype_descriptor));
 
-	const u8 ports = HCS_MAX_PORTS(readl(&ctrl->hccr->cr_hcsparams1));
+	const u8 ports = HCS_MAX_PORTS(mmio_read32(&ctrl->hccr->cr_hcsparams1));
 	rh->descriptor.hub_30.bNbrPorts = ports;
 	rh->descriptor.hub_20.bNbrPorts = ports;
 
 	Kprintf("Initializing root hub with %ld ports\n", (LONG)ports);
 
 	/* Port Indicators */
-	const u32 hccParams1 = readl(&ctrl->hccr->cr_hccparams1);
-	u16 wHubCharacteristics = LE16(rh->descriptor.hub_30.wHubCharacteristics);
+	const u32 hccParams1 = mmio_read32(&ctrl->hccr->cr_hccparams1);
+	u16 wHubCharacteristics = le16(rh->descriptor.hub_30.wHubCharacteristics);
 	if (HCS_INDICATOR(hccParams1))
 	{
 		wHubCharacteristics |= HUB_CHAR_PORTIND;
@@ -375,21 +375,21 @@ struct xhci_root_hub *xhci_roothub_create(struct usb_device *udev, io_reply_data
 		rh->descriptor.ss_dev_cap.bmAttributes |= USB_SS_DEVICE_ATT_LATENCY_TOLERANCE_MESSAGES;
 	// TODO add support for Set Latency Tolerance Value command
 
-	rh->descriptor.hub_30.wHubCharacteristics = LE16(wHubCharacteristics);
-	rh->descriptor.hub_20.wHubCharacteristics = LE16(wHubCharacteristics);
+	rh->descriptor.hub_30.wHubCharacteristics = le16(wHubCharacteristics);
+	rh->descriptor.hub_20.wHubCharacteristics = le16(wHubCharacteristics);
 
 	/* Exit latencies */
-	const u32 hcsParams3 = readl(&ctrl->hccr->cr_hcsparams3);
+	const u32 hcsParams3 = mmio_read32(&ctrl->hccr->cr_hcsparams3);
 	rh->descriptor.ss_dev_cap.bU1DevExitLat = HCS_U1_LATENCY(hcsParams3);
 	rh->descriptor.ss_dev_cap.wU2DevExitLat = HCS_U2_LATENCY(hcsParams3);
 	Kprintf("Host controller U1 exit latency: %ld microseconds\n", (LONG)rh->descriptor.ss_dev_cap.bU1DevExitLat);
 	Kprintf("Host controller U2 exit latency: %ld microseconds\n", (LONG)rh->descriptor.ss_dev_cap.wU2DevExitLat);
 
 	/* Create port structs and fill with data from protool extended capability */
-	rh->ports = AllocVecPooled(ctrl->memoryPool, ports * sizeof(struct xhci_root_hub_port));
+	rh->ports = pool_zalloc(ctrl->memoryPool, ports * sizeof(struct xhci_root_hub_port));
 	if (!rh->ports)
 	{
-		FreeVecPooled(ctrl->memoryPool, rh);
+		pool_free(ctrl->memoryPool, rh);
 		Kprintf("Failed to allocate root hub port data\n");
 		return NULL;
 	}
@@ -454,9 +454,9 @@ void xhci_roothub_destroy(struct xhci_root_hub *rh)
 	xhci_roothub_abort_int_request(rh);
 
 	if (rh->ports)
-		FreeVecPooled(rh->udev->controller->memoryPool, rh->ports);
+		pool_free(rh->udev->controller->memoryPool, rh->ports);
 
-	FreeVecPooled(rh->udev->controller->memoryPool, rh);
+	pool_free(rh->udev->controller->memoryPool, rh);
 }
 
 unsigned int xhci_roothub_get_address(struct xhci_root_hub *rh)
@@ -515,7 +515,7 @@ void xhci_roothub_complete_int_request(struct xhci_root_hub *rh)
 	BOOL change = FALSE;
 	for (u8 port = 0; port < num_ports; ++port)
 	{
-		u32 portsc = readl(&ctrl->hcor->portregs[port].or_portsc);
+		u32 portsc = mmio_read32(&ctrl->hcor->portregs[port].or_portsc);
 		u32 change_bits = portsc & change_mask;
 		if (!change_bits)
 			continue;
@@ -571,7 +571,7 @@ inline static void xhci_roothub_reply(struct USBIORequest *req, void *data, u32 
 	if (!req)
 		return;
 
-	length = min(length, LE16(req->setup.wLength));
+	length = min(length, le16(req->setup.wLength));
 	if (data && length > 0)
 		CopyMem(data, req->data_buffer, length);
 
@@ -618,11 +618,11 @@ static void xhci_roothub_handle_device_get_descriptor(struct xhci_root_hub *rh, 
 {
 	struct USBSetupPacket *setup = &req->setup;
 
-	switch (LE16(setup->wValue) >> 8)
+	switch (le16(setup->wValue) >> 8)
 	{
 	case USB_DT_BOS:
 		KprintfH("get USB_DT_BOS\n");
-		xhci_roothub_reply(req, &rh->descriptor.bos, LE16(rh->descriptor.bos.wTotalLength));
+		xhci_roothub_reply(req, &rh->descriptor.bos, le16(rh->descriptor.bos.wTotalLength));
 		break;
 	case USB_DT_DEVICE:
 		KprintfH("get USB_DT_DEVICE\n");
@@ -633,11 +633,11 @@ static void xhci_roothub_handle_device_get_descriptor(struct xhci_root_hub *rh, 
 		break;
 	case USB_DT_CONFIG:
 		KprintfH("get USB_DT_CONFIG\n");
-		xhci_roothub_reply(req, &rh->descriptor.config, LE16(rh->descriptor.config.wTotalLength));
+		xhci_roothub_reply(req, &rh->descriptor.config, le16(rh->descriptor.config.wTotalLength));
 		break;
 	case USB_DT_STRING:
 		KprintfH("get USB_DT_STRING\n");
-		switch (LE16(setup->wValue) & 0xff)
+		switch (le16(setup->wValue) & 0xff)
 		{
 		case 0: /* Language */
 			xhci_roothub_reply(req, "\4\3\11\4", 4);
@@ -649,12 +649,12 @@ static void xhci_roothub_handle_device_get_descriptor(struct xhci_root_hub *rh, 
 			xhci_roothub_reply(req, "\52\3X\0H\0C\0I\0 \0H\0o\0s\0t\0 \0C\0o\0n\0t\0r\0o\0l\0l\0e\0r\0", 42);
 			break;
 		default:
-			Kprintf("unknown value DT_STRING %lx\n", LE16(setup->wValue));
+			Kprintf("unknown value DT_STRING %lx\n", le16(setup->wValue));
 			xhci_roothub_stall(req);
 		}
 		break;
 	default:
-		Kprintf("get unknown wValue %lx\n", LE16(setup->wValue));
+		Kprintf("get unknown wValue %lx\n", le16(setup->wValue));
 		xhci_roothub_stall(req);
 	}
 }
@@ -737,10 +737,10 @@ inline static void xhci_roothub_clear_port_change_bit(u16 wValue, u8 portNo, vol
 	}
 
 	/* Change bits are all write 1 to clear */
-	writel(port_status | status, addr);
+	mmio_write32(port_status | status, addr);
 
 #ifdef DEBUG_HIGH
-	port_status = readl(addr);
+	port_status = mmio_read32(addr);
 	KprintfH("clear port %s change, actual port %ld status  = 0x%lx\n", port_change_bit, portNo, port_status);
 #else
 	(void)port_change_bit;
@@ -751,7 +751,7 @@ inline static void xhci_roothub_clear_port_change_bit(u16 wValue, u8 portNo, vol
 inline static struct xhci_hcor_port_regs *xhci_roothub_get_port(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
 	struct xhci_ctrl *ctrl = rh->udev->controller;
-	u8 port = LE16(req->setup.wIndex) & 0xff; // port number is in low byte of wIndex;
+	u8 port = le16(req->setup.wIndex) & 0xff; // port number is in low byte of wIndex;
 
 	if (port == 0 || port > rh->descriptor.hub_30.bNbrPorts)
 		return NULL;
@@ -761,15 +761,15 @@ inline static struct xhci_hcor_port_regs *xhci_roothub_get_port(struct xhci_root
 
 static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
-	const u16 wValue = LE16(req->setup.wValue); // feature selector
-	const u16 wIndex = LE16(req->setup.wIndex); // selector | port
+	const u16 wValue = le16(req->setup.wValue); // feature selector
+	const u16 wIndex = le16(req->setup.wIndex); // selector | port
 	const u8 portNo = wIndex & 0xff;
 #ifdef DEBUG_HIGH
 	xhci_roothub_debug_port(rh, portNo - 1);
 #endif
 
 	struct xhci_hcor_port_regs *port = xhci_roothub_get_port(rh, req);
-	u32 reg = readl(&port->or_portsc);
+	u32 reg = mmio_read32(&port->or_portsc);
 	reg = xhci_roothub_port_state_to_neutral(reg);
 
 	switch (wValue)
@@ -778,7 +778,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 	case USB_PORT_FEAT_POWER:
 		KprintfH("Clear port %ld PORT_POWER\n", portNo);
 		reg &= ~PORT_POWER;
-		writel(reg, &port->or_portsc);
+		mmio_write32(reg, &port->or_portsc);
 		break;
 	case USB_PORT_FEAT_C_CONNECTION:
 	case USB_PORT_FEAT_C_OVER_CURRENT:
@@ -791,11 +791,11 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 		 * so we clear WRC here alongside PRC. */
 		if (rh->ports[portNo - 1].major_revision >= 3)
 		{
-			u32 tmp = readl(&port->or_portsc);
+			u32 tmp = mmio_read32(&port->or_portsc);
 			if (tmp & PORT_WRC)
 			{
 				tmp = xhci_roothub_port_state_to_neutral(tmp);
-				writel(tmp | PORT_WRC, &port->or_portsc);
+				mmio_write32(tmp | PORT_WRC, &port->or_portsc);
 			}
 		}
 		break;
@@ -808,9 +808,9 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 		// USB3 specific features
 	case USB_SS_PORT_FEAT_FORCE_LINKPM_ACCEPT:
 		KprintfH("Clear port %ld FORCE_LINKPM_ACCEPT\n", portNo);
-		reg = readl(&port->or_portpmsc);
+		reg = mmio_read32(&port->or_portpmsc);
 		reg &= ~PORT_FLA;
-		writel(reg, &port->or_portpmsc);
+		mmio_write32(reg, &port->or_portpmsc);
 		break;
 	case USB_SS_PORT_FEAT_C_LINK_STATE:
 	case USB_SS_PORT_FEAT_C_CONFIG_ERROR:
@@ -833,7 +833,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 		else
 		{
 			reg |= PORT_PE;
-			writel(reg, &port->or_portsc);
+			mmio_write32(reg, &port->or_portsc);
 		}
 		break;
 	case USB_PORT_FEAT_SUSPEND:
@@ -844,15 +844,15 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 			reg &= ~PORT_PLS_MASK;
 			reg |= XDEV_RESUME;
 			reg |= PORT_LINK_STROBE;
-			writel(reg, &port->or_portsc);
+			mmio_write32(reg, &port->or_portsc);
 			xhci_roothub_delay_ms(25); // wait at least 20ms for resume to take effect
-			reg = readl(&port->or_portsc);
+			reg = mmio_read32(&port->or_portsc);
 			reg = xhci_roothub_port_state_to_neutral(reg);
 		}
 		reg &= ~PORT_PLS_MASK;
 		reg |= XDEV_U0; // put port back to U0 (active) state
 		reg |= PORT_LINK_STROBE;
-		writel(reg, &port->or_portsc);
+		mmio_write32(reg, &port->or_portsc);
 		break;
 	case USB_PORT_FEAT_C_ENABLE:
 	case USB_PORT_FEAT_C_SUSPEND:
@@ -872,7 +872,7 @@ static void xhci_roothub_handle_hub_get_descriptor(struct xhci_root_hub *rh, str
 {
 	(void)rh;
 	KprintfH("USB_REQ_GET_DESCRIPTOR HUB\n");
-	const u16 wValue = LE16(req->setup.wValue);
+	const u16 wValue = le16(req->setup.wValue);
 	if (wValue >> 8 == USB_DT_SS_HUB && rh->is_super_speed)
 	{
 		xhci_roothub_reply(req, &rh->descriptor.hub_30, rh->descriptor.hub_30.bLength);
@@ -900,9 +900,9 @@ static void xhci_roothub_handle_hub_get_status(struct xhci_root_hub *rh, struct 
 
 static void xhci_roothub_handle_port_get_status(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
-	const u16 wIndex = LE16(req->setup.wIndex);
-	const u16 wValue = LE16(req->setup.wValue);
-	const u16 wLength = LE16(req->setup.wLength);
+	const u16 wIndex = le16(req->setup.wIndex);
+	const u16 wValue = le16(req->setup.wValue);
+	const u16 wLength = le16(req->setup.wLength);
 	const u8 portNo = wIndex & 0xff;
 	const u8 portStatusType = wValue & 0xff;
 
@@ -918,7 +918,7 @@ static void xhci_roothub_handle_port_get_status(struct xhci_root_hub *rh, struct
 #endif
 
 	struct xhci_hcor_port_regs *port = xhci_roothub_get_port(rh, req);
-	const u32 reg = readl(&port->or_portsc);
+	const u32 reg = mmio_read32(&port->or_portsc);
 
 	u16 wPortStatus;
 	if (rh->is_super_speed)
@@ -998,7 +998,7 @@ static void xhci_roothub_handle_port_get_status(struct xhci_root_hub *rh, struct
 
 static void xhci_roothub_handle_get_port_error_count(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
-	const u16 wIndex = LE16(req->setup.wIndex);
+	const u16 wIndex = le16(req->setup.wIndex);
 	const u8 portNo = wIndex & 0xff;
 
 	if (rh->ports[portNo - 1].major_revision < 3)
@@ -1007,15 +1007,15 @@ static void xhci_roothub_handle_get_port_error_count(struct xhci_root_hub *rh, s
 		xhci_roothub_stall(req);
 		return;
 	}
-	if (req->setup.wValue != 0 || LE16(req->setup.wLength) < 2)
+	if (req->setup.wValue != 0 || le16(req->setup.wLength) < 2)
 	{
-		Kprintf("invalid get port error count request value 0x%lx length %ld\n", LE16(req->setup.wValue), LE16(req->setup.wLength));
+		Kprintf("invalid get port error count request value 0x%lx length %ld\n", le16(req->setup.wValue), le16(req->setup.wLength));
 		xhci_roothub_stall(req);
 		return;
 	}
 
 	struct xhci_hcor_port_regs *port = xhci_roothub_get_port(rh, req);
-	const u16 errors = readl(&port->or_portli) & 0xffff;
+	const u16 errors = mmio_read32(&port->or_portli) & 0xffff;
 
 	KprintfH("USB_REQ_GET_PORT_ERROR_COUNT PORT %ld error count=%u\n", wIndex, errors);
 	u8 tmpbuf[2] = {errors & 0xff, errors >> 8};
@@ -1024,8 +1024,8 @@ static void xhci_roothub_handle_get_port_error_count(struct xhci_root_hub *rh, s
 
 static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
-	const u16 wValue = LE16(req->setup.wValue);
-	const u16 wIndex = LE16(req->setup.wIndex);
+	const u16 wValue = le16(req->setup.wValue);
+	const u16 wIndex = le16(req->setup.wIndex);
 	const u8 portNo = wIndex & 0xff;
 
 #ifdef DEBUG_HIGH
@@ -1033,7 +1033,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 #endif
 
 	struct xhci_hcor_port_regs *port = xhci_roothub_get_port(rh, req);
-	u32 reg = readl(&port->or_portsc);
+	u32 reg = mmio_read32(&port->or_portsc);
 	reg = xhci_roothub_port_state_to_neutral(reg);
 
 	switch (wValue)
@@ -1052,7 +1052,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 			Kprintf("SS port %ld PLS=%ld (%s); upgrading to warm reset (portsc=%08lx)\n",
 					(LONG)portNo, (LONG)(pls >> 5),
 					pls == XDEV_COMPLIANCE ? "Compliance" : "SS.Inactive",
-					(ULONG)readl(&port->or_portsc));
+					(ULONG)mmio_read32(&port->or_portsc));
 
 			/* Clear all pending change bits before the warm reset.
 			 * Stale change bits (especially PLC from the Compliance
@@ -1060,16 +1060,16 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 			 * the link bounces through disconnect/reconnect and recovers
 			 * via normal link training instead, leaving WRC=0 and the
 			 * device in a state where ADDRESS_DEVICE times out. */
-			writel(reg | PORT_CSC | PORT_PEC | PORT_WRC |
+			mmio_write32(reg | PORT_CSC | PORT_PEC | PORT_WRC |
 					   PORT_OCC | PORT_RC | PORT_PLC | PORT_CEC,
 				   &port->or_portsc);
 
 			/* Re-read and re-neutralize after clearing change bits */
-			reg = readl(&port->or_portsc);
+			reg = mmio_read32(&port->or_portsc);
 			reg = xhci_roothub_port_state_to_neutral(reg);
 
 			/* Initiate warm reset */
-			writel(reg | PORT_WR, &port->or_portsc);
+			mmio_write32(reg | PORT_WR, &port->or_portsc);
 
 			/* Poll until the warm reset completes (PORT_RESET clears)
 			 * or we time out.  Linux's hub_port_wait_reset() does the
@@ -1080,7 +1080,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 				for (attempts = 0; attempts < 100; attempts++)
 				{
 					xhci_roothub_delay_ms(10);
-					temp = readl(&port->or_portsc);
+					temp = mmio_read32(&port->or_portsc);
 					if (!(temp & PORT_RESET))
 						break;
 				}
@@ -1107,14 +1107,14 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 		{
 			KprintfH("Set port %ld PORT_RESET\n", portNo);
 			reg |= PORT_RESET;
-			writel(reg, &port->or_portsc);
+			mmio_write32(reg, &port->or_portsc);
 		}
 		break;
 	}
 	case USB_PORT_FEAT_POWER:
 		KprintfH("Set port %ld PORT_POWER\n", portNo);
 		reg |= PORT_POWER;
-		writel(reg, &port->or_portsc);
+		mmio_write32(reg, &port->or_portsc);
 		break;
 	case USB_PORT_FEAT_CONNECTION:
 	case USB_PORT_FEAT_OVER_CURRENT:
@@ -1127,21 +1127,21 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 	case USB_SS_PORT_FEAT_BH_RESET:
 		KprintfH("Set port %ld PORT_BH_RESET\n", portNo);
 		reg |= PORT_WR;
-		writel(reg, &port->or_portsc);
+		mmio_write32(reg, &port->or_portsc);
 		break;
 	case USB_SS_PORT_FEAT_U1_TIMEOUT:
 		KprintfH("Setting port %ld U1 timeout to %ld microseconds\n", portNo, wIndex >> 8);
-		reg = readl(&port->or_portpmsc);
+		reg = mmio_read32(&port->or_portpmsc);
 		reg &= ~0xff;
 		reg |= PORT_U1_TIMEOUT(wIndex >> 8);
-		writel(reg, &port->or_portpmsc);
+		mmio_write32(reg, &port->or_portpmsc);
 		break;
 	case USB_SS_PORT_FEAT_U2_TIMEOUT:
 		KprintfH("Setting port %ld U2 timeout to %ld microseconds\n", portNo, wIndex >> 8);
-		reg = readl(&port->or_portpmsc);
+		reg = mmio_read32(&port->or_portpmsc);
 		reg &= ~0xff00;
 		reg |= PORT_U2_TIMEOUT(wIndex >> 8);
-		writel(reg, &port->or_portpmsc);
+		mmio_write32(reg, &port->or_portpmsc);
 		break;
 	case USB_PORT_FEAT_LINK_STATE:
 	{
@@ -1152,7 +1152,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 			reg &= ~PORT_PLS_MASK;
 			reg |= PORT_LINK_STROBE;
 			reg |= link_state << 5;
-			writel(reg, &port->or_portsc);
+			mmio_write32(reg, &port->or_portsc);
 		}
 		else
 		{
@@ -1168,14 +1168,14 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 		KprintfH("Set port %ld REMOTE_WAKE_MASK to %lx\n", portNo, wake_mask);
 		reg &= ~(PORT_WKCONN_E | PORT_WKDISC_E | PORT_WKOC_E);
 		reg |= wake_mask << 25;
-		writel(reg, &port->or_portsc);
+		mmio_write32(reg, &port->or_portsc);
 		break;
 	}
 	case USB_SS_PORT_FEAT_FORCE_LINKPM_ACCEPT:
 		KprintfH("Set port %ld FORCE_LINKPM_ACCEPT\n", portNo);
-		reg = readl(&port->or_portpmsc);
+		reg = mmio_read32(&port->or_portpmsc);
 		reg |= PORT_FLA;
-		writel(reg, &port->or_portpmsc);
+		mmio_write32(reg, &port->or_portpmsc);
 		break;
 
 	// USB2 specific features
@@ -1184,7 +1184,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 		reg &= ~PORT_PLS_MASK;
 		reg |= XDEV_U3;
 		reg |= PORT_LINK_STROBE;
-		writel(reg, &port->or_portsc);
+		mmio_write32(reg, &port->or_portsc);
 		break;
 	case USB_PORT_FEAT_TEST:
 		/* No-op */
@@ -1207,9 +1207,9 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
  */
 void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct USBIORequest *io)
 {
-	const u16 wIndex = LE16(io->setup.wIndex);
+	const u16 wIndex = le16(io->setup.wIndex);
 #ifdef DEBUG_HIGH
-	const u16 wValue = LE16(io->setup.wValue);
+	const u16 wValue = le16(io->setup.wValue);
 #endif
 
 	struct USBSetupPacket *setup = &io->setup;

--- a/xhci.device/src/xhci/xhci-root-hub.c
+++ b/xhci.device/src/xhci/xhci-root-hub.c
@@ -72,22 +72,22 @@ static struct descriptor
 		.bDescriptorType = USB_DT_SS_HUB, /* hub descriptor */
 		.bNbrPorts = 2,					  /* patched to real port count during init */
 		.wHubCharacteristics = le16(HUB_CHAR_INDV_PORT_LPSM |
-										   HUB_CHAR_INDV_PORT_OCPM), /* per-port power + OC */
-		.bPwrOn2PwrGood = 10,										 /* 20 ms between power on and usable */
-		.bHubContrCurrent = 0,										 /* self-powered: no bus draw */
+									HUB_CHAR_INDV_PORT_OCPM), /* per-port power + OC */
+		.bPwrOn2PwrGood = 10,								  /* 20 ms between power on and usable */
+		.bHubContrCurrent = 0,								  /* self-powered: no bus draw */
 		.u.ss = {
-			.bHubHdrDecLat = 0,			 /* no hub delay */
+			.bHubHdrDecLat = 0,	  /* no hub delay */
 			.wHubDelay = le16(0), /* no hub delay */
-			.DeviceRemovable = 0,		 /* all ports permanently wired */
+			.DeviceRemovable = 0, /* all ports permanently wired */
 		},
 	},
 	.hub_20 = {
 		.bLength = 9,
-		.bDescriptorType = USB_DT_HUB,														   /* hub descriptor */
-		.bNbrPorts = 2,																		   /* patched to real port count during init */
+		.bDescriptorType = USB_DT_HUB,													/* hub descriptor */
+		.bNbrPorts = 2,																	/* patched to real port count during init */
 		.wHubCharacteristics = le16(HUB_CHAR_INDV_PORT_LPSM | HUB_CHAR_INDV_PORT_OCPM), /* per-port power + OC */
-		.bPwrOn2PwrGood = 10,																   /* 20 ms between power on and usable */
-		.bHubContrCurrent = 0,																   /* self-powered: no bus draw */
+		.bPwrOn2PwrGood = 10,															/* 20 ms between power on and usable */
+		.bHubContrCurrent = 0,															/* self-powered: no bus draw */
 		.u.hs = {
 			.DeviceRemovable = {0},		 /* all ports permanently wired */
 			.PortPowerCtrlMask = {0xff}, /* all ports always have power */
@@ -96,14 +96,14 @@ static struct descriptor
 	.device_30 = {
 		.bLength = sizeof(struct usb_device_descriptor), /* size of device descriptor */
 		.bDescriptorType = USB_DT_DEVICE,				 /* device descriptor */
-		.bcdUSB = le16(0x0310),					 /* advertise as USB 3.2 */
+		.bcdUSB = le16(0x0310),							 /* advertise as USB 3.2 */
 		.bDeviceClass = USB_CLASS_HUB,					 /* hub */
 		.bDeviceSubClass = 0,							 /* no subclass */
 		.bDeviceProtocol = USB_HUB_PR_SS,				 /* super-speed hub */
 		.bMaxPacketSize0 = 9,							 /* control endpoint max packet */
 		.idVendor = 0x0000,								 /* virtual root hub: leave VID zero */
 		.idProduct = 0x0000,							 /* virtual root hub: leave PID zero */
-		.bcdDevice = le16(0x0200),				 /* device revision */
+		.bcdDevice = le16(0x0200),						 /* device revision */
 		.iManufacturer = 1,								 /* string index */
 		.iProduct = 2,									 /* string index */
 		.iSerialNumber = 0,								 /* no serial */
@@ -112,28 +112,28 @@ static struct descriptor
 	.device_20 = {
 		.bLength = sizeof(struct usb_device_descriptor), /* size of device descriptor */
 		.bDescriptorType = USB_DT_DEVICE,				 /* device descriptor */
-		.bcdUSB = le16(0x0200),					 /* advertise as USB 2.0 */
+		.bcdUSB = le16(0x0200),							 /* advertise as USB 2.0 */
 		.bDeviceClass = USB_CLASS_HUB,					 /* hub */
 		.bDeviceSubClass = 0,
 		.bDeviceProtocol = USB_HUB_PR_HS_SINGLE_TT, /* high-speed hub */
 		.bMaxPacketSize0 = 64,						/* control endpoint max packet */
 		.idVendor = 0x0000,							/* virtual root hub: leave VID zero */
 		.idProduct = 0x0000,						/* virtual root hub: leave PID zero */
-		.bcdDevice = le16(0x0200),			/* device revision */
+		.bcdDevice = le16(0x0200),					/* device revision */
 		.iManufacturer = 1,							/* string index */
 		.iProduct = 2,								/* string index */
 		.iSerialNumber = 0,							/* no serial */
 		.bNumConfigurations = 1,					/* single configuration */
 	},
 	.config = {
-		.bLength = sizeof(struct usb_config_descriptor),																																				 /* size of configuration descriptor */
-		.bDescriptorType = USB_DT_CONFIG,																																								 /* configuration descriptor */
+		.bLength = sizeof(struct usb_config_descriptor),																																		  /* size of configuration descriptor */
+		.bDescriptorType = USB_DT_CONFIG,																																						  /* configuration descriptor */
 		.wTotalLength = le16(sizeof(struct usb_config_descriptor) + sizeof(struct usb_interface_descriptor) + sizeof(struct usb_endpoint_descriptor) + sizeof(struct usb_ss_ep_comp_descriptor)), /* config + interface + endpoint + ss companion */
-		.bNumInterfaces = 1,																																											 /* single interface */
-		.bConfigurationValue = 1,																																										 /* configuration ID */
-		.iConfiguration = 0,																																											 /* no string descriptor */
-		.bmAttributes = USB_CONFIG_ATT_ONE | USB_CONFIG_ATT_SELFPOWER,																																	 /* must-set + self-powered */
-		.bMaxPower = 0,																																													 /* no bus power drawn */
+		.bNumInterfaces = 1,																																									  /* single interface */
+		.bConfigurationValue = 1,																																								  /* configuration ID */
+		.iConfiguration = 0,																																									  /* no string descriptor */
+		.bmAttributes = USB_CONFIG_ATT_ONE | USB_CONFIG_ATT_SELFPOWER,																															  /* must-set + self-powered */
+		.bMaxPower = 0,																																											  /* no bus power drawn */
 	},
 	.interface = {
 		.bLength = sizeof(struct usb_interface_descriptor), /* size of interface descriptor */
@@ -162,10 +162,10 @@ static struct descriptor
 		.wBytesPerInterval = le16(STATUS_CHANGE_BITMAP_LENGTH),
 	},
 	.bos = {
-		.bLength = sizeof(struct usb_bos_descriptor),																																														  /* size of BOS descriptor */
-		.bDescriptorType = USB_DT_BOS,																																																		  /* BOS descriptor */
+		.bLength = sizeof(struct usb_bos_descriptor),																																												   /* size of BOS descriptor */
+		.bDescriptorType = USB_DT_BOS,																																																   /* BOS descriptor */
 		.wTotalLength = le16(sizeof(struct usb_bos_descriptor) + sizeof(struct usb_2_0_extension_capability_descriptor) + sizeof(struct usb_ss_device_capability_descriptor) + sizeof(struct usb_container_id_capability_descriptor)), /* total length of all BOS descriptors */
-		.bNumDeviceCaps = 3,																																																				  /* number of device capability descriptors */
+		.bNumDeviceCaps = 3,																																																		   /* number of device capability descriptors */
 	},
 	.ext_cap = {
 		.bLength = sizeof(struct usb_2_0_extension_capability_descriptor), /* size of USB 2.0 extension descriptor */
@@ -179,9 +179,9 @@ static struct descriptor
 		.bDevCapabilityType = USB_CAP_DESC_SS_USB_DEVICE,			   /* SuperSpeed USB device capability */
 		.bmAttributes = 0,
 		.wSpeedsSupported = le16(USB_SS_DEVICE_LOWSPEED_SUPPORT | USB_SS_DEVICE_FULLSPEED_SUPPORT | USB_SS_DEVICE_HIGHSPEED_SUPPORT | USB_SS_DEVICE_SUPERSPEED_SUPPORT), /* supports all speeds */
-		.bFunctionalitySupport = 1,																																				/* lowest speed is 1 (low speed) */
-		.bU1DevExitLat = 0,																																						/* no U1 exit latency */
-		.wU2DevExitLat = le16(0),																																		/* no U2 exit latency */
+		.bFunctionalitySupport = 1,																																		 /* lowest speed is 1 (low speed) */
+		.bU1DevExitLat = 0,																																				 /* no U1 exit latency */
+		.wU2DevExitLat = le16(0),																																		 /* no U2 exit latency */
 	},
 	.container_id_cap = {
 		.bLength = sizeof(struct usb_container_id_capability_descriptor), /* size of Container ID capability descriptor */
@@ -221,11 +221,11 @@ struct xhci_root_hub
 };
 
 #ifdef DEBUG_HIGH
-static void xhci_roothub_debug_port(struct xhci_root_hub *rh, int port)
+static void xhci_roothub_debug_port(struct xhci_root_hub *rh, u32 port)
 {
 	struct xhci_ctrl *ctrl = rh->udev->controller;
 	u32 portsc = mmio_read32(&ctrl->hcor->portregs[port].or_portsc);
-	KprintfH("port %ld status: 0x%08lx\n", (LONG)port + 1, portsc);
+	KprintfH("port %lu status: 0x%08lx\n", (ULONG)port + 1, (ULONG)portsc);
 
 	if (portsc & PORT_CONNECT) // ROS
 		KprintfH("  device connected\n");
@@ -288,7 +288,7 @@ static void xhci_roothub_debug_port(struct xhci_root_hub *rh, int port)
 		KprintfH("  link state: Resume\n");
 		break;
 	default:
-		KprintfH("  link state: unknown (%ld)\n", (LONG)pls >> 5);
+		KprintfH("  link state: unknown (%lu)\n", (ULONG)(pls >> 5));
 		break;
 	}
 
@@ -313,7 +313,7 @@ static void xhci_roothub_debug_port(struct xhci_root_hub *rh, int port)
 		KprintfH("  device speed: Super Speed\n");
 		break;
 	default:
-		KprintfH("  device speed: unknown (%ld)\n", (LONG)speed >> 10);
+		KprintfH("  device speed: unknown (%lu)\n", (ULONG)(speed >> 10));
 		break;
 	}
 
@@ -353,7 +353,7 @@ struct xhci_root_hub *xhci_roothub_create(struct usb_device *udev, io_reply_data
 	rh->descriptor.hub_30.bNbrPorts = ports;
 	rh->descriptor.hub_20.bNbrPorts = ports;
 
-	Kprintf("Initializing root hub with %ld ports\n", (LONG)ports);
+	Kprintf("Initializing root hub with %lu ports\n", (ULONG)ports);
 
 	/* Port Indicators */
 	const u32 hccParams1 = mmio_read32(&ctrl->hccr->cr_hccparams1);
@@ -381,9 +381,9 @@ struct xhci_root_hub *xhci_roothub_create(struct usb_device *udev, io_reply_data
 	/* Exit latencies */
 	const u32 hcsParams3 = mmio_read32(&ctrl->hccr->cr_hcsparams3);
 	rh->descriptor.ss_dev_cap.bU1DevExitLat = HCS_U1_LATENCY(hcsParams3);
-	rh->descriptor.ss_dev_cap.wU2DevExitLat = HCS_U2_LATENCY(hcsParams3);
-	Kprintf("Host controller U1 exit latency: %ld microseconds\n", (LONG)rh->descriptor.ss_dev_cap.bU1DevExitLat);
-	Kprintf("Host controller U2 exit latency: %ld microseconds\n", (LONG)rh->descriptor.ss_dev_cap.wU2DevExitLat);
+	rh->descriptor.ss_dev_cap.wU2DevExitLat = le16(HCS_U2_LATENCY(hcsParams3));
+	Kprintf("Host controller U1 exit latency: %lu microseconds\n", (ULONG)rh->descriptor.ss_dev_cap.bU1DevExitLat);
+	Kprintf("Host controller U2 exit latency: %lu microseconds\n", (ULONG)le16(rh->descriptor.ss_dev_cap.wU2DevExitLat));
 
 	/* Create port structs and fill with data from protool extended capability */
 	rh->ports = pool_zalloc(ctrl->memoryPool, ports * sizeof(struct xhci_root_hub_port));
@@ -401,7 +401,7 @@ struct xhci_root_hub *xhci_roothub_create(struct usb_device *udev, io_reply_data
 	while ((cap_base = xhci_find_next_capability(ctrl, XHCI_EXT_CAPS_PROTOCOL, &next_offset)) != NULL)
 	{
 		struct xhci_protocol_caps caps = xhci_get_protocol_caps(cap_base);
-		for (int port_index = caps.port_offset - 1; port_index < caps.port_offset - 1 + caps.port_count && port_index < ports; ++port_index)
+		for (u32 port_index = (u32)caps.port_offset - 1u; port_index < (u32)(caps.port_offset - 1 + caps.port_count) && port_index < ports; ++port_index)
 		{
 			rh->ports[port_index].major_revision = caps.major_revision;
 			rh->ports[port_index].minor_revision = caps.minor_revision;
@@ -412,10 +412,10 @@ struct xhci_root_hub *xhci_roothub_create(struct usb_device *udev, io_reply_data
 			rh->ports[port_index].usb2_hs_only = caps.usb2_hs_only;
 			rh->ports[port_index].usb2_hw_lpm = caps.usb2_hw_lpm;
 			rh->ports[port_index].usb2_besl_lpm = caps.usb2_besl_lpm;
-			Kprintf("Port %ld: USB %ld.%ld, slot type %ld, max hub depth %ld\n",
-					(LONG)port_index + 1,
-					caps.major_revision, caps.minor_revision,
-					caps.protocol_slot_type, caps.max_hub_depth);
+			Kprintf("Port %lu: USB %lu.%lu, slot type %lu, max hub depth %lu\n",
+					(ULONG)port_index + 1,
+					(ULONG)caps.major_revision, (ULONG)caps.minor_revision,
+					(ULONG)caps.protocol_slot_type, (ULONG)caps.max_hub_depth);
 			if (caps.major_revision >= 3)
 			{
 				rh->is_super_speed = TRUE;
@@ -439,7 +439,7 @@ struct xhci_root_hub *xhci_roothub_create(struct usb_device *udev, io_reply_data
 	rh->udev->speed = rh->is_super_speed ? USB_SPEED_SUPER : USB_SPEED_HIGH;
 
 #ifdef DEBUG_HIGH
-	for (int i = 0; i < ports; ++i)
+	for (u32 i = 0; i < ports; ++i)
 		xhci_roothub_debug_port(rh, i);
 #endif
 
@@ -459,7 +459,7 @@ void xhci_roothub_destroy(struct xhci_root_hub *rh)
 	pool_free(rh->udev->controller->memoryPool, rh);
 }
 
-unsigned int xhci_roothub_get_address(struct xhci_root_hub *rh)
+u16 xhci_roothub_get_address(struct xhci_root_hub *rh)
 {
 	if (!rh || !rh->udev)
 		return 0;
@@ -467,7 +467,7 @@ unsigned int xhci_roothub_get_address(struct xhci_root_hub *rh)
 	return rh->udev->virtual_address;
 }
 
-UBYTE xhci_roothub_get_num_ports(struct xhci_root_hub *rh)
+u8 xhci_roothub_get_num_ports(struct xhci_root_hub *rh)
 {
 	if (!rh)
 		return 0;
@@ -475,7 +475,7 @@ UBYTE xhci_roothub_get_num_ports(struct xhci_root_hub *rh)
 	return rh->descriptor.hub_30.bNbrPorts;
 }
 
-int xhci_roothub_submit_int_request(struct xhci_root_hub *rh, struct USBIORequest *req)
+s8 xhci_roothub_submit_int_request(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
 	if (rh->int_req)
 	{
@@ -499,7 +499,7 @@ void xhci_roothub_complete_int_request(struct xhci_root_hub *rh)
 
 	const u8 num_ports = rh->descriptor.hub_30.bNbrPorts;
 	/* USB 3.0 spec is always two bytes, however the stack may request fewer bytes */
-	const u8 need_bytes = (num_ports + 7) / 8;
+	const u8 need_bytes = (u8)(((u32)num_ports + 7U) / 8U);
 	if (!buffer || rh->int_req->data_buffer_length < need_bytes)
 	{
 		rh->io_reply_data(rh->udev, rh->int_req, ERR_DEVICE_STALL, 0);
@@ -520,12 +520,12 @@ void xhci_roothub_complete_int_request(struct xhci_root_hub *rh)
 		if (!change_bits)
 			continue;
 
-		u32 index = (port + 1) >> 3;
+		u32 index = (port + 1U) >> 3;
 		if (index >= need_bytes)
 			continue;
 
-		buffer[index] |= 1U << ((port + 1) & 7);
-		KprintfH("port %ld status change detected: changebits=0x%08lx\n", (LONG)(port + 1), (ULONG)change_bits);
+		buffer[index] |= (u8)(1U << (((u32)port + 1U) & 7U));
+		KprintfH("port %lu status change detected: changebits=0x%08lx\n", (ULONG)(port + 1), (ULONG)change_bits);
 		change = TRUE;
 	}
 
@@ -571,7 +571,9 @@ inline static void xhci_roothub_reply(struct USBIORequest *req, void *data, u32 
 	if (!req)
 		return;
 
-	length = min(length, le16(req->setup.wLength));
+	u32 req_length = le16(req->setup.wLength);
+	length = length < req_length ? length : req_length;
+
 	if (data && length > 0)
 		CopyMem(data, req->data_buffer, length);
 
@@ -579,7 +581,7 @@ inline static void xhci_roothub_reply(struct USBIORequest *req, void *data, u32 
 	req->req.io_Error = ERR_NO_ERROR;
 }
 
-inline static void xhci_roothub_delay_ms(ULONG milliseconds)
+inline static void xhci_roothub_delay_ms(u32 milliseconds)
 {
 	if (milliseconds == 0)
 		return;
@@ -693,7 +695,7 @@ inline static u32 xhci_roothub_port_state_to_neutral(u32 state)
  * @param port_status	state of port status register
  * Return: none
  */
-inline static void xhci_roothub_clear_port_change_bit(u16 wValue, u8 portNo, volatile uint32_t *addr, u32 port_status)
+inline static void xhci_roothub_clear_port_change_bit(u16 wValue, u8 portNo, volatile u32 *addr, u32 port_status)
 {
 	char *port_change_bit;
 	u32 status;
@@ -741,7 +743,7 @@ inline static void xhci_roothub_clear_port_change_bit(u16 wValue, u8 portNo, vol
 
 #ifdef DEBUG_HIGH
 	port_status = mmio_read32(addr);
-	KprintfH("clear port %s change, actual port %ld status  = 0x%lx\n", port_change_bit, portNo, port_status);
+	KprintfH("clear port %s change, actual port %lu status  = 0x%lx\n", port_change_bit, (ULONG)portNo, (ULONG)port_status);
 #else
 	(void)port_change_bit;
 	(void)portNo;
@@ -751,7 +753,7 @@ inline static void xhci_roothub_clear_port_change_bit(u16 wValue, u8 portNo, vol
 inline static struct xhci_hcor_port_regs *xhci_roothub_get_port(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
 	struct xhci_ctrl *ctrl = rh->udev->controller;
-	u8 port = le16(req->setup.wIndex) & 0xff; // port number is in low byte of wIndex;
+	u8 port = le16(req->setup.wIndex) & 0xffU; // port number is in low byte of wIndex;
 
 	if (port == 0 || port > rh->descriptor.hub_30.bNbrPorts)
 		return NULL;
@@ -763,7 +765,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 {
 	const u16 wValue = le16(req->setup.wValue); // feature selector
 	const u16 wIndex = le16(req->setup.wIndex); // selector | port
-	const u8 portNo = wIndex & 0xff;
+	const u8 portNo = wIndex & 0xffU;
 #ifdef DEBUG_HIGH
 	xhci_roothub_debug_port(rh, portNo - 1);
 #endif
@@ -776,7 +778,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 	{
 	// Common for USB2 and USB3 ports
 	case USB_PORT_FEAT_POWER:
-		KprintfH("Clear port %ld PORT_POWER\n", portNo);
+		KprintfH("Clear port %lu PORT_POWER\n", (ULONG)portNo);
 		reg &= ~PORT_POWER;
 		mmio_write32(reg, &port->or_portsc);
 		break;
@@ -807,7 +809,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 
 		// USB3 specific features
 	case USB_SS_PORT_FEAT_FORCE_LINKPM_ACCEPT:
-		KprintfH("Clear port %ld FORCE_LINKPM_ACCEPT\n", portNo);
+		KprintfH("Clear port %lu FORCE_LINKPM_ACCEPT\n", (ULONG)portNo);
 		reg = mmio_read32(&port->or_portpmsc);
 		reg &= ~PORT_FLA;
 		mmio_write32(reg, &port->or_portpmsc);
@@ -823,7 +825,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 
 	// USB2 specific features
 	case USB_PORT_FEAT_ENABLE:
-		KprintfH("Clear port %ld PORT_PE\n", portNo);
+		KprintfH("Clear port %lu PORT_PE\n", (ULONG)portNo);
 		if (rh->ports[portNo - 1].major_revision >= 3)
 		{
 			Kprintf("Can't disable USB 3.0 port\n");
@@ -837,7 +839,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 		}
 		break;
 	case USB_PORT_FEAT_SUSPEND:
-		KprintfH("Clear port %ld PORT_SUSPEND\n", portNo);
+		KprintfH("Clear port %lu PORT_SUSPEND\n", (ULONG)portNo);
 		/* For USB2, need to write 15 (XDEV_RESUME) first, wait 20ms, then write U0 */
 		if (rh->ports[portNo - 1].major_revision < 3)
 		{
@@ -860,7 +862,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 		break;
 
 	default:
-		Kprintf("Clear port %ld:Unknown feature 0x%lx\n", portNo, wValue);
+		Kprintf("Clear port %lu:Unknown feature 0x%lx\n", (ULONG)portNo, (ULONG)wValue);
 		xhci_roothub_stall(req);
 		return;
 	}
@@ -903,12 +905,12 @@ static void xhci_roothub_handle_port_get_status(struct xhci_root_hub *rh, struct
 	const u16 wIndex = le16(req->setup.wIndex);
 	const u16 wValue = le16(req->setup.wValue);
 	const u16 wLength = le16(req->setup.wLength);
-	const u8 portNo = wIndex & 0xff;
-	const u8 portStatusType = wValue & 0xff;
+	const u8 portNo = wIndex & 0xffU;
+	const u8 portStatusType = wValue & 0xffU;
 
 	if (portStatusType != 0 || wLength != 4)
 	{
-		Kprintf("invalid get port status request value 0x%lx length %ld\n", wValue, wLength);
+		Kprintf("invalid get port status request value 0x%lx length %lu\n", (ULONG)wValue, (ULONG)wLength);
 		xhci_roothub_stall(req);
 		return;
 	}
@@ -991,25 +993,25 @@ static void xhci_roothub_handle_port_get_status(struct xhci_root_hub *rh, struct
 	if (!rh->is_super_speed && (reg & PORT_PLC) && (reg & PORT_PLS_MASK) == XDEV_U0)
 		wPortChange |= USB_PORT_STAT_C_SUSPEND;
 
-	u8 tmpbuf[4] = {wPortStatus & 0xff, (wPortStatus >> 8) & 0xff, wPortChange & 0xff, (wPortChange >> 8) & 0xff};
-	KprintfH("USB_REQ_GET_STATUS PORT %ld status=0x%lx\n", portNo, reg);
+	u8 tmpbuf[4] = {wPortStatus & 0xffU, (wPortStatus >> 8) & 0xffU, wPortChange & 0xffU, (wPortChange >> 8) & 0xffU};
+	KprintfH("USB_REQ_GET_STATUS PORT %lu status=0x%lx\n", (ULONG)portNo, (ULONG)reg);
 	xhci_roothub_reply(req, tmpbuf, 4);
 }
 
 static void xhci_roothub_handle_get_port_error_count(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
 	const u16 wIndex = le16(req->setup.wIndex);
-	const u8 portNo = wIndex & 0xff;
+	const u8 portNo = wIndex & 0xffU;
 
 	if (rh->ports[portNo - 1].major_revision < 3)
 	{
-		Kprintf("get port error count not supported on USB 2.0 port %ld\n", portNo);
+		Kprintf("get port error count not supported on USB 2.0 port %lu\n", (ULONG)portNo);
 		xhci_roothub_stall(req);
 		return;
 	}
 	if (req->setup.wValue != 0 || le16(req->setup.wLength) < 2)
 	{
-		Kprintf("invalid get port error count request value 0x%lx length %ld\n", le16(req->setup.wValue), le16(req->setup.wLength));
+		Kprintf("invalid get port error count request value 0x%lx length %lu\n", le16(req->setup.wValue), (ULONG)le16(req->setup.wLength));
 		xhci_roothub_stall(req);
 		return;
 	}
@@ -1017,8 +1019,8 @@ static void xhci_roothub_handle_get_port_error_count(struct xhci_root_hub *rh, s
 	struct xhci_hcor_port_regs *port = xhci_roothub_get_port(rh, req);
 	const u16 errors = mmio_read32(&port->or_portli) & 0xffff;
 
-	KprintfH("USB_REQ_GET_PORT_ERROR_COUNT PORT %ld error count=%u\n", wIndex, errors);
-	u8 tmpbuf[2] = {errors & 0xff, errors >> 8};
+	KprintfH("USB_REQ_GET_PORT_ERROR_COUNT PORT %lu error count=%u\n", (ULONG)wIndex, errors);
+	u8 tmpbuf[2] = {errors & 0xffU, (u8)(errors >> 8)};
 	xhci_roothub_reply(req, tmpbuf, 2);
 }
 
@@ -1026,7 +1028,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 {
 	const u16 wValue = le16(req->setup.wValue);
 	const u16 wIndex = le16(req->setup.wIndex);
-	const u8 portNo = wIndex & 0xff;
+	const u8 portNo = wIndex & 0xffU;
 
 #ifdef DEBUG_HIGH
 	xhci_roothub_debug_port(rh, portNo - 1);
@@ -1049,8 +1051,8 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 		if (rh->ports[portNo - 1].major_revision >= 3 &&
 			(pls == XDEV_COMPLIANCE || pls == XDEV_INACTIVE))
 		{
-			Kprintf("SS port %ld PLS=%ld (%s); upgrading to warm reset (portsc=%08lx)\n",
-					(LONG)portNo, (LONG)(pls >> 5),
+			Kprintf("SS port %lu PLS=%lu (%s); upgrading to warm reset (portsc=%08lx)\n",
+					(ULONG)portNo, (ULONG)(pls >> 5),
 					pls == XDEV_COMPLIANCE ? "Compliance" : "SS.Inactive",
 					(ULONG)mmio_read32(&port->or_portsc));
 
@@ -1061,8 +1063,8 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 			 * via normal link training instead, leaving WRC=0 and the
 			 * device in a state where ADDRESS_DEVICE times out. */
 			mmio_write32(reg | PORT_CSC | PORT_PEC | PORT_WRC |
-					   PORT_OCC | PORT_RC | PORT_PLC | PORT_CEC,
-				   &port->or_portsc);
+							 PORT_OCC | PORT_RC | PORT_PLC | PORT_CEC,
+						 &port->or_portsc);
 
 			/* Re-read and re-neutralize after clearing change bits */
 			reg = mmio_read32(&port->or_portsc);
@@ -1087,15 +1089,15 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 
 				if (attempts >= 100)
 				{
-					Kprintf("SS port %ld warm reset timed out after 1s "
+					Kprintf("SS port %lu warm reset timed out after 1s "
 							"(portsc=%08lx)\n",
-							(LONG)portNo, (ULONG)temp);
+							(ULONG)portNo, (ULONG)temp);
 				}
 				else
 				{
-					Kprintf("SS port %ld warm reset completed in %ld0ms "
+					Kprintf("SS port %lu warm reset completed in %ld0ms "
 							"(portsc=%08lx)\n",
-							(LONG)portNo, (LONG)attempts, (ULONG)temp);
+							(ULONG)portNo, (LONG)attempts, (ULONG)temp);
 
 					/* Allow the link partner to stabilise before
 					 * the stack tries ADDRESS_DEVICE. */
@@ -1105,14 +1107,14 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 		}
 		else
 		{
-			KprintfH("Set port %ld PORT_RESET\n", portNo);
+			KprintfH("Set port %lu PORT_RESET\n", (ULONG)portNo);
 			reg |= PORT_RESET;
 			mmio_write32(reg, &port->or_portsc);
 		}
 		break;
 	}
 	case USB_PORT_FEAT_POWER:
-		KprintfH("Set port %ld PORT_POWER\n", portNo);
+		KprintfH("Set port %lu PORT_POWER\n", (ULONG)portNo);
 		reg |= PORT_POWER;
 		mmio_write32(reg, &port->or_portsc);
 		break;
@@ -1125,28 +1127,28 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 
 	// USB3 specific features
 	case USB_SS_PORT_FEAT_BH_RESET:
-		KprintfH("Set port %ld PORT_BH_RESET\n", portNo);
+		KprintfH("Set port %lu PORT_BH_RESET\n", (ULONG)portNo);
 		reg |= PORT_WR;
 		mmio_write32(reg, &port->or_portsc);
 		break;
 	case USB_SS_PORT_FEAT_U1_TIMEOUT:
-		KprintfH("Setting port %ld U1 timeout to %ld microseconds\n", portNo, wIndex >> 8);
+		KprintfH("Setting port %lu U1 timeout to %lu microseconds\n", (ULONG)portNo, (ULONG)(wIndex >> 8));
 		reg = mmio_read32(&port->or_portpmsc);
-		reg &= ~0xff;
+		reg &= ~0xffU;
 		reg |= PORT_U1_TIMEOUT(wIndex >> 8);
 		mmio_write32(reg, &port->or_portpmsc);
 		break;
 	case USB_SS_PORT_FEAT_U2_TIMEOUT:
-		KprintfH("Setting port %ld U2 timeout to %ld microseconds\n", portNo, wIndex >> 8);
+		KprintfH("Setting port %lu U2 timeout to %lu microseconds\n", (ULONG)portNo, (ULONG)(wIndex >> 8));
 		reg = mmio_read32(&port->or_portpmsc);
-		reg &= ~0xff00;
+		reg &= ~0xff00U;
 		reg |= PORT_U2_TIMEOUT(wIndex >> 8);
 		mmio_write32(reg, &port->or_portpmsc);
 		break;
 	case USB_PORT_FEAT_LINK_STATE:
 	{
 		const u32 link_state = wIndex >> 8;
-		KprintfH("Set port %ld PORT_LINK_STATE to %ld\n", portNo, link_state);
+		KprintfH("Set port %lu PORT_LINK_STATE to %lu\n", (ULONG)portNo, (ULONG)link_state);
 		if (link_state <= 5 || link_state == 10)
 		{
 			reg &= ~PORT_PLS_MASK;
@@ -1156,7 +1158,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 		}
 		else
 		{
-			Kprintf("invalid link state %ld\n", link_state);
+			Kprintf("invalid link state %lu\n", (ULONG)link_state);
 			xhci_roothub_stall(req);
 			return;
 		}
@@ -1165,14 +1167,14 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 	case USB_SS_PORT_FEAT_REMOTE_WAKE_MASK:
 	{
 		const u32 wake_mask = (wIndex >> 8) & 7;
-		KprintfH("Set port %ld REMOTE_WAKE_MASK to %lx\n", portNo, wake_mask);
+		KprintfH("Set port %lu REMOTE_WAKE_MASK to %lx\n", (ULONG)portNo, (ULONG)wake_mask);
 		reg &= ~(PORT_WKCONN_E | PORT_WKDISC_E | PORT_WKOC_E);
 		reg |= wake_mask << 25;
 		mmio_write32(reg, &port->or_portsc);
 		break;
 	}
 	case USB_SS_PORT_FEAT_FORCE_LINKPM_ACCEPT:
-		KprintfH("Set port %ld FORCE_LINKPM_ACCEPT\n", portNo);
+		KprintfH("Set port %lu FORCE_LINKPM_ACCEPT\n", (ULONG)portNo);
 		reg = mmio_read32(&port->or_portpmsc);
 		reg |= PORT_FLA;
 		mmio_write32(reg, &port->or_portpmsc);
@@ -1180,7 +1182,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 
 	// USB2 specific features
 	case USB_PORT_FEAT_SUSPEND:
-		KprintfH("Putting port %ld link to U3 standby\n", portNo);
+		KprintfH("Putting port %lu link to U3 standby\n", (ULONG)portNo);
 		reg &= ~PORT_PLS_MASK;
 		reg |= XDEV_U3;
 		reg |= PORT_LINK_STROBE;
@@ -1191,7 +1193,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 		break;
 
 	default:
-		Kprintf("Set port %ld: unknown feature %lx\n", portNo, wValue);
+		Kprintf("Set port %lu: unknown feature %lx\n", (ULONG)portNo, (ULONG)wValue);
 		xhci_roothub_stall(req);
 		return;
 	}
@@ -1216,12 +1218,12 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct USBIORequ
 
 	if ((setup->bmRequestType & USB_RT_PORT) && (wIndex & 0xff) > rh->descriptor.hub_30.bNbrPorts)
 	{
-		Kprintf("The request port(%ld) exceeds maximum port number\n", wIndex);
+		Kprintf("The request port(%lu) exceeds maximum port number\n", (ULONG)wIndex);
 		xhci_roothub_stall(io);
 		return;
 	}
 
-	const u16 typeReq = setup->bRequest | setup->bmRequestType << 8;
+	const u16 typeReq = (u16)(((u16)setup->bmRequestType << 8) | setup->bRequest);
 	switch (typeReq)
 	{
 	/* Standard device requests */
@@ -1239,7 +1241,7 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct USBIORequ
 		xhci_roothub_handle_device_get_status(rh, io);
 		break;
 	case DeviceOutRequest | USB_REQ_SET_ADDRESS:
-		KprintfH("USB_REQ_SET_ADDRESS rootdev=%ld\n", wValue);
+		KprintfH("USB_REQ_SET_ADDRESS rootdev=%lu\n", (ULONG)wValue);
 		/* Do nothing, higher layer will handle context migration */
 		xhci_roothub_no_error(io);
 		break;

--- a/xhci.device/src/xhci/xhci-td.c
+++ b/xhci.device/src/xhci/xhci-td.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: GPL-2.0-only */
+
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #else

--- a/xhci.device/src/xhci/xhci-td.c
+++ b/xhci.device/src/xhci/xhci-td.c
@@ -67,6 +67,16 @@ struct TransferDescriptorList
     u32 queued_tds;
 };
 
+void xhci_td_slab_init(struct xhci_ctrl *ctrl)
+{
+    slab_cache_init(&ctrl->td_slab, ctrl->memoryPool, sizeof(struct xhci_td), DMA_ALIGN_MIN, 2048);
+}
+
+void xhci_td_slab_destroy(struct xhci_ctrl *ctrl)
+{
+    slab_cache_destroy(&ctrl->td_slab);
+}
+
 TransferDescriptorList *xhci_td_create_list(struct xhci_ctrl *ctrl)
 {
     TransferDescriptorList *td_list = pool_zalloc(ctrl->memoryPool, sizeof(TransferDescriptorList));
@@ -153,7 +163,7 @@ static struct xhci_td *td_create(TransferDescriptorList *td_list,
     if (!td_list)
         return NULL;
 
-    struct xhci_td *td = pool_zalloc(td_list->memoryPool, sizeof(struct xhci_td));
+    struct xhci_td *td = slab_zalloc(&td_list->ctrl->td_slab);
     if (!td)
     {
         Kprintf("Failed to alloc xhci_td\n");
@@ -273,8 +283,15 @@ inline static void xhci_dma_unmap(struct xhci_ctrl *ctrl, struct USBIORequest *r
         xhci_copy_from_bounce_buffer(bounce, addr, size);
     }
 
-    dma_free(ctrl->memoryPool, bounce);
-    req->driver_private_flags &= (u32)~REQ_DMA_MAPPED;
+    u32 bounce_class = (req->driver_private_flags & REQ_BOUNCE_CLASS_MASK) >> REQ_BOUNCE_CLASS_SHIFT;
+    switch (bounce_class)
+    {
+    case REQ_BOUNCE_CLASS_SMALL: slab_free(&ctrl->bounce_small, bounce); break;
+    case REQ_BOUNCE_CLASS_MED:   slab_free(&ctrl->bounce_med,   bounce); break;
+    case REQ_BOUNCE_CLASS_LARGE: slab_free(&ctrl->bounce_large, bounce); break;
+    default:                     dma_free(ctrl->memoryPool,     bounce); break;
+    }
+    req->driver_private_flags &= (u32)~(REQ_DMA_MAPPED | REQ_BOUNCE_CLASS_MASK);
     req->driver_private_dma_address = NULL;
 }
 
@@ -282,11 +299,14 @@ static void xhci_td_free(TransferDescriptorList *td_list, struct xhci_td *td)
 {
     if (td->trb_addrs)
     {
-        pool_free(td_list->memoryPool, td->trb_addrs);
+        if (td->trb_count <= XHCI_TD_SMALL_TRBS)
+            slab_free(&td_list->ctrl->trb_addr_slab, td->trb_addrs);
+        else
+            pool_free(td_list->memoryPool, td->trb_addrs);
         td->trb_addrs = NULL;
     }
 
-    pool_free(td_list->memoryPool, td);
+    slab_free(&td_list->ctrl->td_slab, td);
 }
 
 BOOL xhci_td_has_request(TransferDescriptorList *td_list, struct USBIORequest *io_req)
@@ -496,17 +516,7 @@ void xhci_td_fail_all(TransferDescriptorList *td_list, s8 io_Error)
     while ((n = RemHeadMinList(&td_list->list)) != NULL)
     {
         struct xhci_td *td = (struct xhci_td *)n;
-        if (td->req)
-        {
-            if (td->req->data_buffer)
-                xhci_dma_unmap(td_list->ctrl, td->req, FALSE);
-            if (td->is_rt_iso && td->req->direction == DIRECTION_IN && td->req->data_buffer)
-                pool_free(td_list->memoryPool, td->req->data_buffer);
-            if (td->is_rt_iso)
-                pool_free(td_list->memoryPool, td->req);
-            else
-                xhci_udev_io_reply_failed(td_list->ctrl, td->req, io_Error);
-        }
+        td_unmap_and_reply(td_list, td, io_Error);
         xhci_td_free(td_list, td);
     }
 

--- a/xhci.device/src/xhci/xhci-td.c
+++ b/xhci.device/src/xhci/xhci-td.c
@@ -1,12 +1,15 @@
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
 #endif
 
 #include <exec/errors.h>
 
 #include <device.h>
+#include <emu_memory.h>
 #include <xhci/xhci-descriptors.h>
 #include <xhci/xhci-context.h>
 #include <xhci/xhci-endpoint.h>

--- a/xhci.device/src/xhci/xhci-td.c
+++ b/xhci.device/src/xhci/xhci-td.c
@@ -9,7 +9,8 @@
 #include <exec/errors.h>
 
 #include <device.h>
-#include <emu_memory.h>
+#include <memory.h>
+#include <timing.h>
 #include <xhci/xhci-descriptors.h>
 #include <xhci/xhci-context.h>
 #include <xhci/xhci-endpoint.h>
@@ -30,6 +31,17 @@
 #undef KprintfH
 #define KprintfH(fmt, ...) PrintPistorm("[xhci-td] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
+
+static inline void xhci_copy_from_bounce_buffer(CONST_APTR src, APTR dst, ULONG size)
+{
+    if ((((ULONG)src | (ULONG)dst | size) & (sizeof(ULONG) - 1)) == 0)
+    {
+        CopyMemQuick((ULONG *)src, (ULONG *)dst, size);
+        return;
+    }
+
+    CopyMem(src, dst, size);
+}
 
 struct xhci_td
 {
@@ -55,7 +67,7 @@ struct TransferDescriptorList
 
 TransferDescriptorList *xhci_td_create_list(struct xhci_ctrl *ctrl)
 {
-    TransferDescriptorList *td_list = AllocVecPooled(ctrl->memoryPool, sizeof(TransferDescriptorList));
+    TransferDescriptorList *td_list = pool_zalloc(ctrl->memoryPool, sizeof(TransferDescriptorList));
     if (!td_list)
     {
         Kprintf("Failed to alloc TransferDescriptorList\n");
@@ -78,7 +90,7 @@ void xhci_td_destroy_list(TransferDescriptorList *td_list, UBYTE error_code)
 
     xhci_td_fail_all(td_list, error_code);
 
-    FreeVecPooled(td_list->memoryPool, td_list);
+    pool_free(td_list->memoryPool, td_list);
 }
 
 BOOL xhci_td_is_empty(TransferDescriptorList *td_list)
@@ -139,14 +151,12 @@ static struct xhci_td *td_create(TransferDescriptorList *td_list,
     if (!td_list)
         return NULL;
 
-    struct xhci_td *td = AllocVecPooled(td_list->memoryPool, sizeof(struct xhci_td));
+    struct xhci_td *td = pool_zalloc(td_list->memoryPool, sizeof(struct xhci_td));
     if (!td)
     {
         Kprintf("Failed to alloc xhci_td\n");
         return NULL;
     }
-
-    _memset(td, 0, sizeof(struct xhci_td));
 
     td->req = io_req;
 
@@ -258,10 +268,10 @@ inline static void xhci_dma_unmap(struct xhci_ctrl *ctrl, struct USBIORequest *r
     if (copy)
     {
         xhci_inval_cache(bounce, size);
-        CopyMem(bounce, addr, size);
+        xhci_copy_from_bounce_buffer(bounce, addr, size);
     }
 
-    memalign_free(ctrl->memoryPool, bounce);
+    dma_free(ctrl->memoryPool, bounce);
     req->driver_private_flags &= ~REQ_DMA_MAPPED;
     req->driver_private_dma_address = NULL;
 }
@@ -270,11 +280,11 @@ static void xhci_td_free(TransferDescriptorList *td_list, struct xhci_td *td)
 {
     if (td->trb_addrs)
     {
-        FreeVecPooled(td_list->memoryPool, td->trb_addrs);
+        pool_free(td_list->memoryPool, td->trb_addrs);
         td->trb_addrs = NULL;
     }
 
-    FreeVecPooled(td_list->memoryPool, td);
+    pool_free(td_list->memoryPool, td);
 }
 
 BOOL xhci_td_has_request(TransferDescriptorList *td_list, struct USBIORequest *io_req)
@@ -489,9 +499,9 @@ void xhci_td_fail_all(TransferDescriptorList *td_list, BYTE io_Error)
             if (td->req->data_buffer)
                 xhci_dma_unmap(td_list->ctrl, td->req, FALSE);
             if (td->is_rt_iso && td->req->direction == DIRECTION_IN && td->req->data_buffer)
-                FreeVecPooled(td_list->memoryPool, td->req->data_buffer);
+                pool_free(td_list->memoryPool, td->req->data_buffer);
             if (td->is_rt_iso)
-                FreeVecPooled(td_list->memoryPool, td->req);
+                pool_free(td_list->memoryPool, td->req);
             else
                 xhci_udev_io_reply_failed(td_list->ctrl, td->req, io_Error);
         }

--- a/xhci.device/src/xhci/xhci-td.c
+++ b/xhci.device/src/xhci/xhci-td.c
@@ -65,6 +65,7 @@ struct TransferDescriptorList
     APTR memoryPool;
     u32 queued_trbs;
     u32 queued_tds;
+    struct ep_context *ep_ctx; /* back-reference for per-endpoint resource cleanup */
 };
 
 void xhci_td_slab_init(struct xhci_ctrl *ctrl)
@@ -77,7 +78,7 @@ void xhci_td_slab_destroy(struct xhci_ctrl *ctrl)
     slab_cache_destroy(&ctrl->td_slab);
 }
 
-TransferDescriptorList *xhci_td_create_list(struct xhci_ctrl *ctrl)
+TransferDescriptorList *xhci_td_create_list(struct xhci_ctrl *ctrl, struct ep_context *ep_ctx)
 {
     TransferDescriptorList *td_list = pool_zalloc(ctrl->memoryPool, sizeof(TransferDescriptorList));
     if (!td_list)
@@ -91,6 +92,7 @@ TransferDescriptorList *xhci_td_create_list(struct xhci_ctrl *ctrl)
     td_list->memoryPool = ctrl->memoryPool;
     td_list->queued_trbs = 0;
     td_list->queued_tds = 0;
+    td_list->ep_ctx = ep_ctx;
 
     return td_list;
 }
@@ -348,6 +350,14 @@ static void td_unmap_and_reply(TransferDescriptorList *td_list, struct xhci_td *
 
     if (req && req->data_buffer_length > 0)
         xhci_dma_unmap(td_list->ctrl, req, FALSE);
+
+    /* For RT ISO IN clones, free the staging buffer back to the per-endpoint slab
+     * before handing off to io_reply_failed (which frees the clone IO request). */
+    if (req && (req->driver_private_flags & REQ_RT_ISO_CLONE))
+    {
+        xhci_ep_free_rt_iso_buffer(td_list->ep_ctx, req->data_buffer);
+        req->data_buffer = NULL;
+    }
 
     if (req)
         xhci_udev_io_reply_failed(td_list->ctrl, req, error_code);

--- a/xhci.device/src/xhci/xhci-td.c
+++ b/xhci.device/src/xhci/xhci-td.c
@@ -34,9 +34,9 @@
 #define KprintfH(fmt, ...) PrintPistorm("[xhci-td] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-static inline void xhci_copy_from_bounce_buffer(CONST_APTR src, APTR dst, ULONG size)
+static inline void xhci_copy_from_bounce_buffer(CONST_APTR src, APTR dst, u32 size)
 {
-    if ((((ULONG)src | (ULONG)dst | size) & (sizeof(ULONG) - 1)) == 0)
+    if ((((uintptr_t)src | (uintptr_t)dst | size) & (sizeof(ULONG) - 1)) == 0)
     {
         CopyMemQuick((ULONG *)src, (ULONG *)dst, size);
         return;
@@ -50,11 +50,11 @@ struct xhci_td
     struct MinNode node;       /* linkage in active TD list */
     struct USBIORequest *req;  /* owning request */
     dma_addr_t completion_trb; /* TRB address we expect a completion for */
-    ULONG length;              /* total length for completion accounting */
+    u32 length;                /* total length for completion accounting */
     BOOL deadline_active;      /* true if deadline_us is valid */
-    ULONG deadline_us;         /* absolute deadline in usec, 0 means no timeout */
+    u32 deadline_us;           /* absolute deadline in usec, 0 means no timeout */
     BOOL is_rt_iso;            /* true if this TD is part of RT ISO pipeline */
-    UWORD trb_count;           /* number of TRBs consumed by this TD */
+    u32 trb_count;             /* number of TRBs consumed by this TD */
     dma_addr_t *trb_addrs;     /* DMA addresses for every TRB in this TD */
 };
 
@@ -63,8 +63,8 @@ struct TransferDescriptorList
     struct MinList list;
     struct xhci_ctrl *ctrl;
     APTR memoryPool;
-    ULONG queued_trbs;
-    ULONG queued_tds;
+    u32 queued_trbs;
+    u32 queued_tds;
 };
 
 TransferDescriptorList *xhci_td_create_list(struct xhci_ctrl *ctrl)
@@ -85,7 +85,7 @@ TransferDescriptorList *xhci_td_create_list(struct xhci_ctrl *ctrl)
     return td_list;
 }
 
-void xhci_td_destroy_list(TransferDescriptorList *td_list, UBYTE error_code)
+void xhci_td_destroy_list(TransferDescriptorList *td_list, s8 error_code)
 {
     if (!td_list)
         return;
@@ -107,7 +107,7 @@ BOOL xhci_td_is_expired(TransferDescriptorList *td_list)
     if (!td_list)
         return FALSE;
 
-    ULONG now = get_time();
+    u32 now = get_time();
 
     struct MinNode *n = td_list->list.mlh_Head;
     while (n && n->mln_Succ)
@@ -127,7 +127,7 @@ BOOL xhci_td_is_expired(TransferDescriptorList *td_list)
     return FALSE;
 }
 
-ULONG xhci_td_get_queued_trb_count(TransferDescriptorList *td_list)
+u32 xhci_td_get_queued_trb_count(TransferDescriptorList *td_list)
 {
     if (!td_list)
         return 0;
@@ -135,7 +135,7 @@ ULONG xhci_td_get_queued_trb_count(TransferDescriptorList *td_list)
     return td_list->queued_trbs;
 }
 
-ULONG xhci_td_get_queued_td_count(TransferDescriptorList *td_list)
+u32 xhci_td_get_queued_td_count(TransferDescriptorList *td_list)
 {
     if (!td_list)
         return 0;
@@ -145,10 +145,10 @@ ULONG xhci_td_get_queued_td_count(TransferDescriptorList *td_list)
 
 static struct xhci_td *td_create(TransferDescriptorList *td_list,
                                  struct USBIORequest *io_req,
-                                 ULONG timeout_ms,
+                                 u32 timeout_ms,
                                  BOOL is_rt_iso,
                                  dma_addr_t *trb_addresses,
-                                 ULONG trb_count)
+                                 u32 trb_count)
 {
     if (!td_list)
         return NULL;
@@ -179,10 +179,10 @@ static struct xhci_td *td_create(TransferDescriptorList *td_list,
 
 BOOL xhci_td_add(TransferDescriptorList *td_list,
                  struct USBIORequest *io_req,
-                 ULONG timeout_ms,
+                 u32 timeout_ms,
                  BOOL is_rt_iso,
                  dma_addr_t *trb_addresses,
-                 ULONG trb_count)
+                 u32 trb_count)
 {
     if (!td_list)
         return FALSE;
@@ -217,7 +217,7 @@ static struct xhci_td *find_td_by_trb(TransferDescriptorList *td_list, dma_addr_
 
         if (td->trb_addrs)
         {
-            for (unsigned int i = 0; i < td->trb_count; i++)
+            for (u32 i = 0; i < td->trb_count; i++)
             {
                 if (td->trb_addrs[i] == trb_addr)
                     return td;
@@ -249,7 +249,7 @@ inline static void xhci_dma_unmap(struct xhci_ctrl *ctrl, struct USBIORequest *r
         return;
 
     APTR addr = req->data_buffer;
-    ULONG size = req->data_buffer_length;
+    u32 size = req->data_buffer_length;
     if (!addr || size == 0)
         return;
 
@@ -263,7 +263,7 @@ inline static void xhci_dma_unmap(struct xhci_ctrl *ctrl, struct USBIORequest *r
     APTR bounce = (APTR)req->driver_private_dma_address;
     if (!bounce)
     {
-        Kprintf("No bounce buffer found for unmap of %lx len=%ld\n", (ULONG)addr, (LONG)size);
+        Kprintf("No bounce buffer found for unmap of %lx len=%lu\n", (ULONG)addr, (ULONG)size);
         return;
     }
 
@@ -274,7 +274,7 @@ inline static void xhci_dma_unmap(struct xhci_ctrl *ctrl, struct USBIORequest *r
     }
 
     dma_free(ctrl->memoryPool, bounce);
-    req->driver_private_flags &= ~REQ_DMA_MAPPED;
+    req->driver_private_flags &= (u32)~REQ_DMA_MAPPED;
     req->driver_private_dma_address = NULL;
 }
 
@@ -306,17 +306,17 @@ BOOL xhci_td_has_request(TransferDescriptorList *td_list, struct USBIORequest *i
     return FALSE;
 }
 
-static inline BOOL td_is_expired_at(struct xhci_td *td, ULONG now)
+static inline BOOL td_is_expired_at(struct xhci_td *td, u32 now)
 {
     return td && td->deadline_active && (int32_t)(now - td->deadline_us) >= 0;
 }
 
-static WORD td_find_trb_index(struct xhci_td *td, dma_addr_t trb_addr)
+static s32 td_find_trb_index(struct xhci_td *td, dma_addr_t trb_addr)
 {
-    for (UWORD index = 0; index < td->trb_count; ++index)
+    for (u32 index = 0; index < td->trb_count; ++index)
     {
         if (td->trb_addrs[index] == trb_addr)
-            return (WORD)index;
+            return (s32)index;
     }
 
     return -1;
@@ -352,7 +352,7 @@ static inline BOOL td_req_is_recovery_abort(IOReqList *abort_reqs, struct USBIOR
 
 static inline BOOL td_is_recovery_abort(struct xhci_td *td,
                                         IOReqList *abort_reqs,
-                                        ULONG now_us)
+                                        u32 now_us)
 {
     if (td_is_expired_at(td, now_us))
         return TRUE;
@@ -363,7 +363,7 @@ static inline BOOL td_is_recovery_abort(struct xhci_td *td,
 static void td_resolve_recovery_deq_ptr(TransferDescriptorList *td_list,
                                         struct xhci_ring *ring,
                                         IOReqList *abort_reqs,
-                                        ULONG now_us,
+                                        u32 now_us,
                                         dma_addr_t stopped_deq_ptr,
                                         dma_addr_t *resolved_deq_ptr)
 {
@@ -411,7 +411,7 @@ static void td_resolve_recovery_deq_ptr(TransferDescriptorList *td_list,
 
 static void td_abort_recovery_requests(TransferDescriptorList *td_list,
                                        IOReqList *abort_reqs,
-                                       ULONG now_us)
+                                       u32 now_us)
 {
     struct MinNode *node = td_list->list.mlh_Head;
 
@@ -444,7 +444,7 @@ void xhci_td_patch_recovery(TransferDescriptorList *td_list,
     if (!td_list || !ring || !new_deq_ptr || !stopped_deq_ptr)
         return;
 
-    ULONG now_us = get_time();
+    u32 now_us = get_time();
 
     td_resolve_recovery_deq_ptr(td_list, ring,
                                 abort_reqs, now_us,
@@ -487,7 +487,7 @@ struct USBIORequest *xhci_td_get_by_trb(TransferDescriptorList *td_list, dma_add
     return req;
 }
 
-void xhci_td_fail_all(TransferDescriptorList *td_list, BYTE io_Error)
+void xhci_td_fail_all(TransferDescriptorList *td_list, s8 io_Error)
 {
     if (!td_list)
         return;
@@ -532,7 +532,7 @@ void xhci_td_abort_req(struct USBIORequest *io)
     if (!ctrl || !udev)
         return;
 
-    int ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
+    u8 ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
 
     if (io->driver_private_flags & REQ_ON_RING)

--- a/xhci.device/src/xhci/xhci-udev.c
+++ b/xhci.device/src/xhci/xhci-udev.c
@@ -419,21 +419,14 @@ void xhci_udev_io_reply_failed(struct xhci_ctrl *ctrl, struct USBIORequest *io, 
         }
 
         /* RT ISO clones were never sent as messages — never ReplyMsg.
-         * IN clones own their staging data_buffer; free both. OUT clones
-         * point at user buffers, so leave data_buffer alone. */
+         * IN clone staging buffers must be freed by callers (td_unmap_and_reply /
+         * ep_handle_rt_iso / halted branch) before reaching here; data_buffer
+         * should be NULL at this point. */
         if (io->driver_private_flags & REQ_RT_ISO_CLONE)
         {
             if (ctrl)
-            {
-                if (io->direction == DIRECTION_IN && io->data_buffer)
-                {
-                    if (io->driver_private_flags & REQ_RT_IN_BUF_SLABBED)
-                        slab_free(&ctrl->iso_in_staging_slab, io->data_buffer);
-                    else
-                        pool_free(ctrl->memoryPool, io->data_buffer);
-                }
                 slab_free(&ctrl->iso_clone_slab, io);
-            }
+
             return;
         }
 

--- a/xhci.device/src/xhci/xhci-udev.c
+++ b/xhci.device/src/xhci/xhci-udev.c
@@ -22,9 +22,9 @@
 
 #include <device.h>
 #include <debug.h>
-#include <emu_bits.h>
-#include <emu_byteorder.h>
-#include <emu_memory.h>
+#include <bits.h>
+#include <byteorder.h>
+#include <memory.h>
 #include <minlist.h>
 
 #ifdef DEBUG
@@ -49,14 +49,13 @@ struct usb_device *xhci_udev_alloc(struct xhci_ctrl *ctrl, UWORD virtual_address
     if (ctrl->devices_by_virtual_address[virtual_address])
         xhci_udev_free(ctrl->devices_by_virtual_address[virtual_address]);
 
-    struct usb_device *udev = AllocVecPooled(ctrl->memoryPool, sizeof(*udev));
+    struct usb_device *udev = pool_zalloc(ctrl->memoryPool, sizeof(*udev));
     if (!udev)
     {
         Kprintf("Failed to allocate usb_device for addr %ld\n", (LONG)virtual_address);
         goto nothing;
     }
 
-    _memset(udev, 0, sizeof(*udev));
     udev->virtual_address = virtual_address;
     udev->controller = ctrl;
     udev->speed = ctrl->pending_parent_speed;
@@ -89,7 +88,7 @@ struct usb_device *xhci_udev_alloc(struct xhci_ctrl *ctrl, UWORD virtual_address
 destroy_out_ctx:
     xhci_free_container_ctx(ctrl, udev->out_ctx);
 free_udev:
-    FreeVecPooled(ctrl->memoryPool, udev);
+    pool_free(ctrl->memoryPool, udev);
 nothing:
     return NULL;
 }
@@ -146,7 +145,7 @@ void xhci_udev_free(struct usb_device *udev)
     while ((node = RemHeadMinList(&udev->configurations)) != NULL)
     {
         struct usb_config *conf = (struct usb_config *)node;
-        FreeVecPooled(ctrl->memoryPool, conf);
+        pool_free(ctrl->memoryPool, conf);
     }
 
     if (udev->in_ctx)
@@ -157,7 +156,7 @@ void xhci_udev_free(struct usb_device *udev)
     ctrl->dcbaa->dev_context_ptrs[udev->slot_id] = 0;
     ctrl->devices_by_virtual_address[udev->virtual_address] = NULL;
     ctrl->devices_by_slot_id[udev->slot_id] = NULL;
-    FreeVecPooled(ctrl->memoryPool, udev);
+    pool_free(ctrl->memoryPool, udev);
 }
 
 static UBYTE xhci_udev_find_epaddr_by_num(struct usb_device *udev, UBYTE epnum)
@@ -194,7 +193,7 @@ static void xhci_udev_patch_endpoint_address(struct usb_device *udev, struct USB
         return;
 
     /* If direction bit is already present, leave untouched. */
-    UWORD wIndex = LE16(setup->wIndex);
+    UWORD wIndex = le16(setup->wIndex);
     if (wIndex & 0x0080)
         return;
 
@@ -206,7 +205,7 @@ static void xhci_udev_patch_endpoint_address(struct usb_device *udev, struct USB
     if (!fixed || fixed == (UBYTE)wIndex)
         return;
 
-    setup->wIndex = cpu_to_le16(fixed);
+    setup->wIndex = le16(fixed);
 
     KprintfH("Patched endpoint address wIndex from %02lx to %02lx for epnum %ld\n",
              (ULONG)wIndex, (ULONG)fixed, (LONG)epnum);
@@ -224,15 +223,15 @@ static BOOL xhci_udev_filter_emulated_hub_ctrl_request(struct usb_device *udev, 
     if ((setup->bmRequestType & (USB_TYPE_MASK | USB_RECIP_MASK)) != (USB_TYPE_CLASS | USB_RECIP_OTHER))
         return FALSE;
 
-    const u16 wValue = LE16(setup->wValue);
-    const u8 portNo = LE16(setup->wIndex) & 0xFF;
+    const u16 wValue = le16(setup->wValue);
+    const u8 portNo = le16(setup->wIndex) & 0xFF;
     switch (wValue)
     {
     case USB_PORT_FEAT_SUSPEND:
     {
         const u8 link_state = (setup->bRequest == USB_REQ_CLEAR_FEATURE) ? 0 : 3;
-        setup->wValue = LE16(USB_PORT_FEAT_LINK_STATE);
-        setup->wIndex = LE16(portNo | (link_state << 8));
+        setup->wValue = le16(USB_PORT_FEAT_LINK_STATE);
+        setup->wIndex = le16(portNo | (link_state << 8));
         return FALSE;
     }
 
@@ -247,7 +246,7 @@ static BOOL xhci_udev_filter_emulated_hub_ctrl_request(struct usb_device *udev, 
         return TRUE;
 
     case USB_PORT_FEAT_C_SUSPEND: // this is only used for clear feature
-        setup->wValue = LE16(USB_SS_PORT_FEAT_C_LINK_STATE);
+        setup->wValue = le16(USB_SS_PORT_FEAT_C_LINK_STATE);
         return FALSE;
 
     default:
@@ -280,9 +279,9 @@ static int xhci_udev_send_ctrl_first(struct usb_device *udev, struct USBIOReques
     KprintfH("bmReqType=%02lx bReq=%02lx wValue=%04lx wIndex=%04lx wLength=%04lx\n",
              (ULONG)io->setup.bmRequestType,
              (ULONG)io->setup.bRequest,
-             LE16(io->setup.wValue),
-             LE16(io->setup.wIndex),
-             LE16(io->setup.wLength));
+             le16(io->setup.wValue),
+             le16(io->setup.wIndex),
+             le16(io->setup.wLength));
 
     /* Translate USB 2.0 hub requests to SS format for SS hubs */
     xhci_udev_translate_hub_descriptor_request(udev, io);
@@ -324,7 +323,7 @@ static int xhci_udev_send_ctrl_first(struct usb_device *udev, struct USBIOReques
                 return ERR_NO_ERROR;
         }
 
-        int ret = xhci_set_configuration(udev, LE16(setup->wValue) & 0xff);
+        int ret = xhci_set_configuration(udev, le16(setup->wValue) & 0xff);
         if (ret != ERR_NO_ERROR)
         {
             Kprintf("Failed to configure xHCI endpoint\n");
@@ -415,7 +414,7 @@ void xhci_udev_io_reply_failed(struct xhci_ctrl *ctrl, struct USBIORequest *io, 
         if (io->driver_private_flags & REQ_INTERNAL)
         {
             if (ctrl)
-                FreeVecPooled(ctrl->memoryPool, io);
+                pool_free(ctrl->memoryPool, io);
             return;
         }
 
@@ -435,7 +434,7 @@ static void xhci_udev_handle_hub_prefetch(struct usb_device *udev, struct USBIOR
 
     if (ctrl && io->data_buffer)
     {
-        memalign_free(ctrl->memoryPool, io->data_buffer);
+        dma_free(ctrl->memoryPool, io->data_buffer);
         io->data_buffer = NULL;
     }
 
@@ -444,7 +443,7 @@ static void xhci_udev_handle_hub_prefetch(struct usb_device *udev, struct USBIOR
     udev->pending_set_config_req = NULL;
 
     /* Now run the deferred xhci_set_configuration — hub data is cached */
-    UWORD config_value = LE16(orig_req->setup.wValue) & 0xff;
+    UWORD config_value = le16(orig_req->setup.wValue) & 0xff;
     int ret = xhci_set_configuration(udev, config_value);
     if (ret != ERR_NO_ERROR)
     {
@@ -482,7 +481,7 @@ void xhci_udev_io_reply_data(struct usb_device *udev, struct USBIORequest *io, i
 
         struct xhci_ctrl *ctrl = udev->controller;
         if (ctrl)
-            FreeVecPooled(ctrl->memoryPool, io);
+            pool_free(ctrl->memoryPool, io);
         return;
     }
 
@@ -505,30 +504,29 @@ static BOOL xhci_udev_fetch_hub_descriptor(struct usb_device *udev)
     const UBYTE desc_type = (udev->speed >= USB_SPEED_SUPER) ? USB_DT_SS_HUB : USB_DT_HUB;
     const UBYTE desc_len = (desc_type == USB_DT_SS_HUB) ? 12 : 9;
 
-    const ULONG alloc_len = ALIGN(desc_len, ARCH_DMA_MINALIGN);
-    UBYTE *buf = memalign(ctrl->memoryPool, ARCH_DMA_MINALIGN, alloc_len);
-    struct USBIORequest *io = AllocVecPooled(ctrl->memoryPool, sizeof(*io));
+    const ULONG alloc_len = ALIGN_UP(desc_len, DMA_ALIGN_MIN);
+    UBYTE *buf = dma_alloc(ctrl->memoryPool, DMA_ALIGN_MIN, alloc_len);
+    struct USBIORequest *io = pool_zalloc(ctrl->memoryPool, sizeof(*io));
     if (!io || !buf)
     {
         Kprintf("xhci_udev_fetch_hub_descriptor: alloc failed, falling back to SET_CONFIGURATION without hub data\n");
         if (buf)
-            memalign_free(ctrl->memoryPool, buf);
+            dma_free(ctrl->memoryPool, buf);
         if (io)
-            FreeVecPooled(ctrl->memoryPool, io);
+            pool_free(ctrl->memoryPool, io);
         udev->pending_set_config_req = NULL;
         return FALSE;
     }
 
-    _memset(io, 0, sizeof(*io));
     io->req.io_Command = CMD_REQUEST_CONTROL;
     io->req.io_Flags = IOF_QUICK;
     io->driver_private_flags = REQ_INTERNAL | REQ_ENQUEUED | REQ_HUB_DESC_FETCH;
 
     io->setup.bmRequestType = USB_DIR_IN | USB_RT_HUB;
     io->setup.bRequest = USB_REQ_GET_DESCRIPTOR;
-    io->setup.wValue = cpu_to_le16((u16)(desc_type << 8));
+    io->setup.wValue = le16((u16)(desc_type << 8));
     io->setup.wIndex = 0;
-    io->setup.wLength = cpu_to_le16(desc_len);
+    io->setup.wLength = le16(desc_len);
 
     io->virtual_address = udev->virtual_address;
     io->data_buffer = buf;
@@ -545,8 +543,8 @@ static BOOL xhci_udev_fetch_hub_descriptor(struct usb_device *udev)
     if (ring_ret != ERR_NO_ERROR)
     {
         Kprintf("xhci_udev_fetch_hub_descriptor: ring_enqueue_td failed (%ld), falling back\n", (LONG)ring_ret);
-        memalign_free(ctrl->memoryPool, buf);
-        FreeVecPooled(ctrl->memoryPool, io);
+        dma_free(ctrl->memoryPool, buf);
+        pool_free(ctrl->memoryPool, io);
         udev->pending_set_config_req = NULL;
         return FALSE;
     }
@@ -563,20 +561,19 @@ static inline void xhci_udev_send_control_request(struct usb_device *udev, int e
         return;
 
     struct xhci_ctrl *ctrl = udev->controller;
-    struct USBIORequest *io = AllocVecPooled(ctrl->memoryPool, sizeof(*io));
+    struct USBIORequest *io = pool_zalloc(ctrl->memoryPool, sizeof(*io));
     if (!io)
         return;
 
-    _memset(io, 0, sizeof(*io));
     io->req.io_Command = CMD_REQUEST_CONTROL;
     io->req.io_Flags = IOF_QUICK;                           /* no reply port */
     io->driver_private_flags = REQ_INTERNAL | REQ_ENQUEUED; /* magic tag to free on completion */
 
     io->setup.bmRequestType = bmRequestType;
     io->setup.bRequest = bRequest;
-    io->setup.wValue = cpu_to_le16(wValue);
-    io->setup.wIndex = cpu_to_le16(wIndex);
-    io->setup.wLength = cpu_to_le16(wLength);
+    io->setup.wValue = le16(wValue);
+    io->setup.wIndex = le16(wIndex);
+    io->setup.wLength = le16(wLength);
 
     io->virtual_address = udev->virtual_address;
 
@@ -584,7 +581,7 @@ static inline void xhci_udev_send_control_request(struct usb_device *udev, int e
     if (!ep_ctx)
     {
         Kprintf("No ep context for ep index %d\n", ep_index);
-        FreeVecPooled(ctrl->memoryPool, io);
+        pool_free(ctrl->memoryPool, io);
         return;
     }
     if (enqueue)
@@ -705,13 +702,12 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
         return;
     }
 
-    struct usb_config *conf = AllocVecPooled(udev->controller->memoryPool, sizeof(*conf));
+    struct usb_config *conf = pool_zalloc(udev->controller->memoryPool, sizeof(*conf));
     if (!conf)
     {
-        Kprintf("AllocVecPooled failed\n");
+		Kprintf("pool_zalloc failed\n");
         return;
     }
-    _memset(conf, 0, sizeof(*conf));
 
     struct usb_config_descriptor *desc = (struct usb_config_descriptor *)data;
     if (desc->bDescriptorType != USB_DT_CONFIG)
@@ -720,7 +716,7 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
         goto error;
     }
 
-    UWORD total_len = LE16(desc->wTotalLength);
+    UWORD total_len = le16(desc->wTotalLength);
     if ((UWORD)len < total_len)
     {
         KprintfH("short buffer len=%ld total_len=%ld\n", (LONG)len, (LONG)total_len);
@@ -739,7 +735,7 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
     cursor += desc->bLength;
 
     KprintfH("wTotalLength=%ld bNumInterfaces=%ld bConfigurationValue=%ld iConfiguration=%ld bmAttributes=0x%02lx bMaxPower=%ld\n",
-             (LONG)LE16(desc->wTotalLength),
+             (LONG)le16(desc->wTotalLength),
              (LONG)desc->bNumInterfaces,
              (LONG)desc->bConfigurationValue,
              (LONG)desc->iConfiguration,
@@ -799,7 +795,7 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
                 }
                 interface_map[iface_number] = if_index;
                 current_if = &conf->if_desc[if_index];
-                _memset(current_if, 0, sizeof(struct usb_interface));
+                mem_zero(current_if, sizeof(struct usb_interface));
                 current_if->interface_number = (u8)iface_number;
                 current_if->num_altsetting = 0;
                 current_if->active_altsetting = NULL;
@@ -823,7 +819,7 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
 
             current_alt_index = current_if->num_altsetting++;
             current_alt = &current_if->altsetting[current_alt_index];
-            _memset(current_alt, 0, sizeof(struct usb_interface_altsetting));
+            mem_zero(current_alt, sizeof(struct usb_interface_altsetting));
 
             CopyMem(ifd, &current_alt->desc, sizeof(struct usb_interface_descriptor));
             current_alt->no_of_ep = 0;
@@ -864,7 +860,7 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
                      (LONG)ep_idx,
                      (LONG)epd->bEndpointAddress,
                      (LONG)epd->bmAttributes,
-                     (LONG)LE16(epd->wMaxPacketSize),
+                     (LONG)le16(epd->wMaxPacketSize),
                      (LONG)epd->bInterval);
 
             current_alt->no_of_ep++;
@@ -905,7 +901,7 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
         {
             KprintfH("removing old config with value %ld\n", (LONG)oldconf->desc.bConfigurationValue);
             RemoveMinNode(n);
-            FreeVecPooled(udev->controller->memoryPool, oldconf);
+            pool_free(udev->controller->memoryPool, oldconf);
             break;
         }
     }
@@ -914,7 +910,7 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
     return;
 
 error:
-    FreeVecPooled(udev->controller->memoryPool, conf);
+    pool_free(udev->controller->memoryPool, conf);
 }
 
 static void xhci_filter_ss_ep_companion_desc(struct USBIORequest *io)
@@ -926,7 +922,7 @@ static void xhci_filter_ss_ep_companion_desc(struct USBIORequest *io)
     if (desc->bDescriptorType != USB_DT_CONFIG)
         return;
 
-    UWORD total_len = LE16(desc->wTotalLength);
+    UWORD total_len = le16(desc->wTotalLength);
     if (total_len > io->actual_length)
         total_len = io->actual_length;
 
@@ -955,11 +951,11 @@ static void xhci_filter_ss_ep_companion_desc(struct USBIORequest *io)
     }
 
     if (write < end)
-        _memset(write, 0, end - write);
+        mem_zero(write, end - write);
 
     UWORD new_total = (UWORD)(write - (UBYTE *)io->data_buffer);
     if (new_total != total_len)
-        desc->wTotalLength = LE16(new_total);
+        desc->wTotalLength = le16(new_total);
 
     io->actual_length = new_total;
 }
@@ -1132,7 +1128,7 @@ static ULONG xhci_udev_build_usb2_hub_descriptor(struct usb_device *udev, UBYTE 
         return 0;
 
     struct usb_hub_descriptor hub;
-    _memset(&hub, 0, sizeof(hub));
+    mem_zero(&hub, sizeof(hub));
 
     const UBYTE ports = udev->hub_num_ports;
     const UBYTE needed = min((ports + 1U + 7U) / 8U, sizeof(hub.u.hs.DeviceRemovable));
@@ -1161,7 +1157,7 @@ static void xhci_udev_translate_hub_descriptor_request(struct usb_device *udev, 
         return;
 
     struct USBSetupPacket *setup = &io->setup;
-    const u8 descriptorType = (LE16(setup->wValue) >> 8) & 0xFF;
+    const u8 descriptorType = (le16(setup->wValue) >> 8) & 0xFF;
     const u16 typeReq = setup->bRequest | setup->bmRequestType << 8;
 
     /* Only translate GetHubDescriptor requests for USB_DT_HUB */
@@ -1169,11 +1165,11 @@ static void xhci_udev_translate_hub_descriptor_request(struct usb_device *udev, 
         return;
 
     /* Modify the request to ask for SS hub descriptor instead */
-    u16 old_value = LE16(setup->wValue);
-    setup->wValue = cpu_to_le16((USB_DT_SS_HUB << 8) | (old_value & 0xFF));
+    u16 old_value = le16(setup->wValue);
+    setup->wValue = le16((USB_DT_SS_HUB << 8) | (old_value & 0xFF));
 
     KprintfH("SS hub addr=%ld: modified wValue from 0x%04lx (USB_DT_HUB) to 0x%04lx (USB_DT_SS_HUB)\n",
-             (LONG)udev->virtual_address, (ULONG)old_value, (ULONG)LE16(setup->wValue));
+             (LONG)udev->virtual_address, (ULONG)old_value, (ULONG)le16(setup->wValue));
 
     /* Return FALSE to let the request proceed normally - it will be translated back in parse */
     return;
@@ -1238,14 +1234,14 @@ static void handle_get_device_descriptor(struct usb_device *udev, struct USBIORe
     KprintfH("Device Descriptor: bLength=%ld bDescriptorType=%ld bcdUSB=0x%04lx bDeviceClass=0x%02lx bDeviceSubClass=0x%02lx bDeviceProtocol=0x%02lx bMaxPacketSize0=%ld idVendor=0x%04lx idProduct=0x%04lx bcdDevice=0x%04lx iManufacturer=%ld iProduct=%ld iSerialNumber=%ld bNumConfigurations=%ld\n",
              (LONG)dev_desc->bLength,
              (LONG)dev_desc->bDescriptorType,
-             (ULONG)LE16(dev_desc->bcdUSB),
+             (ULONG)le16(dev_desc->bcdUSB),
              (LONG)dev_desc->bDeviceClass,
              (LONG)dev_desc->bDeviceSubClass,
              (LONG)dev_desc->bDeviceProtocol,
              (LONG)dev_desc->bMaxPacketSize0,
-             (ULONG)LE16(dev_desc->idVendor),
-             (ULONG)LE16(dev_desc->idProduct),
-             (ULONG)LE16(dev_desc->bcdDevice),
+             (ULONG)le16(dev_desc->idVendor),
+             (ULONG)le16(dev_desc->idProduct),
+             (ULONG)le16(dev_desc->bcdDevice),
              (LONG)dev_desc->iManufacturer,
              (LONG)dev_desc->iProduct,
              (LONG)dev_desc->iSerialNumber,
@@ -1289,14 +1285,14 @@ static void handle_get_hub_descriptor(struct usb_device *udev, struct USBIOReque
              (LONG)hub->bLength,
              (LONG)hub->bDescriptorType,
              (LONG)hub->bNbrPorts,
-             (ULONG)LE16(hub->wHubCharacteristics),
+             (ULONG)le16(hub->wHubCharacteristics),
              (LONG)hub->bPwrOn2PwrGood,
              (LONG)hub->bHubContrCurrent);
 
     /* Update TT think time if changed */
     if (udev->parent)
     {
-        const UWORD characteristics = LE16(hub->wHubCharacteristics);
+        const UWORD characteristics = le16(hub->wHubCharacteristics);
         udev->tt_think_time = (u8)((characteristics >> 5) & 0x3);
         KprintfH("hub addr %ld TT think time code=%ld (bit-times=%ld)\n",
                  (LONG)udev->virtual_address, (LONG)udev->tt_think_time, (LONG)((udev->tt_think_time + 1) * 8));
@@ -1380,10 +1376,10 @@ static void handle_get_port_status(struct usb_device *udev, struct USBIORequest 
     struct xhci_ctrl *ctrl = udev->controller;
     if (!ctrl)
         return;
-    const u16 port = LE16(io->setup.wIndex);
+    const u16 port = le16(io->setup.wIndex);
 
-    u16 wStatus = LE16(((u16 *)io->data_buffer)[0]);
-    u16 wChange = LE16(((u16 *)io->data_buffer)[1]);
+    u16 wStatus = le16(((u16 *)io->data_buffer)[0]);
+    u16 wChange = le16(((u16 *)io->data_buffer)[1]);
     const u16 rawStatus = wStatus;
     const u16 rawChange = wChange;
     /* Extract speed from the appropriate bit positions based on hub type */
@@ -1392,8 +1388,8 @@ static void handle_get_port_status(struct usb_device *udev, struct USBIORequest 
     if (udev->ss_hub_emulation)
     {
         xhci_udev_map_ss_port_status(&wStatus, &wChange, speed);
-        ((u16 *)io->data_buffer)[0] = LE16(wStatus);
-        ((u16 *)io->data_buffer)[1] = LE16(wChange);
+        ((u16 *)io->data_buffer)[0] = le16(wStatus);
+        ((u16 *)io->data_buffer)[1] = le16(wChange);
     }
 
     KprintfH("hub addr=%ld port=%ld status=%04lx change=%04lx\n", (LONG)udev->virtual_address, (LONG)port, (ULONG)wStatus, (ULONG)wChange);
@@ -1452,7 +1448,7 @@ static void handle_get_port_status(struct usb_device *udev, struct USBIORequest 
 static void handle_set_address(struct usb_device *udev, struct USBIORequest *io)
 {
     UWORD old_addr = io->virtual_address & 0x7F;
-    UWORD new_addr = (UWORD)(LE16(io->setup.wValue) & 0x7F);
+    UWORD new_addr = (UWORD)(le16(io->setup.wValue) & 0x7F);
     if (new_addr == old_addr)
         return;
 
@@ -1482,8 +1478,8 @@ static void handle_set_address(struct usb_device *udev, struct USBIORequest *io)
 
 static void handle_set_interface(struct usb_device *udev, struct USBIORequest *io)
 {
-    unsigned int iface = (unsigned int)(LE16(io->setup.wIndex) & 0xFF);
-    unsigned int alt = (unsigned int)(LE16(io->setup.wValue) & 0xFF);
+    unsigned int iface = (unsigned int)(le16(io->setup.wIndex) & 0xFF);
+    unsigned int alt = (unsigned int)(le16(io->setup.wValue) & 0xFF);
     /*
      * This is a workaround for Poseidon issue.
      * Poseidon issues SET_INTERFACE for all devices after connecting a new one.
@@ -1512,12 +1508,12 @@ static void xhci_udev_parse_control_message(struct usb_device *udev, struct USBI
              (ULONG)udev, (ULONG)udev->virtual_address,
              (ULONG)io->setup.bmRequestType,
              (ULONG)io->setup.bRequest,
-             LE16(io->setup.wValue),
-             LE16(io->setup.wIndex),
-             LE16(io->setup.wLength),
+             le16(io->setup.wValue),
+             le16(io->setup.wIndex),
+             le16(io->setup.wLength),
              (LONG)io->actual_length);
 
-    const u8 descriptorType = (LE16(io->setup.wValue) >> 8) & 0xFF;
+    const u8 descriptorType = (le16(io->setup.wValue) >> 8) & 0xFF;
     const u16 typeReq = io->setup.bRequest | io->setup.bmRequestType << 8;
 
     switch (typeReq)
@@ -1540,7 +1536,7 @@ static void xhci_udev_parse_control_message(struct usb_device *udev, struct USBI
             break;
         case USB_DT_STRING:
         {
-            const u16 string_index = LE16(io->setup.wValue) & 0xFF;
+            const u16 string_index = le16(io->setup.wValue) & 0xFF;
             if (string_index && string_index == udev->product_string_index)
             {
                 xhci_trim_string_descriptor(io);

--- a/xhci.device/src/xhci/xhci-udev.c
+++ b/xhci.device/src/xhci/xhci-udev.c
@@ -418,6 +418,25 @@ void xhci_udev_io_reply_failed(struct xhci_ctrl *ctrl, struct USBIORequest *io, 
             return;
         }
 
+        /* RT ISO clones were never sent as messages — never ReplyMsg.
+         * IN clones own their staging data_buffer; free both. OUT clones
+         * point at user buffers, so leave data_buffer alone. */
+        if (io->driver_private_flags & REQ_RT_ISO_CLONE)
+        {
+            if (ctrl)
+            {
+                if (io->direction == DIRECTION_IN && io->data_buffer)
+                {
+                    if (io->driver_private_flags & REQ_RT_IN_BUF_SLABBED)
+                        slab_free(&ctrl->iso_in_staging_slab, io->data_buffer);
+                    else
+                        pool_free(ctrl->memoryPool, io->data_buffer);
+                }
+                slab_free(&ctrl->iso_clone_slab, io);
+            }
+            return;
+        }
+
         KprintfH("addr %lu EP %lu err=%ld\n", (ULONG)io->virtual_address, (ULONG)io->endpoint, (LONG)err);
         ReplyMsg((struct Message *)io);
     }

--- a/xhci.device/src/xhci/xhci-udev.c
+++ b/xhci.device/src/xhci/xhci-udev.c
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-2.0+
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
-#include <clib/utility_protos.h>
 #else
+#define __NOLIBBASE__
+#define EXEC_BASE_NAME (*(struct ExecBase **)4UL)
 #include <proto/exec.h>
-#include <proto/utility.h>
 #endif
 
 #include <devices/hcd_api.h>
@@ -22,7 +22,9 @@
 
 #include <device.h>
 #include <debug.h>
-#include <compat.h>
+#include <emu_bits.h>
+#include <emu_byteorder.h>
+#include <emu_memory.h>
 #include <minlist.h>
 
 #ifdef DEBUG

--- a/xhci.device/src/xhci/xhci-udev.c
+++ b/xhci.device/src/xhci/xhci-udev.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 #ifdef __INTELLISENSE__
 #include <clib/exec_protos.h>
 #else

--- a/xhci.device/src/xhci/xhci-udev.c
+++ b/xhci.device/src/xhci/xhci-udev.c
@@ -41,7 +41,7 @@ static void xhci_udev_parse_control_message(struct usb_device *udev, struct USBI
 static void xhci_udev_translate_hub_descriptor_request(struct usb_device *udev, struct USBIORequest *io);
 static BOOL xhci_udev_fetch_hub_descriptor(struct usb_device *udev);
 
-struct usb_device *xhci_udev_alloc(struct xhci_ctrl *ctrl, UWORD virtual_address)
+struct usb_device *xhci_udev_alloc(struct xhci_ctrl *ctrl, u16 virtual_address)
 {
     if (!ctrl || virtual_address > USB_MAX_ADDRESS)
         return NULL;
@@ -52,7 +52,7 @@ struct usb_device *xhci_udev_alloc(struct xhci_ctrl *ctrl, UWORD virtual_address
     struct usb_device *udev = pool_zalloc(ctrl->memoryPool, sizeof(*udev));
     if (!udev)
     {
-        Kprintf("Failed to allocate usb_device for addr %ld\n", (LONG)virtual_address);
+        Kprintf("Failed to allocate usb_device for addr %lu\n", (ULONG)virtual_address);
         goto nothing;
     }
 
@@ -66,20 +66,20 @@ struct usb_device *xhci_udev_alloc(struct xhci_ctrl *ctrl, UWORD virtual_address
     udev->out_ctx = xhci_alloc_container_ctx(ctrl, XHCI_CTX_TYPE_DEVICE);
     if (!udev->out_ctx)
     {
-        Kprintf("Failed to allocate out context for addr %ld\n", (LONG)virtual_address);
+        Kprintf("Failed to allocate out context for addr %lu\n", (ULONG)virtual_address);
         goto free_udev;
     }
-    KprintfH("out_ctx bytes=%lx size=%ld\n",
+    KprintfH("out_ctx bytes=%lx size=%lu\n",
              (ULONG)udev->out_ctx->bytes, (ULONG)udev->out_ctx->size);
 
     /* Allocate the (input) device context for address device command */
     udev->in_ctx = xhci_alloc_container_ctx(ctrl, XHCI_CTX_TYPE_INPUT);
     if (!udev->in_ctx)
     {
-        Kprintf("Failed to allocate in context for addr %ld\n", (LONG)virtual_address);
+        Kprintf("Failed to allocate in context for addr %lu\n", (ULONG)virtual_address);
         goto destroy_out_ctx;
     }
-    KprintfH("in_ctx bytes=%lx size=%ld\n",
+    KprintfH("in_ctx bytes=%lx size=%lu\n",
              (ULONG)udev->in_ctx->bytes, (ULONG)udev->in_ctx->size);
 
     ctrl->devices_by_virtual_address[virtual_address] = udev;
@@ -93,7 +93,7 @@ nothing:
     return NULL;
 }
 
-struct usb_device *xhci_udev_get(struct XHCIUnit *unit, UWORD virtual_address)
+struct usb_device *xhci_udev_get(struct XHCIUnit *unit, u16 virtual_address)
 {
     if (!unit || !unit->xhci_ctrl || virtual_address > USB_MAX_ADDRESS)
         return NULL;
@@ -105,14 +105,14 @@ struct usb_device *xhci_udev_get(struct XHCIUnit *unit, UWORD virtual_address)
         // We'll be only creating contexts for newly detected devices
         if (virtual_address != 0 && virtual_address != xhci_roothub_get_address(ctrl->root_hub))
             return NULL;
-        KprintfH("new device addr=%ld\n", (LONG)virtual_address);
+        KprintfH("new device addr=%lu\n", (ULONG)virtual_address);
         udev = xhci_udev_alloc(ctrl, virtual_address);
     }
 
     return udev;
 }
 
-static void xhci_udev_flush(struct usb_device *udev, UBYTE reply_code)
+static void xhci_udev_flush(struct usb_device *udev, s8 reply_code)
 {
     if (!udev)
         return;
@@ -120,7 +120,7 @@ static void xhci_udev_flush(struct usb_device *udev, UBYTE reply_code)
     struct xhci_ctrl *ctrl = udev->controller;
     if (!ctrl)
         return;
-    KprintfH("flushing device addr=%ld slot=%ld\n", (LONG)udev->virtual_address, (LONG)udev->slot_id);
+    KprintfH("flushing device addr=%lu slot=%lu\n", (ULONG)udev->virtual_address, (ULONG)udev->slot_id);
 
     if (udev->virtual_address == xhci_roothub_get_address(ctrl->root_hub))
     {
@@ -159,7 +159,7 @@ void xhci_udev_free(struct usb_device *udev)
     pool_free(ctrl->memoryPool, udev);
 }
 
-static UBYTE xhci_udev_find_epaddr_by_num(struct usb_device *udev, UBYTE epnum)
+static u8 xhci_udev_find_epaddr_by_num(struct usb_device *udev, u8 epnum)
 {
     if (!udev || !udev->active_config || epnum == 0)
         return 0;
@@ -175,7 +175,7 @@ static UBYTE xhci_udev_find_epaddr_by_num(struct usb_device *udev, UBYTE epnum)
 
         for (int e = 0; e < alt->no_of_ep; ++e)
         {
-            UBYTE addr = alt->ep_desc[e].bEndpointAddress;
+            u8 addr = alt->ep_desc[e].bEndpointAddress;
             if ((addr & 0x0F) == epnum)
                 return addr;
         }
@@ -193,22 +193,22 @@ static void xhci_udev_patch_endpoint_address(struct usb_device *udev, struct USB
         return;
 
     /* If direction bit is already present, leave untouched. */
-    UWORD wIndex = le16(setup->wIndex);
+    u16 wIndex = le16(setup->wIndex);
     if (wIndex & 0x0080)
         return;
 
-    UBYTE epnum = wIndex & 0x0F;
+    u8 epnum = wIndex & 0x0F;
     if (epnum == 0)
         return;
 
-    UBYTE fixed = xhci_udev_find_epaddr_by_num(udev, epnum);
-    if (!fixed || fixed == (UBYTE)wIndex)
+    u8 fixed = xhci_udev_find_epaddr_by_num(udev, epnum);
+    if (!fixed || fixed == (u8)wIndex)
         return;
 
     setup->wIndex = le16(fixed);
 
-    KprintfH("Patched endpoint address wIndex from %02lx to %02lx for epnum %ld\n",
-             (ULONG)wIndex, (ULONG)fixed, (LONG)epnum);
+    KprintfH("Patched endpoint address wIndex from %02lx to %02lx for epnum %lu\n",
+             (ULONG)wIndex, (ULONG)fixed, (ULONG)epnum);
 }
 
 static BOOL xhci_udev_filter_emulated_hub_ctrl_request(struct usb_device *udev, struct USBIORequest *io)
@@ -224,7 +224,7 @@ static BOOL xhci_udev_filter_emulated_hub_ctrl_request(struct usb_device *udev, 
         return FALSE;
 
     const u16 wValue = le16(setup->wValue);
-    const u8 portNo = le16(setup->wIndex) & 0xFF;
+    const u8 portNo = le16(setup->wIndex) & 0xFFU;
     switch (wValue)
     {
     case USB_PORT_FEAT_SUSPEND:
@@ -254,7 +254,7 @@ static BOOL xhci_udev_filter_emulated_hub_ctrl_request(struct usb_device *udev, 
     }
 }
 
-int xhci_udev_send_ctrl(struct usb_device *udev, struct USBIORequest *io)
+s8 xhci_udev_send_ctrl(struct usb_device *udev, struct USBIORequest *io)
 {
     if (!udev || !io)
     {
@@ -262,16 +262,16 @@ int xhci_udev_send_ctrl(struct usb_device *udev, struct USBIORequest *io)
         return ERR_BAD_PARAMETERS;
     }
 
-    unsigned int timeout_ms = 0;
+    u32 timeout_ms = 0;
     if ((io->flags & DRIVER_FLAG_TIMEOUT_DEFINED))
         timeout_ms = io->timeout;
 
-    int ret = xhci_ring_enqueue_td(udev, io, timeout_ms, FALSE);
+    s8 ret = xhci_ring_enqueue_td(udev, io, timeout_ms, FALSE);
 
     return ret;
 }
 
-static int xhci_udev_send_ctrl_first(struct usb_device *udev, struct USBIORequest *io, unsigned int timeout_ms)
+static s8 xhci_udev_send_ctrl_first(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms)
 {
     /* Work around class drivers that omit the direction bit in endpoint-recipient requests (e.g., UAC1 SET_CUR). */
     xhci_udev_patch_endpoint_address(udev, io);
@@ -323,7 +323,7 @@ static int xhci_udev_send_ctrl_first(struct usb_device *udev, struct USBIOReques
                 return ERR_NO_ERROR;
         }
 
-        int ret = xhci_set_configuration(udev, le16(setup->wValue) & 0xff);
+        s8 ret = xhci_set_configuration(udev, le16(setup->wValue) & 0xff);
         if (ret != ERR_NO_ERROR)
         {
             Kprintf("Failed to configure xHCI endpoint\n");
@@ -343,35 +343,35 @@ static int xhci_udev_send_ctrl_first(struct usb_device *udev, struct USBIOReques
         return ERR_NO_ERROR;
     }
 
-    int ret = xhci_ring_enqueue_td(udev, io, timeout_ms, FALSE);
+    s8 ret = xhci_ring_enqueue_td(udev, io, timeout_ms, FALSE);
     return ret;
 }
 
-int xhci_udev_send(struct USBIORequest *req)
+s8 xhci_udev_send(struct USBIORequest *req)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)req->req.io_Unit;
     if (!unit)
     {
-        Kprintf("missing unit pointer (cmd=%ld, req=%lx, devaddr=%ld)\n",
-                (LONG)req->req.io_Command, (ULONG)req, (LONG)req->virtual_address);
+        Kprintf("missing unit pointer (cmd=%lu, req=%lx, devaddr=%lu)\n",
+                (ULONG)req->req.io_Command, (ULONG)req, (ULONG)req->virtual_address);
         return ERR_BAD_PARAMETERS;
     }
 
     struct usb_device *udev = xhci_udev_get(unit, req->virtual_address);
     if (!udev)
     {
-        KprintfH("Device does not exist for addr %ld\n", (LONG)req->virtual_address);
+        KprintfH("Device does not exist for addr %lu\n", (ULONG)req->virtual_address);
         return ERR_TIMEOUT;
     }
 
-    unsigned int timeout_ms = 0;
+    u32 timeout_ms = 0;
     if ((req->flags & DRIVER_FLAG_TIMEOUT_DEFINED))
-        timeout_ms = (unsigned int)req->timeout;
+        timeout_ms = req->timeout;
 
-    KprintfH("dev=%lx addr=%ld slot=%ld ep=%ld dir=%s len=%ld flags=%lx tmo=%lu\n",
-             (ULONG)udev, (ULONG)udev->virtual_address, (LONG)udev->slot_id,
-             req->endpoint & 0x0F, (req->direction == DIRECTION_IN) ? "IN" : "OUT",
-             (LONG)req->data_buffer_length, (ULONG)req->flags,
+    KprintfH("dev=%lx addr=%lu slot=%lu ep=%lu dir=%s len=%lu flags=%lx tmo=%lu\n",
+             (ULONG)udev, (ULONG)udev->virtual_address, (ULONG)udev->slot_id,
+             (ULONG)(req->endpoint & 0x0F), (req->direction == DIRECTION_IN) ? "IN" : "OUT",
+             (ULONG)req->data_buffer_length, (ULONG)req->flags,
              (ULONG)timeout_ms);
 
     switch (req->req.io_Command)
@@ -386,25 +386,25 @@ int xhci_udev_send(struct USBIORequest *req)
         struct xhci_ctrl *ctrl = unit->xhci_ctrl;
         if (udev->virtual_address == xhci_roothub_get_address(ctrl->root_hub))
         {
-            int result = xhci_roothub_submit_int_request(ctrl->root_hub, req);
+            s8 result = xhci_roothub_submit_int_request(ctrl->root_hub, req);
             return result;
         }
 
         return xhci_ring_enqueue_td(udev, req, timeout_ms, FALSE);
     }
     default:
-        Kprintf("unsupported command %ld (req=%lx, devaddr=%ld, endpoint=%ld, flags=0x%lx)\n",
-                (LONG)req->req.io_Command,
+        Kprintf("unsupported command %lu (req=%lx, devaddr=%lu, endpoint=%lu, flags=0x%lx)\n",
+                (ULONG)req->req.io_Command,
                 (ULONG)req,
-                (LONG)req->virtual_address,
-                (LONG)req->endpoint,
+                (ULONG)req->virtual_address,
+                (ULONG)req->endpoint,
                 (ULONG)req->flags);
         return ERR_BAD_PARAMETERS;
     }
 }
 
 /* Hooks for responding to requests for lower layer */
-void xhci_udev_io_reply_failed(struct xhci_ctrl *ctrl, struct USBIORequest *io, int err)
+void xhci_udev_io_reply_failed(struct xhci_ctrl *ctrl, struct USBIORequest *io, s8 err)
 {
     if (io)
     {
@@ -418,7 +418,7 @@ void xhci_udev_io_reply_failed(struct xhci_ctrl *ctrl, struct USBIORequest *io, 
             return;
         }
 
-        KprintfH("addr %ld EP %ld err=%ld\n", (LONG)io->virtual_address, (LONG)io->endpoint, (LONG)err);
+        KprintfH("addr %lu EP %lu err=%ld\n", (ULONG)io->virtual_address, (ULONG)io->endpoint, (LONG)err);
         ReplyMsg((struct Message *)io);
     }
 }
@@ -427,10 +427,10 @@ static void xhci_udev_handle_hub_prefetch(struct usb_device *udev, struct USBIOR
 {
     struct xhci_ctrl *ctrl = udev->controller;
 
-    KprintfH("Hub descriptor pre-fetch done for addr=%ld (ports=%ld tt=%ld)\n",
-             (LONG)udev->virtual_address,
-             (LONG)udev->ss_hub_desc.bNbrPorts,
-             (LONG)udev->tt_think_time);
+    KprintfH("Hub descriptor pre-fetch done for addr=%lu (ports=%lu tt=%lu)\n",
+             (ULONG)udev->virtual_address,
+             (ULONG)udev->ss_hub_desc.bNbrPorts,
+             (ULONG)udev->tt_think_time);
 
     if (ctrl && io->data_buffer)
     {
@@ -443,8 +443,8 @@ static void xhci_udev_handle_hub_prefetch(struct usb_device *udev, struct USBIOR
     udev->pending_set_config_req = NULL;
 
     /* Now run the deferred xhci_set_configuration — hub data is cached */
-    UWORD config_value = le16(orig_req->setup.wValue) & 0xff;
-    int ret = xhci_set_configuration(udev, config_value);
+    const u8 config_value = le16(orig_req->setup.wValue) & 0xffU;
+    s8 ret = xhci_set_configuration(udev, config_value);
     if (ret != ERR_NO_ERROR)
     {
         Kprintf("Hub SET_CONFIGURATION failed after hub desc fetch\n");
@@ -456,7 +456,7 @@ static void xhci_udev_handle_hub_prefetch(struct usb_device *udev, struct USBIOR
     xhci_configure_endpoints(udev, FALSE, orig_req);
 }
 
-void xhci_udev_io_reply_data(struct usb_device *udev, struct USBIORequest *io, int err, ULONG actual)
+void xhci_udev_io_reply_data(struct usb_device *udev, struct USBIORequest *io, s8 err, u32 actual)
 {
     if (!io || !udev)
         return;
@@ -467,7 +467,7 @@ void xhci_udev_io_reply_data(struct usb_device *udev, struct USBIORequest *io, i
     if (io->req.io_Command == CMD_REQUEST_CONTROL && err == ERR_NO_ERROR && io->endpoint == 0)
         xhci_udev_parse_control_message(udev, io);
 
-    KprintfH("err=%ld actual=%ld\n", (LONG)err, (LONG)actual);
+    KprintfH("err=%ld actual=%lu\n", (LONG)err, (ULONG)actual);
 
     /* Internal, reply-less requests (IOF_QUICK + magic tag) */
     if (io->driver_private_flags & REQ_INTERNAL)
@@ -501,11 +501,11 @@ static BOOL xhci_udev_fetch_hub_descriptor(struct usb_device *udev)
     struct xhci_ctrl *ctrl = udev->controller;
 
     /* Choose descriptor type based on device speed */
-    const UBYTE desc_type = (udev->speed >= USB_SPEED_SUPER) ? USB_DT_SS_HUB : USB_DT_HUB;
-    const UBYTE desc_len = (desc_type == USB_DT_SS_HUB) ? 12 : 9;
+    const u8 desc_type = (udev->speed >= USB_SPEED_SUPER) ? USB_DT_SS_HUB : USB_DT_HUB;
+    const u8 desc_len = (desc_type == USB_DT_SS_HUB) ? 12 : 9;
 
-    const ULONG alloc_len = ALIGN_UP(desc_len, DMA_ALIGN_MIN);
-    UBYTE *buf = dma_alloc(ctrl->memoryPool, DMA_ALIGN_MIN, alloc_len);
+    const u32 alloc_len = ALIGN_UP((u32)desc_len, DMA_ALIGN_MIN);
+    u8 *buf = dma_alloc(ctrl->memoryPool, DMA_ALIGN_MIN, alloc_len);
     struct USBIORequest *io = pool_zalloc(ctrl->memoryPool, sizeof(*io));
     if (!io || !buf)
     {
@@ -533,13 +533,13 @@ static BOOL xhci_udev_fetch_hub_descriptor(struct usb_device *udev)
     io->data_buffer_length = desc_len;
     io->direction = DIRECTION_IN;
 
-    KprintfH("Fetching hub descriptor (type=0x%02lx len=%ld) for addr=%ld before CONFIG_EP\n",
-             (ULONG)desc_type, (LONG)desc_len, (LONG)udev->virtual_address);
+    KprintfH("Fetching hub descriptor (type=0x%02lx len=%lu) for addr=%lu before CONFIG_EP\n",
+             (ULONG)desc_type, (ULONG)desc_len, (ULONG)udev->virtual_address);
 
     /* Submit directly to the transfer ring — xhci_ep_enqueue only queues
      * for later and requires a completion event to drain, but EP0 may be
      * idle right now so nothing would ever kick the queue. */
-    int ring_ret = xhci_ring_enqueue_td(udev, io, 1000, FALSE);
+    s8 ring_ret = xhci_ring_enqueue_td(udev, io, 1000, FALSE);
     if (ring_ret != ERR_NO_ERROR)
     {
         Kprintf("xhci_udev_fetch_hub_descriptor: ring_enqueue_td failed (%ld), falling back\n", (LONG)ring_ret);
@@ -552,9 +552,9 @@ static BOOL xhci_udev_fetch_hub_descriptor(struct usb_device *udev)
     return TRUE;
 }
 
-static inline void xhci_udev_send_control_request(struct usb_device *udev, int ep_index,
-                                                  UBYTE bmRequestType, UBYTE bRequest,
-                                                  UWORD wValue, UWORD wIndex, UWORD wLength,
+static inline void xhci_udev_send_control_request(struct usb_device *udev, u8 ep_index,
+                                                  u8 bmRequestType, u8 bRequest,
+                                                  u16 wValue, u16 wIndex, u16 wLength,
                                                   BOOL enqueue)
 {
     if (!udev || !udev->controller)
@@ -591,21 +591,21 @@ static inline void xhci_udev_send_control_request(struct usb_device *udev, int e
         xhci_ring_enqueue_td(udev, io, 1000, FALSE);
 }
 
-inline static UBYTE xhci_ep_index_to_address(u32 ep_index)
+inline static u8 xhci_ep_index_to_address(u8 ep_index)
 {
     if (ep_index == 0)
         return 0;
-    return EP_INDEX_TO_ENDPOINT(ep_index) | ((ep_index & 0x1) ? USB_DIR_OUT : USB_DIR_IN);
+    return (u8)(EP_INDEX_TO_ENDPOINT(ep_index) | ((ep_index & 0x1U) ? USB_DIR_OUT : USB_DIR_IN));
 }
 
 /* Issue an internal CLEAR_FEATURE(ENDPOINT_HALT) to endpoint (by ep_index) on udev. Fire-and-forget. */
-void xhci_udev_clear_feature_halt(struct usb_device *udev, ULONG ep_index)
+void xhci_udev_clear_feature_halt(struct usb_device *udev, u8 ep_index)
 {
     if (!udev || !udev->controller || ep_index == 0)
         return;
 
     /* Convert ep_index (DCI-1) to USB endpoint address (number + direction bit). */
-    UBYTE addr = xhci_ep_index_to_address(ep_index);
+    u8 addr = xhci_ep_index_to_address(ep_index);
 
     xhci_udev_send_control_request(udev, ep_index,
                                    USB_DIR_OUT | USB_TYPE_STANDARD | USB_RECIP_ENDPOINT,
@@ -617,7 +617,7 @@ void xhci_udev_clear_feature_halt(struct usb_device *udev, ULONG ep_index)
 }
 
 /* Issue an internal CLEAR_TT_BUFFER to the parent hub for control/bulk endpoints behind a TT. */
-void xhci_udev_clear_tt_buffer(struct usb_device *udev, ULONG ep_index, int ep_type)
+void xhci_udev_clear_tt_buffer(struct usb_device *udev, u8 ep_index, int ep_type)
 {
     if (!udev || !udev->parent)
         return;
@@ -632,10 +632,10 @@ void xhci_udev_clear_tt_buffer(struct usb_device *udev, ULONG ep_index, int ep_t
     BOOL out = (ep_index & 0x1) != 0;
 
     u16 devinfo = epnum;
-    devinfo |= ((u16)udev->xhci_address) << 4;
-    devinfo |= ((u16)ep_type) << 11;
+    devinfo |= (u16)((u16)udev->xhci_address << 4);
+    devinfo |= (u16)((u16)ep_type << 11);
     if (!out)
-        devinfo |= 1 << 15;
+        devinfo |= 1U << 15;
 
     xhci_udev_send_control_request(hub,
                                    0, /* ep_index 0 */
@@ -662,7 +662,7 @@ void xhci_udev_clear_tt_buffer(struct usb_device *udev, ULONG ep_index, int ep_t
  * Descriptor access
  */
 
-int xhci_ep_type_for_index(struct usb_device *udev, u32 ep_index)
+s32 xhci_ep_type_for_index(struct usb_device *udev, u8 ep_index)
 {
     if (!udev)
         return -1;
@@ -674,7 +674,7 @@ int xhci_ep_type_for_index(struct usb_device *udev, u32 ep_index)
     if (!cfg)
         return -1;
 
-    UBYTE addr = xhci_ep_index_to_address(ep_index);
+    u8 addr = xhci_ep_index_to_address(ep_index);
 
     for (int i = 0; i < cfg->no_of_if; ++i)
     {
@@ -694,50 +694,50 @@ int xhci_ep_type_for_index(struct usb_device *udev, u32 ep_index)
     return -1;
 }
 
-static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD len)
+static void parse_config_descriptor(struct usb_device *udev, u8 *data, u16 len)
 {
     if (len < 2)
     {
-        KprintfH("too short, len=%ld\n", (LONG)len);
+        KprintfH("too short, len=%lu\n", (ULONG)len);
         return;
     }
 
     struct usb_config *conf = pool_zalloc(udev->controller->memoryPool, sizeof(*conf));
     if (!conf)
     {
-		Kprintf("pool_zalloc failed\n");
+        Kprintf("pool_zalloc failed\n");
         return;
     }
 
     struct usb_config_descriptor *desc = (struct usb_config_descriptor *)data;
     if (desc->bDescriptorType != USB_DT_CONFIG)
     {
-        Kprintf("bad desc type %ld\n", (LONG)desc->bDescriptorType);
+        Kprintf("bad desc type %lu\n", (ULONG)desc->bDescriptorType);
         goto error;
     }
 
-    UWORD total_len = le16(desc->wTotalLength);
-    if ((UWORD)len < total_len)
+    u16 total_len = le16(desc->wTotalLength);
+    if (len < total_len)
     {
-        KprintfH("short buffer len=%ld total_len=%ld\n", (LONG)len, (LONG)total_len);
+        KprintfH("short buffer len=%lu total_len=%lu\n", (ULONG)len, (ULONG)total_len);
         return;
     }
 
-    UBYTE *cursor = data;
-    UBYTE *end = data + total_len;
+    u8 *cursor = data;
+    u8 *end = data + total_len;
     if (cursor + desc->bLength > end)
     {
-        Kprintf("bad desc length %ld\n", (LONG)desc->bLength);
+        Kprintf("bad desc length %lu\n", (ULONG)desc->bLength);
         goto error;
     }
 
     CopyMem(desc, &conf->desc, sizeof(struct usb_config_descriptor));
     cursor += desc->bLength;
 
-    KprintfH("wTotalLength=%ld bNumInterfaces=%ld bConfigurationValue=%ld iConfiguration=%ld bmAttributes=0x%02lx bMaxPower=%ld\n",
-             (LONG)le16(desc->wTotalLength),
-             (LONG)desc->bNumInterfaces,
-             (LONG)desc->bConfigurationValue,
+    KprintfH("wTotalLength=%lu bNumInterfaces=%lu bConfigurationValue=%lu iConfiguration=%lu bmAttributes=0x%02lx bMaxPower=%lu\n",
+             (ULONG)le16(desc->wTotalLength),
+             (ULONG)desc->bNumInterfaces,
+             (ULONG)desc->bConfigurationValue,
              (LONG)desc->iConfiguration,
              (LONG)desc->bmAttributes,
              (LONG)desc->bMaxPower);
@@ -756,8 +756,8 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
 
     while (cursor + 2 <= end)
     {
-        UBYTE dlen = cursor[0];
-        UBYTE dtype = cursor[1];
+        u8 dlen = cursor[0];
+        u8 dtype = cursor[1];
         if (dlen == 0)
         {
             Kprintf("zero length descriptor, aborting\n");
@@ -765,7 +765,7 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
         }
         if (cursor + dlen > end)
         {
-            Kprintf("descriptor overruns buffer (type=%ld len=%ld)\n", (LONG)dtype, (LONG)dlen);
+            Kprintf("descriptor overruns buffer (type=%lu len=%lu)\n", (ULONG)dtype, (ULONG)dlen);
             break;
         }
 
@@ -774,10 +774,10 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
         case USB_DT_INTERFACE:
         {
             struct usb_interface_descriptor *ifd = (struct usb_interface_descriptor *)cursor;
-            unsigned int iface_number = ifd->bInterfaceNumber;
+            u32 iface_number = ifd->bInterfaceNumber;
             if (iface_number >= USB_MAXINTERFACES)
             {
-                Kprintf("interface number %ld exceeds max %ld\n", (LONG)iface_number, (LONG)USB_MAXINTERFACES);
+                Kprintf("interface number %lu exceeds max %lu\n", (ULONG)iface_number, (ULONG)USB_MAXINTERFACES);
                 current_if = NULL;
                 current_alt = NULL;
                 current_alt_index = -1;
@@ -790,7 +790,7 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
                 if_index = conf->no_of_if;
                 if (if_index >= USB_MAXINTERFACES)
                 {
-                    Kprintf("too many unique interfaces (%ld)\n", (LONG)if_index);
+                    Kprintf("too many unique interfaces (%lu)\n", (ULONG)if_index);
                     goto error;
                 }
                 interface_map[iface_number] = if_index;
@@ -810,8 +810,8 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
 
             if (current_if->num_altsetting >= USB_ALTSETTINGALLOC)
             {
-                Kprintf("too many alternate settings (%ld) for interface %ld\n",
-                        (LONG)current_if->num_altsetting, (LONG)iface_number);
+                Kprintf("too many alternate settings (%lu) for interface %lu\n",
+                        (ULONG)current_if->num_altsetting, (ULONG)iface_number);
                 current_alt = NULL;
                 current_alt_index = -1;
                 break;
@@ -824,16 +824,16 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
             CopyMem(ifd, &current_alt->desc, sizeof(struct usb_interface_descriptor));
             current_alt->no_of_ep = 0;
 
-            KprintfH("interface %ld alt %ld: bInterfaceNumber=%ld bAlternateSetting=%ld bNumEndpoints=%ld bInterfaceClass=0x%02lx bInterfaceSubClass=0x%02lx bInterfaceProtocol=0x%02lx iInterface=%ld\n",
-                     (LONG)if_index,
-                     (LONG)current_alt_index,
-                     (LONG)ifd->bInterfaceNumber,
-                     (LONG)ifd->bAlternateSetting,
-                     (LONG)ifd->bNumEndpoints,
-                     (LONG)ifd->bInterfaceClass,
-                     (LONG)ifd->bInterfaceSubClass,
-                     (LONG)ifd->bInterfaceProtocol,
-                     (LONG)ifd->iInterface);
+            KprintfH("interface %lu alt %lu: bInterfaceNumber=%lu bAlternateSetting=%lu bNumEndpoints=%lu bInterfaceClass=0x%02lx bInterfaceSubClass=0x%02lx bInterfaceProtocol=0x%02lx iInterface=%lu\n",
+                     (ULONG)if_index,
+                     (ULONG)current_alt_index,
+                     (ULONG)ifd->bInterfaceNumber,
+                     (ULONG)ifd->bAlternateSetting,
+                     (ULONG)ifd->bNumEndpoints,
+                     (ULONG)ifd->bInterfaceClass,
+                     (ULONG)ifd->bInterfaceSubClass,
+                     (ULONG)ifd->bInterfaceProtocol,
+                     (ULONG)ifd->iInterface);
 
             if (current_if->active_altsetting == NULL || current_alt->desc.bAlternateSetting == 0)
                 current_if->active_altsetting = current_alt;
@@ -848,20 +848,20 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
             }
             if (current_alt->no_of_ep >= USB_MAXENDPOINTS)
             {
-                Kprintf("too many endpoints for interface %ld alt %ld\n",
-                        (LONG)if_index, (LONG)current_alt_index);
+                Kprintf("too many endpoints for interface %lu alt %lu\n",
+                        (ULONG)if_index, (ULONG)current_alt_index);
                 break;
             }
 
             struct usb_endpoint_descriptor *epd = (struct usb_endpoint_descriptor *)cursor;
-            unsigned int ep_idx = current_alt->no_of_ep;
+            u32 ep_idx = current_alt->no_of_ep;
             CopyMem(epd, &current_alt->ep_desc[ep_idx], sizeof(struct usb_endpoint_descriptor));
-            KprintfH("  endpoint %ld: bEndpointAddress=0x%02lx bmAttributes=0x%02lx wMaxPacketSize=%ld bInterval=%ld\n",
-                     (LONG)ep_idx,
-                     (LONG)epd->bEndpointAddress,
-                     (LONG)epd->bmAttributes,
-                     (LONG)le16(epd->wMaxPacketSize),
-                     (LONG)epd->bInterval);
+            KprintfH("  endpoint %lu: bEndpointAddress=0x%02lx bmAttributes=0x%02lx wMaxPacketSize=%lu bInterval=%lu\n",
+                     (ULONG)ep_idx,
+                     (ULONG)epd->bEndpointAddress,
+                     (ULONG)epd->bmAttributes,
+                     (ULONG)le16(epd->wMaxPacketSize),
+                     (ULONG)epd->bInterval);
 
             current_alt->no_of_ep++;
             break;
@@ -872,25 +872,25 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
             if (current_if && current_alt && current_alt->no_of_ep > 0)
             {
                 struct usb_ss_ep_comp_descriptor *comp = (struct usb_ss_ep_comp_descriptor *)cursor;
-                unsigned int ep_slot = current_alt->no_of_ep - 1;
+                u32 ep_slot = (u32)(current_alt->no_of_ep - 1U);
                 CopyMem(comp, &current_alt->ss_ep_comp_desc[ep_slot], sizeof(struct usb_ss_ep_comp_descriptor));
             }
             break;
         }
         default:
             // Skip class- or vendor-specific descriptors gracefully.
-            KprintfH("found class/vendor-specific descriptor 0x%lx, len=%ld\n", (ULONG)dtype, (LONG)dlen);
+            KprintfH("found class/vendor-specific descriptor 0x%lx, len=%lu\n", (ULONG)dtype, (ULONG)dlen);
             break;
         }
 
         cursor += dlen;
     }
-    KprintfH("parsed config with %ld interfaces\n", (LONG)conf->no_of_if);
+    KprintfH("parsed config with %lu interfaces\n", (ULONG)conf->no_of_if);
 
     if (conf->no_of_if != desc->bNumInterfaces)
     {
-        Kprintf("interface count mismatch %ld != %ld\n",
-                (LONG)conf->no_of_if, (LONG)desc->bNumInterfaces);
+        Kprintf("interface count mismatch %lu != %lu\n",
+                (ULONG)conf->no_of_if, (ULONG)desc->bNumInterfaces);
         goto error;
     }
 
@@ -899,7 +899,7 @@ static void parse_config_descriptor(struct usb_device *udev, UBYTE *data, UWORD 
         struct usb_config *oldconf = (struct usb_config *)n;
         if (oldconf->desc.bConfigurationValue == conf->desc.bConfigurationValue)
         {
-            KprintfH("removing old config with value %ld\n", (LONG)oldconf->desc.bConfigurationValue);
+            KprintfH("removing old config with value %lu\n", (ULONG)oldconf->desc.bConfigurationValue);
             RemoveMinNode(n);
             pool_free(udev->controller->memoryPool, oldconf);
             break;
@@ -922,18 +922,18 @@ static void xhci_filter_ss_ep_companion_desc(struct USBIORequest *io)
     if (desc->bDescriptorType != USB_DT_CONFIG)
         return;
 
-    UWORD total_len = le16(desc->wTotalLength);
+    u16 total_len = le16(desc->wTotalLength);
     if (total_len > io->actual_length)
-        total_len = io->actual_length;
+        total_len = (u16)io->actual_length;
 
-    UBYTE *read = io->data_buffer + desc->bLength;
-    UBYTE *write = read;
-    UBYTE *end = io->data_buffer + total_len;
+    u8 *read = io->data_buffer + desc->bLength;
+    u8 *write = read;
+    u8 *end = io->data_buffer + total_len;
 
     while (read + 2 <= end)
     {
-        UBYTE dlen = read[0];
-        UBYTE dtype = read[1];
+        u8 dlen = read[0];
+        u8 dtype = read[1];
         if (dlen == 0 || read + dlen > end)
             break;
 
@@ -941,7 +941,7 @@ static void xhci_filter_ss_ep_companion_desc(struct USBIORequest *io)
         {
             if (write != read)
             {
-                for (UBYTE i = 0; i < dlen; ++i)
+                for (u8 i = 0; i < dlen; ++i)
                     write[i] = read[i];
             }
             write += dlen;
@@ -951,16 +951,16 @@ static void xhci_filter_ss_ep_companion_desc(struct USBIORequest *io)
     }
 
     if (write < end)
-        mem_zero(write, end - write);
+        mem_zero(write, (ULONG)(end - write));
 
-    UWORD new_total = (UWORD)(write - (UBYTE *)io->data_buffer);
+    u16 new_total = (u16)(write - (u8 *)io->data_buffer);
     if (new_total != total_len)
         desc->wTotalLength = le16(new_total);
 
     io->actual_length = new_total;
 }
 
-static BOOL xhci_udev_iface_has_active_rt_iso(struct usb_device *udev, unsigned int iface_number)
+static BOOL xhci_udev_iface_has_active_rt_iso(struct usb_device *udev, u8 iface_number)
 {
     if (!udev || !udev->active_config)
         return FALSE;
@@ -969,7 +969,7 @@ static BOOL xhci_udev_iface_has_active_rt_iso(struct usb_device *udev, unsigned 
     for (int i = 0; i < cfg->no_of_if; ++i)
     {
         struct usb_interface *iface = &cfg->if_desc[i];
-        if (iface->interface_number != (UBYTE)iface_number)
+        if (iface->interface_number != iface_number)
             continue;
 
         struct usb_interface_altsetting *alt = iface->active_altsetting;
@@ -978,7 +978,7 @@ static BOOL xhci_udev_iface_has_active_rt_iso(struct usb_device *udev, unsigned 
 
         for (int e = 0; e < alt->no_of_ep; ++e)
         {
-            int ep_index = xhci_address_to_ep_index(&alt->ep_desc[e]);
+            u8 ep_index = xhci_address_to_ep_index(&alt->ep_desc[e]);
 
             struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
             if (!ep_ctx)
@@ -1016,15 +1016,15 @@ static void xhci_udev_disconnect(struct usb_device *udev, BOOL recursive)
         }
     }
 
-    KprintfH("disconnect device addr=%ld slot=%ld port=%ld\n",
-             (LONG)udev->virtual_address,
-             (LONG)udev->slot_id,
-             (LONG)udev->parent_port);
+    KprintfH("disconnect device addr=%lu slot=%lu port=%lu\n",
+             (ULONG)udev->virtual_address,
+             (ULONG)udev->slot_id,
+             (ULONG)udev->parent_port);
 
     xhci_disable_slot(udev);
 }
 
-static enum usb_device_speed xhci_udev_speed_from_port_status(UWORD status)
+static enum usb_device_speed xhci_udev_speed_from_port_status(u16 status)
 {
     switch (status & USB_PORT_STAT_SPEED_MASK)
     {
@@ -1062,7 +1062,7 @@ static BOOL xhci_udev_ss_port_ready_for_attach(u16 status, enum usb_device_speed
            speed != USB_SPEED_UNKNOWN;
 }
 
-static struct usb_device *xhci_udev_find_child_on_port(struct usb_device *hub, unsigned int port)
+static struct usb_device *xhci_udev_find_child_on_port(struct usb_device *hub, u32 port)
 {
     if (!hub)
         return NULL;
@@ -1081,18 +1081,18 @@ static struct usb_device *xhci_udev_find_child_on_port(struct usb_device *hub, u
     return NULL;
 }
 
-static void xhci_udev_cache_ss_hub_descriptor(struct usb_device *udev, struct usb_hub_descriptor *hub, ULONG actual)
+static void xhci_udev_cache_ss_hub_descriptor(struct usb_device *udev, struct usb_hub_descriptor *hub, u32 actual)
 {
     if (!udev || !hub || actual < 4)
         return;
 
-    UBYTE len = hub->bLength;
+    u8 len = hub->bLength;
     if (len == 0 || len > actual)
-        len = (UBYTE)min(actual, (ULONG)sizeof(struct usb_hub_descriptor));
+        len = (u8)(actual < sizeof(struct usb_hub_descriptor) ? actual : sizeof(struct usb_hub_descriptor));
 
     CopyMem(hub, &udev->ss_hub_desc, len);
-    KprintfH("Cached SS hub descriptor for addr %ld with %ld ports\n",
-             (LONG)udev->virtual_address, (LONG)hub->bNbrPorts);
+    KprintfH("Cached SS hub descriptor for addr %lu with %lu ports\n",
+             (ULONG)udev->virtual_address, (ULONG)hub->bNbrPorts);
 }
 
 static void xhci_udev_set_ss_hub_depth(struct usb_device *udev)
@@ -1107,12 +1107,12 @@ static void xhci_udev_set_ss_hub_depth(struct usb_device *udev)
     if (udev->ss_hub_depth_set)
         return;
 
-    KprintfH("SS hub addr=%ld route=0x%lx -> SET_HUB_DEPTH depth=%ld\n",
-             (LONG)udev->virtual_address, (ULONG)udev->route, (LONG)udev->route_depth);
+    KprintfH("SS hub addr=%lu route=0x%lx -> SET_HUB_DEPTH depth=%lu\n",
+             (ULONG)udev->virtual_address, (ULONG)udev->route, (ULONG)udev->route_depth);
 
     xhci_udev_send_control_request(udev,
                                    0,
-                                   (UBYTE)(USB_DIR_OUT | USB_RT_HUB),
+                                   USB_DIR_OUT | USB_RT_HUB,
                                    USB_REQ_SET_HUB_DEPTH,
                                    udev->route_depth /* wValue */,
                                    0 /* wIndex */,
@@ -1122,7 +1122,7 @@ static void xhci_udev_set_ss_hub_depth(struct usb_device *udev)
     udev->ss_hub_depth_set = TRUE;
 }
 
-static ULONG xhci_udev_build_usb2_hub_descriptor(struct usb_device *udev, UBYTE *buf, const ULONG max_len)
+static u32 xhci_udev_build_usb2_hub_descriptor(struct usb_device *udev, u8 *buf, const u32 max_len)
 {
     if (!udev || !buf || max_len == 0)
         return 0;
@@ -1130,10 +1130,11 @@ static ULONG xhci_udev_build_usb2_hub_descriptor(struct usb_device *udev, UBYTE 
     struct usb_hub_descriptor hub;
     mem_zero(&hub, sizeof(hub));
 
-    const UBYTE ports = udev->hub_num_ports;
-    const UBYTE needed = min((ports + 1U + 7U) / 8U, sizeof(hub.u.hs.DeviceRemovable));
+    const u8 ports = udev->hub_num_ports;
+    u32 needed_words = ((u32)ports + 1U + 7U) / 8U;
+    const u8 needed = (u8)(needed_words < sizeof(hub.u.hs.DeviceRemovable) ? needed_words : sizeof(hub.u.hs.DeviceRemovable));
 
-    hub.bLength = (UBYTE)(7U + 2U * needed);
+    hub.bLength = (u8)(7U + 2U * needed);
     hub.bDescriptorType = USB_DT_HUB;
     hub.bNbrPorts = ports;
 
@@ -1141,10 +1142,10 @@ static ULONG xhci_udev_build_usb2_hub_descriptor(struct usb_device *udev, UBYTE 
     hub.bPwrOn2PwrGood = udev->ss_hub_desc.bPwrOn2PwrGood;
     hub.bHubContrCurrent = udev->ss_hub_desc.bHubContrCurrent;
 
-    for (UBYTE i = 0; i < needed; ++i)
+    for (u8 i = 0; i < needed; ++i)
         hub.u.hs.PortPowerCtrlMask[i] = 0xFF;
 
-    ULONG actual = min(max_len, (ULONG)hub.bLength);
+    u32 actual = max_len < hub.bLength ? max_len : hub.bLength;
     CopyMem(&hub, buf, actual);
     return actual;
 }
@@ -1157,8 +1158,8 @@ static void xhci_udev_translate_hub_descriptor_request(struct usb_device *udev, 
         return;
 
     struct USBSetupPacket *setup = &io->setup;
-    const u8 descriptorType = (le16(setup->wValue) >> 8) & 0xFF;
-    const u16 typeReq = setup->bRequest | setup->bmRequestType << 8;
+    const u8 descriptorType = (le16(setup->wValue) >> 8) & 0xFFU;
+    const u16 typeReq = (u16)(((u16)setup->bmRequestType << 8) | setup->bRequest);
 
     /* Only translate GetHubDescriptor requests for USB_DT_HUB */
     if (typeReq != GetHubDescriptor || descriptorType != USB_DT_HUB)
@@ -1168,8 +1169,8 @@ static void xhci_udev_translate_hub_descriptor_request(struct usb_device *udev, 
     u16 old_value = le16(setup->wValue);
     setup->wValue = le16((USB_DT_SS_HUB << 8) | (old_value & 0xFF));
 
-    KprintfH("SS hub addr=%ld: modified wValue from 0x%04lx (USB_DT_HUB) to 0x%04lx (USB_DT_SS_HUB)\n",
-             (LONG)udev->virtual_address, (ULONG)old_value, (ULONG)le16(setup->wValue));
+    KprintfH("SS hub addr=%lu: modified wValue from 0x%04lx (USB_DT_HUB) to 0x%04lx (USB_DT_SS_HUB)\n",
+             (ULONG)udev->virtual_address, (ULONG)old_value, (ULONG)le16(setup->wValue));
 
     /* Return FALSE to let the request proceed normally - it will be translated back in parse */
     return;
@@ -1231,21 +1232,21 @@ static void handle_get_device_descriptor(struct usb_device *udev, struct USBIORe
         return;
 
     struct usb_device_descriptor *dev_desc = (struct usb_device_descriptor *)io->data_buffer;
-    KprintfH("Device Descriptor: bLength=%ld bDescriptorType=%ld bcdUSB=0x%04lx bDeviceClass=0x%02lx bDeviceSubClass=0x%02lx bDeviceProtocol=0x%02lx bMaxPacketSize0=%ld idVendor=0x%04lx idProduct=0x%04lx bcdDevice=0x%04lx iManufacturer=%ld iProduct=%ld iSerialNumber=%ld bNumConfigurations=%ld\n",
-             (LONG)dev_desc->bLength,
-             (LONG)dev_desc->bDescriptorType,
+    KprintfH("Device Descriptor: bLength=%lu bDescriptorType=%lu bcdUSB=0x%04lx bDeviceClass=0x%02lx bDeviceSubClass=0x%02lx bDeviceProtocol=0x%02lx bMaxPacketSize0=%lu idVendor=0x%04lx idProduct=0x%04lx bcdDevice=0x%04lx iManufacturer=%lu iProduct=%lu iSerialNumber=%lu bNumConfigurations=%lu\n",
+             (ULONG)dev_desc->bLength,
+             (ULONG)dev_desc->bDescriptorType,
              (ULONG)le16(dev_desc->bcdUSB),
-             (LONG)dev_desc->bDeviceClass,
-             (LONG)dev_desc->bDeviceSubClass,
-             (LONG)dev_desc->bDeviceProtocol,
-             (LONG)dev_desc->bMaxPacketSize0,
+             (ULONG)dev_desc->bDeviceClass,
+             (ULONG)dev_desc->bDeviceSubClass,
+             (ULONG)dev_desc->bDeviceProtocol,
+             (ULONG)dev_desc->bMaxPacketSize0,
              (ULONG)le16(dev_desc->idVendor),
              (ULONG)le16(dev_desc->idProduct),
              (ULONG)le16(dev_desc->bcdDevice),
-             (LONG)dev_desc->iManufacturer,
-             (LONG)dev_desc->iProduct,
-             (LONG)dev_desc->iSerialNumber,
-             (LONG)dev_desc->bNumConfigurations);
+             (ULONG)dev_desc->iManufacturer,
+             (ULONG)dev_desc->iProduct,
+             (ULONG)dev_desc->iSerialNumber,
+             (ULONG)dev_desc->bNumConfigurations);
 
     // For full speed devices, max packet size may change once we read the device descriptor
     if (udev->speed == USB_SPEED_FULL)
@@ -1253,7 +1254,7 @@ static void handle_get_device_descriptor(struct usb_device *udev, struct USBIORe
 
     if (udev->speed == USB_SPEED_SUPER && dev_desc->bMaxPacketSize0 != 64)
     {
-        KprintfH("clamping SS bMaxPacketSize0 from %ld to 64\n", (LONG)dev_desc->bMaxPacketSize0);
+        KprintfH("clamping SS bMaxPacketSize0 from %lu to 64\n", (ULONG)dev_desc->bMaxPacketSize0);
         dev_desc->bMaxPacketSize0 = 64;
     }
 
@@ -1262,14 +1263,14 @@ static void handle_get_device_descriptor(struct usb_device *udev, struct USBIORe
 
     if (dev_desc->bDeviceClass == USB_CLASS_HUB && (!udev->is_hub || !udev->ss_hub_emulation))
     {
-        KprintfH("Device at addr=%ld is a hub\n", (LONG)udev->virtual_address);
+        KprintfH("Device at addr=%lu is a hub\n", (ULONG)udev->virtual_address);
         udev->is_hub = TRUE;
 
         /* Only enable SS hub emulation for real external hubs, not the virtual root hub.
          * Root hub (parent == NULL) already provides port status in USB 2.0 format. */
         if (udev->speed >= USB_SPEED_SUPER && !udev->ss_hub_emulation)
         {
-            KprintfH("Detected USB 3.0 hub at addr=%ld, enabling translation mode\n", (LONG)udev->virtual_address);
+            KprintfH("Detected USB 3.0 hub at addr=%lu, enabling translation mode\n", (ULONG)udev->virtual_address);
             udev->ss_hub_emulation = TRUE;
         }
     }
@@ -1281,21 +1282,21 @@ static void handle_get_hub_descriptor(struct usb_device *udev, struct USBIOReque
         return;
 
     struct usb_hub_descriptor *hub = (struct usb_hub_descriptor *)io->data_buffer;
-    KprintfH("Hub Descriptor: bLength=%ld bDescriptorType=%ld bNbrPorts=%ld wHubCharacteristics=0x%04lx bPwrOn2PwrGood=%ld bHubContrCurrent=%ld\n",
-             (LONG)hub->bLength,
-             (LONG)hub->bDescriptorType,
-             (LONG)hub->bNbrPorts,
+    KprintfH("Hub Descriptor: bLength=%lu bDescriptorType=%lu bNbrPorts=%lu wHubCharacteristics=0x%04lx bPwrOn2PwrGood=%lu bHubContrCurrent=%lu\n",
+             (ULONG)hub->bLength,
+             (ULONG)hub->bDescriptorType,
+             (ULONG)hub->bNbrPorts,
              (ULONG)le16(hub->wHubCharacteristics),
-             (LONG)hub->bPwrOn2PwrGood,
-             (LONG)hub->bHubContrCurrent);
+             (ULONG)hub->bPwrOn2PwrGood,
+             (ULONG)hub->bHubContrCurrent);
 
     /* Update TT think time if changed */
     if (udev->parent)
     {
-        const UWORD characteristics = le16(hub->wHubCharacteristics);
+        const u16 characteristics = le16(hub->wHubCharacteristics);
         udev->tt_think_time = (u8)((characteristics >> 5) & 0x3);
-        KprintfH("hub addr %ld TT think time code=%ld (bit-times=%ld)\n",
-                 (LONG)udev->virtual_address, (LONG)udev->tt_think_time, (LONG)((udev->tt_think_time + 1) * 8));
+        KprintfH("hub addr %lu TT think time code=%lu (bit-times=%lu)\n",
+                 (ULONG)udev->virtual_address, (ULONG)udev->tt_think_time, (ULONG)((udev->tt_think_time + 1) * 8));
     }
 
     udev->hub_num_ports = hub->bNbrPorts;
@@ -1303,7 +1304,7 @@ static void handle_get_hub_descriptor(struct usb_device *udev, struct USBIOReque
     /* If this is an SS hub descriptor response, cache it */
     if (descriptorType == USB_DT_SS_HUB)
     {
-        KprintfH("SS hub addr=%ld: caching USB3 hub descriptor (len=%ld)\n", (LONG)udev->virtual_address, (LONG)io->actual_length);
+        KprintfH("SS hub addr=%lu: caching USB3 hub descriptor (len=%lu)\n", (ULONG)udev->virtual_address, (ULONG)io->actual_length);
         xhci_udev_cache_ss_hub_descriptor(udev, hub, io->actual_length);
         xhci_udev_set_ss_hub_depth(udev);
 
@@ -1311,8 +1312,8 @@ static void handle_get_hub_descriptor(struct usb_device *udev, struct USBIOReque
         if (udev->ss_hub_emulation)
         {
             /* Build USB 2.0 descriptor from the SS descriptor we just cached */
-            io->actual_length = xhci_udev_build_usb2_hub_descriptor(udev, (UBYTE *)io->data_buffer, io->data_buffer_length);
-            KprintfH("SS hub addr=%ld: translated USB3 descriptor to USB2 format. Size %ld bytes\n", (LONG)udev->virtual_address, (LONG)io->actual_length);
+            io->actual_length = xhci_udev_build_usb2_hub_descriptor(udev, (u8 *)io->data_buffer, io->data_buffer_length);
+            KprintfH("SS hub addr=%lu: translated USB3 descriptor to USB2 format. Size %lu bytes\n", (ULONG)udev->virtual_address, (ULONG)io->actual_length);
         }
     }
 }
@@ -1326,8 +1327,8 @@ static void xhci_trim_string_descriptor(struct USBIORequest *io)
     if (str_desc->bDescriptorType != USB_DT_STRING || io->actual_length < str_desc->bLength || str_desc->bLength < 2)
         return;
 
-    const u8 length = str_desc->bLength - 2;
-    for (u8 i = 0; i < length; i += 2)
+    const u32 length = str_desc->bLength - 2U;
+    for (u32 i = 0; i < length; i += 2U)
     {
         if (str_desc->bString[i] == 0 && str_desc->bString[i + 1] == 0)
             str_desc->bString[i] = 0x20; // replace embedded nulls with space
@@ -1352,7 +1353,7 @@ static void xhci_append_ss_suffix(struct usb_device *udev, struct USBIORequest *
     if (str_desc->bLength > io->actual_length)
     {
         // the descriptor is actually larger than the buffer used to receive it, just mock the length
-        str_desc->bLength += suffix_len;
+        str_desc->bLength = (__le8)(str_desc->bLength + (u8)suffix_len);
         return;
     }
 
@@ -1364,8 +1365,8 @@ static void xhci_append_ss_suffix(struct usb_device *udev, struct USBIORequest *
     for (int i = 0; i < suffix_len && length + i + 2 < (int)io->data_buffer_length; ++i)
         str_desc->bString[length + i] = (u8)suffix[i];
 
-    str_desc->bLength += suffix_len;
-    io->actual_length = min(str_desc->bLength, io->data_buffer_length);
+    str_desc->bLength = (u8)(str_desc->bLength + (u8)suffix_len);
+    io->actual_length = (u32)str_desc->bLength < io->data_buffer_length ? (u32)str_desc->bLength : io->data_buffer_length;
 }
 
 static void handle_get_port_status(struct usb_device *udev, struct USBIORequest *io)
@@ -1376,7 +1377,7 @@ static void handle_get_port_status(struct usb_device *udev, struct USBIORequest 
     struct xhci_ctrl *ctrl = udev->controller;
     if (!ctrl)
         return;
-    const u16 port = le16(io->setup.wIndex);
+    const u8 port = le16(io->setup.wIndex) & 0xFFu;
 
     u16 wStatus = le16(((u16 *)io->data_buffer)[0]);
     u16 wChange = le16(((u16 *)io->data_buffer)[1]);
@@ -1392,7 +1393,7 @@ static void handle_get_port_status(struct usb_device *udev, struct USBIORequest 
         ((u16 *)io->data_buffer)[1] = le16(wChange);
     }
 
-    KprintfH("hub addr=%ld port=%ld status=%04lx change=%04lx\n", (LONG)udev->virtual_address, (LONG)port, (ULONG)wStatus, (ULONG)wChange);
+    KprintfH("hub addr=%lu port=%lu status=%04lx change=%04lx\n", (ULONG)udev->virtual_address, (ULONG)port, (ULONG)wStatus, (ULONG)wChange);
 
     /* Tear down any existing child as soon as the port is powered-but-disabled,
      * otherwise re-enumeration races the stale slot/context we still own. */
@@ -1404,13 +1405,13 @@ static void handle_get_port_status(struct usb_device *udev, struct USBIORequest 
 
     if (port_lost_child)
     {
-        KprintfH("hub addr=%ld port=%ld lost power, disconnected, or disabled; removing child if any\n",
-                 (LONG)udev->virtual_address, (LONG)port);
+        KprintfH("hub addr=%lu port=%lu lost power, disconnected, or disabled; removing child if any\n",
+                 (ULONG)udev->virtual_address, (ULONG)port);
         struct usb_device *child = xhci_udev_find_child_on_port(udev, port);
         if (child)
         {
-            KprintfH("hub addr=%ld port=%ld tearing down child addr=%ld slot=%ld before re-enumeration\n",
-                     (LONG)udev->virtual_address, (LONG)port, (LONG)child->virtual_address, (LONG)child->slot_id);
+            KprintfH("hub addr=%lu port=%lu tearing down child addr=%lu slot=%lu before re-enumeration\n",
+                     (ULONG)udev->virtual_address, (ULONG)port, (ULONG)child->virtual_address, (ULONG)child->slot_id);
             xhci_udev_disconnect(child, TRUE);
         }
     }
@@ -1427,8 +1428,8 @@ static void handle_get_port_status(struct usb_device *udev, struct USBIORequest 
                           USB_SS_PORT_STAT_C_BH_RESET |
                           USB_SS_PORT_STAT_C_LINK_STATE)))
         {
-            KprintfH("hub addr=%ld port=%ld speed=%ld SS attach ready; remembering for pending attach (raw_status=%04lx)\n",
-                     (LONG)udev->virtual_address, (LONG)port, (LONG)speed, (ULONG)rawStatus);
+            KprintfH("hub addr=%lu port=%lu speed=%lu SS attach ready; remembering for pending attach (raw_status=%04lx)\n",
+                     (ULONG)udev->virtual_address, (ULONG)port, (ULONG)speed, (ULONG)rawStatus);
             ctrl->pending_parent = udev;
             ctrl->pending_parent_port = port;
             ctrl->pending_parent_speed = speed;
@@ -1437,8 +1438,8 @@ static void handle_get_port_status(struct usb_device *udev, struct USBIORequest 
     /* USB 2.0 enables device after reset completes */
     else if ((wChange & USB_PORT_STAT_C_RESET) && (wStatus & (USB_PORT_STAT_CONNECTION | USB_PORT_STAT_ENABLE)))
     {
-        KprintfH("hub addr=%ld port=%ld speed=%ld reset-complete; remembering for pending attach (status=%04lx)\n",
-                 (LONG)udev->virtual_address, (LONG)port, (LONG)speed, (ULONG)wStatus);
+        KprintfH("hub addr=%lu port=%lu speed=%lu reset-complete; remembering for pending attach (status=%04lx)\n",
+                 (ULONG)udev->virtual_address, (ULONG)port, (ULONG)speed, (ULONG)wStatus);
         ctrl->pending_parent = udev;
         ctrl->pending_parent_port = port;
         ctrl->pending_parent_speed = speed;
@@ -1447,8 +1448,8 @@ static void handle_get_port_status(struct usb_device *udev, struct USBIORequest 
 
 static void handle_set_address(struct usb_device *udev, struct USBIORequest *io)
 {
-    UWORD old_addr = io->virtual_address & 0x7F;
-    UWORD new_addr = (UWORD)(le16(io->setup.wValue) & 0x7F);
+    u16 old_addr = io->virtual_address & 0x7F;
+    u16 new_addr = le16(io->setup.wValue) & 0x7F;
     if (new_addr == old_addr)
         return;
 
@@ -1462,7 +1463,7 @@ static void handle_set_address(struct usb_device *udev, struct USBIORequest *io)
 
     if (ctrl->devices_by_virtual_address[new_addr] && ctrl->devices_by_virtual_address[new_addr] != current)
     {
-        Kprintf("overwriting existing ctx for addr %ld\n", (LONG)new_addr);
+        Kprintf("overwriting existing ctx for addr %lu\n", (ULONG)new_addr);
         /* If we are replacing an existing device (e.g., hub power-cycle), disconnect it (and children) first. */
         xhci_udev_disconnect(ctrl->devices_by_virtual_address[new_addr], TRUE);
     }
@@ -1473,13 +1474,13 @@ static void handle_set_address(struct usb_device *udev, struct USBIORequest *io)
 
     current->virtual_address = new_addr;
 
-    KprintfH("migrated ctx from addr %ld to %ld\n", (LONG)old_addr, (LONG)new_addr);
+    KprintfH("migrated ctx from addr %lu to %lu\n", (ULONG)old_addr, (ULONG)new_addr);
 }
 
 static void handle_set_interface(struct usb_device *udev, struct USBIORequest *io)
 {
-    unsigned int iface = (unsigned int)(le16(io->setup.wIndex) & 0xFF);
-    unsigned int alt = (unsigned int)(le16(io->setup.wValue) & 0xFF);
+    u8 iface = le16(io->setup.wIndex) & 0xFFU;
+    u8 alt = le16(io->setup.wValue) & 0xFFU;
     /*
      * This is a workaround for Poseidon issue.
      * Poseidon issues SET_INTERFACE for all devices after connecting a new one.
@@ -1488,33 +1489,33 @@ static void handle_set_interface(struct usb_device *udev, struct USBIORequest *i
      */
     if (!xhci_udev_iface_has_active_rt_iso(udev, iface))
     {
-        int err = xhci_set_interface(udev, iface, alt);
+        s8 err = xhci_set_interface(udev, iface, alt);
         if (err != ERR_NO_ERROR)
         {
-            Kprintf("SET_INTERFACE iface=%ld alt=%ld failed err=%ld\n",
-                    (LONG)iface, (LONG)alt, (LONG)err);
+            Kprintf("SET_INTERFACE iface=%lu alt=%lu failed err=%ld\n",
+                    (ULONG)iface, (ULONG)alt, (LONG)err);
         }
     }
     else
     {
-        KprintfH("SET_INTERFACE iface=%ld alt=%ld ignored (RT ISO active)\n",
-                 (LONG)iface, (LONG)alt);
+        KprintfH("SET_INTERFACE iface=%lu alt=%lu ignored (RT ISO active)\n",
+                 (ULONG)iface, (ULONG)alt);
     }
 }
 
 static void xhci_udev_parse_control_message(struct usb_device *udev, struct USBIORequest *io)
 {
-    KprintfH("dev=%lx addr=%ld bmReqType=%02lx bReq=%02lx wValue=%04lx wIndex=%04lx wLength=%04lx actual=%ld\n",
+    KprintfH("dev=%lx addr=%lu bmReqType=%02lx bReq=%02lx wValue=%04lx wIndex=%04lx wLength=%04lx actual=%lu\n",
              (ULONG)udev, (ULONG)udev->virtual_address,
              (ULONG)io->setup.bmRequestType,
              (ULONG)io->setup.bRequest,
              le16(io->setup.wValue),
              le16(io->setup.wIndex),
              le16(io->setup.wLength),
-             (LONG)io->actual_length);
+             (ULONG)io->actual_length);
 
-    const u8 descriptorType = (le16(io->setup.wValue) >> 8) & 0xFF;
-    const u16 typeReq = io->setup.bRequest | io->setup.bmRequestType << 8;
+    const u8 descriptorType = (le16(io->setup.wValue) >> 8) & 0xFFU;
+    const u16 typeReq = (u16)(((u16)io->setup.bmRequestType << 8) | io->setup.bRequest);
 
     switch (typeReq)
     {
@@ -1525,7 +1526,7 @@ static void xhci_udev_parse_control_message(struct usb_device *udev, struct USBI
             /* If this was a successful GET_DESCRIPTOR(CONFIGURATION),
              * cache the configuration descriptor for later use.
              */
-            parse_config_descriptor(udev, (UBYTE *)io->data_buffer, (UWORD)io->actual_length);
+            parse_config_descriptor(udev, (u8 *)io->data_buffer, (u16)io->actual_length);
 
             /* USB 2.0 stacks  don't like seeing SS companion descriptors */
             xhci_filter_ss_ep_companion_desc(io);

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -304,7 +304,7 @@ static s32 xhci_reset(struct xhci_hcor *hcor)
 	u32 cmd;
 
 	/* Halting the Host first */
-	Kprintf("// Halt the HC: %lx\n", hcor);
+	KprintfH("// Halt the HC: %lx\n", hcor);
 	u32 state = mmio_read32(&hcor->or_usbsts) & STS_HALT;
 	if (!state)
 	{
@@ -320,7 +320,7 @@ static s32 xhci_reset(struct xhci_hcor *hcor)
 		return -EBUSY;
 	}
 
-	Kprintf("// Reset the HC\n");
+	KprintfH("// Reset the HC\n");
 	cmd = mmio_read32(&hcor->or_usbcmd);
 	cmd |= CMD_RESET_USB;
 	mmio_write32(cmd, &hcor->or_usbcmd);
@@ -512,7 +512,7 @@ static void xhci_lowlevel_stop(struct xhci_ctrl *ctrl)
 {
 	xhci_reset(ctrl->hcor);
 
-	Kprintf("// Disabling event ring interrupts\n");
+	KprintfH("// Disabling event ring interrupts\n");
 	u32 temp = mmio_read32(&ctrl->hcor->or_usbsts);
 	mmio_write32(temp & ~STS_EINT, &ctrl->hcor->or_usbsts);
 	temp = mmio_read32(&ctrl->ir_set->irq_pending);
@@ -524,7 +524,7 @@ static void xhci_lowlevel_stop(struct xhci_ctrl *ctrl)
 
 s32 xhci_register(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr, struct xhci_hcor *hcor)
 {
-	Kprintf("ctrl=%lx, hccr=%lx, hcor=%lx\n", ctrl, hccr, hcor);
+	KprintfH("ctrl=%lx, hccr=%lx, hcor=%lx\n", ctrl, hccr, hcor);
 
 	s32 ret = xhci_reset(hcor);
 	if (ret)
@@ -536,7 +536,7 @@ s32 xhci_register(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr, struct xhci_hc
 		ret = -ENOMEM;
 		goto err;
 	}
-	Kprintf("memory pool created: %lx\n", ctrl->memoryPool);
+	KprintfH("memory pool created: %lx\n", ctrl->memoryPool);
 
 	xhci_td_slab_init(ctrl);
 	slab_cache_init(&ctrl->trb_addr_slab, ctrl->memoryPool,

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -442,7 +442,7 @@ static void xhci_dump_caps(struct xhci_ctrl *ctrl)
 	if (HCC_SEC(reg))
 		Kprintf("Host controller supports Stopped EDTLA Capability\n");
 	if (HCC_CFC(reg))
-		Kprintf("Host controller supports Configure Frame ID Capability\n");
+		Kprintf("Host controller supports Contiguous Frame ID Capability\n");
 
 	reg = mmio_read32(&hccr->cr_hccparams2);
 	if (HCC_U3C(reg))
@@ -503,6 +503,9 @@ static s32 xhci_lowlevel_init(struct xhci_ctrl *ctrl)
 	Kprintf("USB XHCI %lx.%02lx\n", reg >> 8, reg & 0xff);
 	ctrl->hci_version = reg & 0xffffU;
 
+	u32 hccp1 = mmio_read32(&hccr->cr_hccparams1);
+	ctrl->cfc_supported = HCC_CFC(hccp1) ? TRUE : FALSE;
+	
 	xhci_dump_caps(ctrl);
 
 	return 0;

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -22,6 +22,7 @@
 #include <exec/memory.h>
 
 #include <debug.h>
+#include <emu_memory.h>
 #include <minlist.h>
 
 #include <xhci/xhci.h>

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0+
+// SPDX-License-Identifier: GPL-2.0-only
 /*
  * USB HOST XHCI Controller stack
  *

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -553,8 +553,6 @@ s32 xhci_register(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr, struct xhci_hc
 		XHCI_BOUNCE_LARGE_SIZE,     DMA_ALIGN_MIN, XHCI_BOUNCE_LARGE_CAP);
 	slab_cache_init(&ctrl->iso_clone_slab, ctrl->memoryPool,
 		sizeof(struct USBIORequest), DMA_ALIGN_MIN, XHCI_ISO_CLONE_CAP);
-	slab_cache_init(&ctrl->iso_in_staging_slab, ctrl->memoryPool,
-		XHCI_ISO_IN_STAGING_SIZE,   DMA_ALIGN_MIN, XHCI_ISO_IN_STAGING_CAP);
 
 	_NewMinList(&ctrl->pending_commands);
 
@@ -582,7 +580,6 @@ void xhci_deregister(struct xhci_ctrl *ctrl)
 
 	if (ctrl->memoryPool)
 	{
-		slab_cache_destroy(&ctrl->iso_in_staging_slab);
 		slab_cache_destroy(&ctrl->iso_clone_slab);
 		slab_cache_destroy(&ctrl->bounce_large);
 		slab_cache_destroy(&ctrl->bounce_med);

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -28,6 +28,7 @@
 #include <minlist.h>
 
 #include <xhci/xhci.h>
+#include <xhci/xhci-td.h>
 #include <xhci/xhci-root-hub.h>
 #include <xhci/xhci-udev.h>
 #include <xhci/xhci-ring.h>
@@ -523,6 +524,20 @@ s32 xhci_register(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr, struct xhci_hc
 	}
 	Kprintf("memory pool created: %lx\n", ctrl->memoryPool);
 
+	xhci_td_slab_init(ctrl);
+	slab_cache_init(&ctrl->trb_addr_slab, ctrl->memoryPool,
+		XHCI_TD_SMALL_TRBS * sizeof(dma_addr_t), DMA_ALIGN_MIN, 256);
+	slab_cache_init(&ctrl->bounce_small, ctrl->memoryPool,
+		XHCI_BOUNCE_SMALL_SIZE,     DMA_ALIGN_MIN, XHCI_BOUNCE_SMALL_CAP);
+	slab_cache_init(&ctrl->bounce_med, ctrl->memoryPool,
+		XHCI_BOUNCE_MED_SIZE,       DMA_ALIGN_MIN, XHCI_BOUNCE_MED_CAP);
+	slab_cache_init(&ctrl->bounce_large, ctrl->memoryPool,
+		XHCI_BOUNCE_LARGE_SIZE,     DMA_ALIGN_MIN, XHCI_BOUNCE_LARGE_CAP);
+	slab_cache_init(&ctrl->iso_clone_slab, ctrl->memoryPool,
+		sizeof(struct USBIORequest), DMA_ALIGN_MIN, XHCI_ISO_CLONE_CAP);
+	slab_cache_init(&ctrl->iso_in_staging_slab, ctrl->memoryPool,
+		XHCI_ISO_IN_STAGING_SIZE,   DMA_ALIGN_MIN, XHCI_ISO_IN_STAGING_CAP);
+
 	_NewMinList(&ctrl->pending_commands);
 
 	ctrl->hccr = hccr;
@@ -549,6 +564,13 @@ void xhci_deregister(struct xhci_ctrl *ctrl)
 
 	if (ctrl->memoryPool)
 	{
+		slab_cache_destroy(&ctrl->iso_in_staging_slab);
+		slab_cache_destroy(&ctrl->iso_clone_slab);
+		slab_cache_destroy(&ctrl->bounce_large);
+		slab_cache_destroy(&ctrl->bounce_med);
+		slab_cache_destroy(&ctrl->bounce_small);
+		slab_cache_destroy(&ctrl->trb_addr_slab);
+		xhci_td_slab_destroy(ctrl);
 		DeletePool(ctrl->memoryPool);
 		ctrl->memoryPool = NULL;
 	}

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -52,10 +52,10 @@
  * @param size	size of memory to be allocated
  * Return: allocates the memory and returns the aligned pointer
  */
-void *xhci_malloc(struct xhci_ctrl *ctrl, unsigned int size)
+void *xhci_malloc(struct xhci_ctrl *ctrl, u32 size)
 {
 	void *ptr;
-	ULONG cacheline_size = max(XHCI_ALIGNMENT, CACHELINE_SIZE);
+	u32 cacheline_size = (XHCI_ALIGNMENT > CACHELINE_SIZE) ? XHCI_ALIGNMENT : CACHELINE_SIZE;
 
 	ptr = dma_zalloc(ctrl->memoryPool, cacheline_size, ALIGN_UP(size, cacheline_size));
 	if (!ptr)
@@ -75,12 +75,12 @@ void *xhci_malloc(struct xhci_ctrl *ctrl, unsigned int size)
  * @ctrl	host controller data structure
  * Return:	-ENOMEM if buffer allocation fails, 0 on success
  */
-static int xhci_scratchpad_alloc(struct xhci_ctrl *ctrl)
+static s32 xhci_scratchpad_alloc(struct xhci_ctrl *ctrl)
 {
 	struct xhci_hccr *hccr = ctrl->hccr;
 	struct xhci_hcor *hcor = ctrl->hcor;
 
-	int num_sp = HCS_MAX_SCRATCHPAD(mmio_read32(&hccr->cr_hcsparams2));
+	u32 num_sp = HCS_MAX_SCRATCHPAD(mmio_read32(&hccr->cr_hcsparams2));
 	if (!num_sp)
 		return 0;
 
@@ -93,11 +93,11 @@ static int xhci_scratchpad_alloc(struct xhci_ctrl *ctrl)
 	if (!scratchpad->sp_array)
 		goto fail_sp2;
 
-	ctrl->dcbaa->dev_context_ptrs[0] = le64((dma_addr_t)scratchpad->sp_array);
+	ctrl->dcbaa->dev_context_ptrs[0] = le64(scratchpad->sp_array);
 	xhci_flush_cache(&ctrl->dcbaa->dev_context_ptrs[0], sizeof(ctrl->dcbaa->dev_context_ptrs[0]));
 
 	u32 page_size = mmio_read32(&hcor->or_pagesize) & 0xffff;
-	int i;
+	u32 i;
 	for (i = 0; i < 16; i++)
 	{
 		if ((0x1 & page_size) != 0)
@@ -110,7 +110,7 @@ static int xhci_scratchpad_alloc(struct xhci_ctrl *ctrl)
 		goto fail_sp3;
 	}
 
-	page_size = 1 << (i + 12);
+	page_size = (u32)1 << (i + 12);
 	void *buf = dma_zalloc(ctrl->memoryPool, page_size, num_sp * page_size);
 	if (!buf)
 		goto fail_sp3;
@@ -119,7 +119,7 @@ static int xhci_scratchpad_alloc(struct xhci_ctrl *ctrl)
 	scratchpad->scratchpad = buf;
 	for (i = 0; i < num_sp; i++)
 	{
-		scratchpad->sp_array[i] = le64((dma_addr_t)buf);
+		scratchpad->sp_array[i] = le64(scratchpad->scratchpad + (i * page_size));
 		buf += page_size;
 	}
 
@@ -165,7 +165,7 @@ static void xhci_scratchpad_free(struct xhci_ctrl *ctrl)
  * @param hcor	pointer to HOST Controller Operational Registers
  * Return: 0 if successful else -1 on failure
  */
-static int xhci_mem_init(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr,
+static s32 xhci_mem_init(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr,
 						 struct xhci_hcor *hcor)
 {
 	uint32_t val;
@@ -250,10 +250,10 @@ static void xhci_cleanup(struct xhci_ctrl *ctrl)
  * @param usec	time to wait till
  * Return: 0 if handshake is success else < 0 on failure
  */
-static int handshake(uint32_t volatile *ptr, uint32_t mask, uint32_t done, int usec)
+static s32 handshake(volatile u32 *ptr, u32 mask, u32 done, u32 usec)
 {
-	uint32_t result;
-	ULONG deadline = get_time() + usec;
+	u32 result;
+	u32 deadline = get_time() + usec;
 
 	for (;;)
 	{
@@ -275,7 +275,7 @@ static int handshake(uint32_t volatile *ptr, uint32_t mask, uint32_t done, int u
  * @param hcor	pointer to host controller operation registers
  * Return: status of the Handshake
  */
-static int xhci_start(struct xhci_hcor *hcor)
+static s32 xhci_start(struct xhci_hcor *hcor)
 {
 	Kprintf("Starting the controller\n");
 	u32 temp = mmio_read32(&hcor->or_usbcmd);
@@ -286,7 +286,7 @@ static int xhci_start(struct xhci_hcor *hcor)
 	 * Wait for the HCHalted Status bit to be 0 to indicate the host is
 	 * running.
 	 */
-	int ret = handshake(&hcor->or_usbsts, STS_HALT, 0, XHCI_MAX_HALT_USEC);
+	s32 ret = handshake(&hcor->or_usbsts, STS_HALT, 0, XHCI_MAX_HALT_USEC);
 	if (ret)
 		Kprintf("Host took too long to start, waited %lu microseconds.\n", XHCI_MAX_HALT_USEC);
 	return ret;
@@ -298,7 +298,7 @@ static int xhci_start(struct xhci_hcor *hcor)
  * @param hcor	pointer to host controller operation registers
  * Return: -EBUSY if XHCI Controller is not halted else status of handshake
  */
-static int xhci_reset(struct xhci_hcor *hcor)
+static s32 xhci_reset(struct xhci_hcor *hcor)
 {
 	u32 cmd;
 
@@ -312,7 +312,7 @@ static int xhci_reset(struct xhci_hcor *hcor)
 		mmio_write32(cmd, &hcor->or_usbcmd);
 	}
 
-	int ret = handshake(&hcor->or_usbsts, STS_HALT, STS_HALT, XHCI_MAX_HALT_USEC);
+	s32 ret = handshake(&hcor->or_usbsts, STS_HALT, STS_HALT, XHCI_MAX_HALT_USEC);
 	if (ret)
 	{
 		Kprintf("Host not halted after %lu microseconds.\n", XHCI_MAX_HALT_USEC);
@@ -388,7 +388,7 @@ u32 *xhci_find_next_capability(struct xhci_ctrl *ctrl, u32 cap_id, u32 *init_off
 	return NULL;
 }
 
-struct xhci_protocol_caps xhci_get_protocol_caps(u32* base_address)
+struct xhci_protocol_caps xhci_get_protocol_caps(u32 *base_address)
 {
 	struct xhci_protocol_caps caps = {0};
 	u32 cap00 = mmio_read32(base_address + 0);
@@ -413,7 +413,7 @@ struct xhci_protocol_caps xhci_get_protocol_caps(u32* base_address)
 		caps.max_hub_depth = XHCI_PROTOCOL_CAP_USB2_MHD(cap08);
 	}
 	caps.protocol_speed_id_count = XHCI_PROTOCOL_CAP_SPEED_ID_COUNT(cap08);
-	caps.protocol_slot_type |= XHCI_PROTOCOL_CAP_SLOT_TYPE(cap0c);
+	caps.protocol_slot_type = (u8)(caps.protocol_slot_type | XHCI_PROTOCOL_CAP_SLOT_TYPE(cap0c));
 
 	return caps;
 }
@@ -452,7 +452,7 @@ static void xhci_dump_caps(struct xhci_ctrl *ctrl)
 		Kprintf("Host controller supports Virtualization Based Trusted I/O Capability\n");
 }
 
-static int xhci_lowlevel_init(struct xhci_ctrl *ctrl)
+static s32 xhci_lowlevel_init(struct xhci_ctrl *ctrl)
 {
 	struct xhci_hccr *hccr = ctrl->hccr;
 	struct xhci_hcor *hcor = ctrl->hcor;
@@ -486,14 +486,14 @@ static int xhci_lowlevel_init(struct xhci_ctrl *ctrl)
 
 	u32 reg = HC_VERSION(mmio_read32(&hccr->cr_capbase));
 	Kprintf("USB XHCI %lx.%02lx\n", reg >> 8, reg & 0xff);
-	ctrl->hci_version = reg;
+	ctrl->hci_version = reg & 0xffffU;
 
 	xhci_dump_caps(ctrl);
 
 	return 0;
 }
 
-static int xhci_lowlevel_stop(struct xhci_ctrl *ctrl)
+static void xhci_lowlevel_stop(struct xhci_ctrl *ctrl)
 {
 	xhci_reset(ctrl->hcor);
 
@@ -505,15 +505,13 @@ static int xhci_lowlevel_stop(struct xhci_ctrl *ctrl)
 
 	xhci_roothub_destroy(ctrl->root_hub);
 	ctrl->root_hub = NULL;
-
-	return 0;
 }
 
-int xhci_register(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr, struct xhci_hcor *hcor)
+s32 xhci_register(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr, struct xhci_hcor *hcor)
 {
 	Kprintf("ctrl=%lx, hccr=%lx, hcor=%lx\n", ctrl, hccr, hcor);
 
-	int ret = xhci_reset(hcor);
+	s32 ret = xhci_reset(hcor);
 	if (ret)
 		goto err;
 
@@ -544,7 +542,7 @@ err:
 	return ret;
 }
 
-int xhci_deregister(struct xhci_ctrl *ctrl)
+void xhci_deregister(struct xhci_ctrl *ctrl)
 {
 	xhci_lowlevel_stop(ctrl);
 	xhci_cleanup(ctrl);
@@ -554,6 +552,4 @@ int xhci_deregister(struct xhci_ctrl *ctrl)
 		DeletePool(ctrl->memoryPool);
 		ctrl->memoryPool = NULL;
 	}
-
-	return 0;
 }

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -425,10 +425,24 @@ static void xhci_dump_caps(struct xhci_ctrl *ctrl)
 	u32 reg = mmio_read32(&hccr->cr_hccparams1);
 	if (HCC_64BIT_ADDR(reg))
 		Kprintf("Host controller supports 64-bit addressing\n");
+	if (HCC_BANDWIDTH_NEG(reg))
+		Kprintf("Host controller supports bandwidth negotiation\n");
 	if (HCC_64BYTE_CONTEXT(reg))
 		Kprintf("Host controller supports 64-byte context structures\n");
+	if (HCC_LIGHT_RESET(reg))
+		Kprintf("Host controller supports Light HC Reset Capability\n");
 	if (HCC_LTC(reg))
 		Kprintf("Host controller supports latency tolerance messaging\n");
+	if (HCC_NSS(reg))
+		Kprintf("Host controller does not support secondary Stream ID\n");
+	if (HCC_PAE(reg))
+		Kprintf("Host controller supports Parse All Event Data\n");
+	if (HCC_SPC(reg))
+		Kprintf("Host controller supports Stopped - Short Packet Capability\n");
+	if (HCC_SEC(reg))
+		Kprintf("Host controller supports Stopped EDTLA Capability\n");
+	if (HCC_CFC(reg))
+		Kprintf("Host controller supports Configure Frame ID Capability\n");
 
 	reg = mmio_read32(&hccr->cr_hccparams2);
 	if (HCC_U3C(reg))

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -207,9 +207,9 @@ static s32 xhci_mem_init(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr,
 	ctrl->ir_set = &ctrl->run_regs->ir_set[0];
 
 	ctrl->erst.entries = xhci_malloc(ctrl, sizeof(struct xhci_erst_entry) *
-											   ERST_NUM_SEGS);
+											   XHCI_INITIAL_SEGS_PER_EVENT_RING);
 	/* Event ring does not maintain link TRB */
-	ctrl->event_ring = xhci_ring_alloc(ctrl, ERST_NUM_SEGS, FALSE, TRUE, 0, 0);
+	ctrl->event_ring = xhci_ring_alloc(ctrl, XHCI_INITIAL_SEGS_PER_EVENT_RING, FALSE, TRUE, 0, 0);
 
 	xhci_ring_setup_erst(ctrl->event_ring, &ctrl->erst, ctrl->ir_set);
 
@@ -506,7 +506,7 @@ static s32 xhci_lowlevel_init(struct xhci_ctrl *ctrl)
 
 	u32 hccp1 = mmio_read32(&hccr->cr_hccparams1);
 	ctrl->cfc_supported = HCC_CFC(hccp1) ? TRUE : FALSE;
-	
+
 	xhci_dump_caps(ctrl);
 
 	return 0;
@@ -544,15 +544,15 @@ s32 xhci_register(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr, struct xhci_hc
 
 	xhci_td_slab_init(ctrl);
 	slab_cache_init(&ctrl->trb_addr_slab, ctrl->memoryPool,
-		XHCI_TD_SMALL_TRBS * sizeof(dma_addr_t), DMA_ALIGN_MIN, 256);
+					XHCI_TD_SMALL_TRBS * sizeof(dma_addr_t), DMA_ALIGN_MIN, 256);
 	slab_cache_init(&ctrl->bounce_small, ctrl->memoryPool,
-		XHCI_BOUNCE_SMALL_SIZE,     DMA_ALIGN_MIN, XHCI_BOUNCE_SMALL_CAP);
+					XHCI_BOUNCE_SMALL_SIZE, DMA_ALIGN_MIN, XHCI_BOUNCE_SMALL_CAP);
 	slab_cache_init(&ctrl->bounce_med, ctrl->memoryPool,
-		XHCI_BOUNCE_MED_SIZE,       DMA_ALIGN_MIN, XHCI_BOUNCE_MED_CAP);
+					XHCI_BOUNCE_MED_SIZE, DMA_ALIGN_MIN, XHCI_BOUNCE_MED_CAP);
 	slab_cache_init(&ctrl->bounce_large, ctrl->memoryPool,
-		XHCI_BOUNCE_LARGE_SIZE,     DMA_ALIGN_MIN, XHCI_BOUNCE_LARGE_CAP);
+					XHCI_BOUNCE_LARGE_SIZE, DMA_ALIGN_MIN, XHCI_BOUNCE_LARGE_CAP);
 	slab_cache_init(&ctrl->iso_clone_slab, ctrl->memoryPool,
-		sizeof(struct USBIORequest), DMA_ALIGN_MIN, XHCI_ISO_CLONE_CAP);
+					sizeof(struct USBIORequest), DMA_ALIGN_MIN, XHCI_ISO_CLONE_CAP);
 
 	_NewMinList(&ctrl->pending_commands);
 

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -27,6 +27,7 @@
 #include <timing.h>
 #include <minlist.h>
 
+#include <config.h>
 #include <xhci/xhci.h>
 #include <xhci/xhci-td.h>
 #include <xhci/xhci-root-hub.h>
@@ -496,7 +497,7 @@ static s32 xhci_lowlevel_init(struct xhci_ctrl *ctrl)
 	}
 
 	/* Zero'ing IRQ control register and IRQ pending register */
-	mmio_write32(0x0, &ctrl->ir_set->irq_control);
+	mmio_write32(IRQ_INTERVAL & ER_IRQ_INTERVAL_MASK, &ctrl->ir_set->irq_control);
 	mmio_write32(0x0, &ctrl->ir_set->irq_pending);
 
 	u32 reg = HC_VERSION(mmio_read32(&hccr->cr_capbase));

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -22,7 +22,9 @@
 #include <exec/memory.h>
 
 #include <debug.h>
-#include <emu_memory.h>
+#include <errors.h>
+#include <memory.h>
+#include <timing.h>
 #include <minlist.h>
 
 #include <xhci/xhci.h>
@@ -55,13 +57,12 @@ void *xhci_malloc(struct xhci_ctrl *ctrl, unsigned int size)
 	void *ptr;
 	ULONG cacheline_size = max(XHCI_ALIGNMENT, CACHELINE_SIZE);
 
-	ptr = memalign(ctrl->memoryPool, cacheline_size, ALIGN(size, cacheline_size));
+	ptr = dma_zalloc(ctrl->memoryPool, cacheline_size, ALIGN_UP(size, cacheline_size));
 	if (!ptr)
 	{
-		Kprintf("memalign failed for size %lu\n", (ULONG)size);
+		Kprintf("dma_zalloc failed for size %lu\n", (ULONG)size);
 		return NULL;
 	}
-	_memset(ptr, '\0', size);
 
 	xhci_flush_cache(ptr, size);
 
@@ -79,11 +80,11 @@ static int xhci_scratchpad_alloc(struct xhci_ctrl *ctrl)
 	struct xhci_hccr *hccr = ctrl->hccr;
 	struct xhci_hcor *hcor = ctrl->hcor;
 
-	int num_sp = HCS_MAX_SCRATCHPAD(readl(&hccr->cr_hcsparams2));
+	int num_sp = HCS_MAX_SCRATCHPAD(mmio_read32(&hccr->cr_hcsparams2));
 	if (!num_sp)
 		return 0;
 
-	struct xhci_scratchpad *scratchpad = AllocVecPooled(ctrl->memoryPool, sizeof(struct xhci_scratchpad));
+	struct xhci_scratchpad *scratchpad = pool_zalloc(ctrl->memoryPool, sizeof(struct xhci_scratchpad));
 	if (!scratchpad)
 		goto fail_sp;
 	ctrl->scratchpad = scratchpad;
@@ -92,10 +93,10 @@ static int xhci_scratchpad_alloc(struct xhci_ctrl *ctrl)
 	if (!scratchpad->sp_array)
 		goto fail_sp2;
 
-	ctrl->dcbaa->dev_context_ptrs[0] = LE64((dma_addr_t)scratchpad->sp_array);
+	ctrl->dcbaa->dev_context_ptrs[0] = le64((dma_addr_t)scratchpad->sp_array);
 	xhci_flush_cache(&ctrl->dcbaa->dev_context_ptrs[0], sizeof(ctrl->dcbaa->dev_context_ptrs[0]));
 
-	u32 page_size = readl(&hcor->or_pagesize) & 0xffff;
+	u32 page_size = mmio_read32(&hcor->or_pagesize) & 0xffff;
 	int i;
 	for (i = 0; i < 16; i++)
 	{
@@ -110,16 +111,15 @@ static int xhci_scratchpad_alloc(struct xhci_ctrl *ctrl)
 	}
 
 	page_size = 1 << (i + 12);
-	void *buf = memalign(ctrl->memoryPool, page_size, num_sp * page_size);
+	void *buf = dma_zalloc(ctrl->memoryPool, page_size, num_sp * page_size);
 	if (!buf)
 		goto fail_sp3;
-	_memset(buf, '\0', num_sp * page_size);
 	xhci_flush_cache(buf, num_sp * page_size);
 
 	scratchpad->scratchpad = buf;
 	for (i = 0; i < num_sp; i++)
 	{
-		scratchpad->sp_array[i] = LE64((dma_addr_t)buf);
+		scratchpad->sp_array[i] = le64((dma_addr_t)buf);
 		buf += page_size;
 	}
 
@@ -127,10 +127,10 @@ static int xhci_scratchpad_alloc(struct xhci_ctrl *ctrl)
 	return 0;
 
 fail_sp3:
-	memalign_free(ctrl->memoryPool, scratchpad->sp_array);
+	dma_free(ctrl->memoryPool, scratchpad->sp_array);
 
 fail_sp2:
-	FreeVecPooled(ctrl->memoryPool, scratchpad);
+	pool_free(ctrl->memoryPool, scratchpad);
 	ctrl->scratchpad = NULL;
 
 fail_sp:
@@ -150,9 +150,9 @@ static void xhci_scratchpad_free(struct xhci_ctrl *ctrl)
 
 	ctrl->dcbaa->dev_context_ptrs[0] = 0;
 
-	memalign_free(ctrl->memoryPool, ctrl->scratchpad->scratchpad);
-	memalign_free(ctrl->memoryPool, ctrl->scratchpad->sp_array);
-	FreeVecPooled(ctrl->memoryPool, ctrl->scratchpad);
+	dma_free(ctrl->memoryPool, ctrl->scratchpad->scratchpad);
+	dma_free(ctrl->memoryPool, ctrl->scratchpad->sp_array);
+	pool_free(ctrl->memoryPool, ctrl->scratchpad);
 	ctrl->scratchpad = NULL;
 }
 
@@ -192,12 +192,12 @@ static int xhci_mem_init(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr,
 	xhci_writeq(&hcor->or_crcr, val_64);
 
 	/* write the address of db register */
-	val = readl(&hccr->cr_dboff);
+	val = mmio_read32(&hccr->cr_dboff);
 	val &= DBOFF_MASK;
 	ctrl->dba = (struct xhci_doorbell_array *)((char *)hccr + val);
 
 	/* write the address of runtime register */
-	val = readl(&hccr->cr_rtsoff);
+	val = mmio_read32(&hccr->cr_rtsoff);
 	val &= RTSOFF_MASK;
 	ctrl->run_regs = (struct xhci_run_regs *)((char *)hccr + val);
 
@@ -219,7 +219,7 @@ static int xhci_mem_init(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr,
 	 * or some spurious Device Notification Events
 	 * might screw things here.
 	 */
-	writel(0x0, &hcor->or_dnctrl);
+	mmio_write32(0x0, &hcor->or_dnctrl);
 
 	return 0;
 }
@@ -235,9 +235,9 @@ static void xhci_cleanup(struct xhci_ctrl *ctrl)
 	xhci_ring_free(ctrl, ctrl->event_ring);
 	xhci_ring_free(ctrl, ctrl->cmd_ring);
 	xhci_scratchpad_free(ctrl);
-	memalign_free(ctrl->memoryPool, ctrl->erst.entries);
-	memalign_free(ctrl->memoryPool, ctrl->dcbaa);
-	_memset(ctrl, 0, sizeof(struct xhci_ctrl));
+	dma_free(ctrl->memoryPool, ctrl->erst.entries);
+	dma_free(ctrl->memoryPool, ctrl->dcbaa);
+	mem_zero(ctrl, sizeof(struct xhci_ctrl));
 }
 
 /**
@@ -253,13 +253,20 @@ static void xhci_cleanup(struct xhci_ctrl *ctrl)
 static int handshake(uint32_t volatile *ptr, uint32_t mask, uint32_t done, int usec)
 {
 	uint32_t result;
+	ULONG deadline = get_time() + usec;
 
-	// TODO fixed value ULONG_MAX
-	int ret = readx_poll_timeout(readl, ptr, result, (result & mask) == done || result == 0xffffffff, usec);
-	if (result == 0xffffffff) /* card removed */
-		return -ENODEV;
+	for (;;)
+	{
+		result = mmio_read32(ptr);
+		if ((result & mask) == done)
+			return 0;
+		if (result == 0xffffffff)
+			return -ENODEV;
+		if (usec && time_deadline_passed(get_time(), deadline))
+			break;
+	}
 
-	return ret;
+	return -ETIMEDOUT;
 }
 
 /**
@@ -271,9 +278,9 @@ static int handshake(uint32_t volatile *ptr, uint32_t mask, uint32_t done, int u
 static int xhci_start(struct xhci_hcor *hcor)
 {
 	Kprintf("Starting the controller\n");
-	u32 temp = readl(&hcor->or_usbcmd);
+	u32 temp = mmio_read32(&hcor->or_usbcmd);
 	temp |= (CMD_RUN);
-	writel(temp, &hcor->or_usbcmd);
+	mmio_write32(temp, &hcor->or_usbcmd);
 
 	/*
 	 * Wait for the HCHalted Status bit to be 0 to indicate the host is
@@ -297,12 +304,12 @@ static int xhci_reset(struct xhci_hcor *hcor)
 
 	/* Halting the Host first */
 	Kprintf("// Halt the HC: %lx\n", hcor);
-	u32 state = readl(&hcor->or_usbsts) & STS_HALT;
+	u32 state = mmio_read32(&hcor->or_usbsts) & STS_HALT;
 	if (!state)
 	{
-		cmd = readl(&hcor->or_usbcmd);
+		cmd = mmio_read32(&hcor->or_usbcmd);
 		cmd &= ~CMD_RUN;
-		writel(cmd, &hcor->or_usbcmd);
+		mmio_write32(cmd, &hcor->or_usbcmd);
 	}
 
 	int ret = handshake(&hcor->or_usbsts, STS_HALT, STS_HALT, XHCI_MAX_HALT_USEC);
@@ -313,9 +320,9 @@ static int xhci_reset(struct xhci_hcor *hcor)
 	}
 
 	Kprintf("// Reset the HC\n");
-	cmd = readl(&hcor->or_usbcmd);
+	cmd = mmio_read32(&hcor->or_usbcmd);
 	cmd |= CMD_RESET_USB;
-	writel(cmd, &hcor->or_usbcmd);
+	mmio_write32(cmd, &hcor->or_usbcmd);
 
 	ret = handshake(&hcor->or_usbcmd, CMD_RESET_USB, 0, XHCI_MAX_RESET_USEC);
 	if (ret)
@@ -356,13 +363,13 @@ u32 *xhci_find_next_capability(struct xhci_ctrl *ctrl, u32 cap_id, u32 *init_off
 		return NULL;
 
 	struct xhci_hccr *hccr = ctrl->hccr;
-	u32 hccParams = readl(&hccr->cr_hccparams1);
+	u32 hccParams = mmio_read32(&hccr->cr_hccparams1);
 
 	u32 current_offset = (*init_offset != 0) ? *init_offset : HCC_EXT_CAPS(hccParams) << 2;
 	while (current_offset != XHCI_EXT_CAPS_SEARCH_DONE)
 	{
 		u32 *current = (u32 *)((u8 *)hccr + current_offset);
-		u32 ext_cap = readl(current);
+		u32 ext_cap = mmio_read32(current);
 
 		u32 next_offset = current_offset + (XHCI_EXT_CAPS_NEXT(ext_cap) << 2);
 		if (next_offset == current_offset)
@@ -384,9 +391,9 @@ u32 *xhci_find_next_capability(struct xhci_ctrl *ctrl, u32 cap_id, u32 *init_off
 struct xhci_protocol_caps xhci_get_protocol_caps(u32* base_address)
 {
 	struct xhci_protocol_caps caps = {0};
-	u32 cap00 = readl(base_address + 0);
-	u32 cap08 = readl(base_address + 2);
-	u32 cap0c = readl(base_address + 3);
+	u32 cap00 = mmio_read32(base_address + 0);
+	u32 cap08 = mmio_read32(base_address + 2);
+	u32 cap0c = mmio_read32(base_address + 3);
 
 	caps.minor_revision = XHCI_PROTOCOL_CAP_MINOR_REV(cap00);
 	caps.major_revision = XHCI_PROTOCOL_CAP_MAJOR_REV(cap00);
@@ -414,7 +421,7 @@ struct xhci_protocol_caps xhci_get_protocol_caps(u32* base_address)
 static void xhci_dump_caps(struct xhci_ctrl *ctrl)
 {
 	struct xhci_hccr *hccr = ctrl->hccr;
-	u32 reg = readl(&hccr->cr_hccparams1);
+	u32 reg = mmio_read32(&hccr->cr_hccparams1);
 	if (HCC_64BIT_ADDR(reg))
 		Kprintf("Host controller supports 64-bit addressing\n");
 	if (HCC_64BYTE_CONTEXT(reg))
@@ -422,7 +429,7 @@ static void xhci_dump_caps(struct xhci_ctrl *ctrl)
 	if (HCC_LTC(reg))
 		Kprintf("Host controller supports latency tolerance messaging\n");
 
-	reg = readl(&hccr->cr_hccparams2);
+	reg = mmio_read32(&hccr->cr_hccparams2);
 	if (HCC_U3C(reg))
 		Kprintf("Host controller supports U3 Entry Capability\n");
 	if (HCC_CMC(reg))
@@ -453,10 +460,10 @@ static int xhci_lowlevel_init(struct xhci_ctrl *ctrl)
 	 * Program the Number of Device Slots Enabled field in the CONFIG
 	 * register with the max value of slots the HC can handle.
 	 */
-	u32 val = (readl(&hccr->cr_hcsparams1) & HCS_SLOTS_MASK);
-	u32 val2 = readl(&hcor->or_config);
+	u32 val = (mmio_read32(&hccr->cr_hcsparams1) & HCS_SLOTS_MASK);
+	u32 val2 = mmio_read32(&hcor->or_config);
 	val |= (val2 & ~HCS_SLOTS_MASK);
-	writel(val, &hcor->or_config);
+	mmio_write32(val, &hcor->or_config);
 
 	/* initializing xhci data structures */
 	if (xhci_mem_init(ctrl, hccr, hcor) < 0)
@@ -474,10 +481,10 @@ static int xhci_lowlevel_init(struct xhci_ctrl *ctrl)
 	}
 
 	/* Zero'ing IRQ control register and IRQ pending register */
-	writel(0x0, &ctrl->ir_set->irq_control);
-	writel(0x0, &ctrl->ir_set->irq_pending);
+	mmio_write32(0x0, &ctrl->ir_set->irq_control);
+	mmio_write32(0x0, &ctrl->ir_set->irq_pending);
 
-	u32 reg = HC_VERSION(readl(&hccr->cr_capbase));
+	u32 reg = HC_VERSION(mmio_read32(&hccr->cr_capbase));
 	Kprintf("USB XHCI %lx.%02lx\n", reg >> 8, reg & 0xff);
 	ctrl->hci_version = reg;
 
@@ -491,10 +498,10 @@ static int xhci_lowlevel_stop(struct xhci_ctrl *ctrl)
 	xhci_reset(ctrl->hcor);
 
 	Kprintf("// Disabling event ring interrupts\n");
-	u32 temp = readl(&ctrl->hcor->or_usbsts);
-	writel(temp & ~STS_EINT, &ctrl->hcor->or_usbsts);
-	temp = readl(&ctrl->ir_set->irq_pending);
-	writel(ER_IRQ_DISABLE(temp), &ctrl->ir_set->irq_pending);
+	u32 temp = mmio_read32(&ctrl->hcor->or_usbsts);
+	mmio_write32(temp & ~STS_EINT, &ctrl->hcor->or_usbsts);
+	temp = mmio_read32(&ctrl->ir_set->irq_pending);
+	mmio_write32(ER_IRQ_DISABLE(temp), &ctrl->ir_set->irq_pending);
 
 	xhci_roothub_destroy(ctrl->root_hub);
 	ctrl->root_hub = NULL;


### PR DESCRIPTION
This pull request introduces a significant update to the emu68-xhci-driver, focusing on improved build instructions, enhanced header and type safety, better library handling, and updated documentation for users and developers. The changes modernize the codebase, clarify the build and runtime requirements, and enforce stricter type correctness, especially for USB descriptor handling.

**Documentation and Build Process Updates:**

* Updated `README.md` and added `AGENTS.md` to clarify build dependencies, installation paths, and runtime requirements, especially the transition to using `bcmpcie.library` as a shared dynamic library for PCIe-based units. Build instructions now recommend CMake workflows and highlight the importance of correct library placement. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R68) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R216) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L222-R243) [[5]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R1-R29)
* The project version is bumped from 3.7 to 4.3, and CMake install paths are updated to place the driver binary in `DEVS/USBHardware/xhci.device`. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL2-R2) [[2]](diffhunk://#diff-088f87957cc3abbc2f31bec42719f6a7f03e645ee7258a4032a97f35e6138cf2L29-R72)

**Type Safety and Header Improvements:**

* USB descriptor structures and related macros now use explicit little-endian and fixed-width types (e.g., `__le8`, `__le16`, `u8`, `u16`, `u32`), and bit macros are used instead of raw shifts for flags, improving portability and correctness. [[1]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bR1-R2) [[2]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL36-R40) [[3]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL223-R241) [[4]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL279-R327) [[5]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL333-R348) [[6]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL372-R380) [[7]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL393-R397) [[8]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL507-R513) [[9]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL518-R530) [[10]](diffhunk://#diff-c0dbdaa4121bba261cd51e70c655ee0d2d0af171ab8b82441e35fb27773fd1e0R1-R18) [[11]](diffhunk://#diff-c0dbdaa4121bba261cd51e70c655ee0d2d0af171ab8b82441e35fb27773fd1e0L52-R55) [[12]](diffhunk://#diff-c0dbdaa4121bba261cd51e70c655ee0d2d0af171ab8b82441e35fb27773fd1e0L62-R71) [[13]](diffhunk://#diff-c0dbdaa4121bba261cd51e70c655ee0d2d0af171ab8b82441e35fb27773fd1e0L84-R90)
* Added SPDX license headers and updated existing ones to clarify GPL-2.0-only licensing throughout the codebase. [[1]](diffhunk://#diff-0dac1ae4541e9a2edb7b238afcdc52b7f9d6c69f320c4b63067f47a12038a55eR1-R2) [[2]](diffhunk://#diff-4d0cc0b9bf34e952093bec05b871d92b58e6f33fad69b4021ec4ff135256f8b2L1-R1) [[3]](diffhunk://#diff-c0dbdaa4121bba261cd51e70c655ee0d2d0af171ab8b82441e35fb27773fd1e0R1-R18) [[4]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bR1-R2)

**Device and Driver API Changes:**

* The `XHCIUnit` and `XHCIDevice` structures are expanded for better device/library tracking, and function signatures are updated for type correctness (e.g., using `s32`, `u32`, and pointer types). [[1]](diffhunk://#diff-4d0cc0b9bf34e952093bec05b871d92b58e6f33fad69b4021ec4ff135256f8b2R31) [[2]](diffhunk://#diff-4d0cc0b9bf34e952093bec05b871d92b58e6f33fad69b4021ec4ff135256f8b2L41-R74)
* The PCIe library is now opened lazily and supports fallback to `openpci.library` if `bcmpcie.library` is not found.

**CMake and Build System Enhancements:**

* The build scripts (`CMakeLists.txt`) now enforce stricter compile options and warnings, improving code quality and maintainability. Installation paths are clarified and aligned with documentation. [[1]](diffhunk://#diff-088f87957cc3abbc2f31bec42719f6a7f03e645ee7258a4032a97f35e6138cf2L4-R36) [[2]](diffhunk://#diff-088f87957cc3abbc2f31bec42719f6a7f03e645ee7258a4032a97f35e6138cf2L29-R72) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL16-L18)

**Summary of Most Important Changes**

**Documentation and Build Process**
- Updated documentation to clarify the build process, runtime dependencies (notably `bcmpcie.library`), and installation paths; added `AGENTS.md` for developer guidance. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R15-R18) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R68) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R216) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L222-R243) [[5]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R1-R29)
- Changed project version to 4.3 and updated CMake install paths for correct binary placement. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL2-R2) [[2]](diffhunk://#diff-088f87957cc3abbc2f31bec42719f6a7f03e645ee7258a4032a97f35e6138cf2L29-R72)

**Type Safety and Licensing**
- Refactored USB descriptor and device structures to use explicit little-endian and fixed-width types, and replaced shift-based flags with `BIT()` macros for clarity and correctness. [[1]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bR1-R2) [[2]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL36-R40) [[3]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL223-R241) [[4]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL279-R327) [[5]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL333-R348) [[6]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL372-R380) [[7]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL393-R397) [[8]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL507-R513) [[9]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bL518-R530) [[10]](diffhunk://#diff-c0dbdaa4121bba261cd51e70c655ee0d2d0af171ab8b82441e35fb27773fd1e0R1-R18) [[11]](diffhunk://#diff-c0dbdaa4121bba261cd51e70c655ee0d2d0af171ab8b82441e35fb27773fd1e0L52-R55) [[12]](diffhunk://#diff-c0dbdaa4121bba261cd51e70c655ee0d2d0af171ab8b82441e35fb27773fd1e0L62-R71) [[13]](diffhunk://#diff-c0dbdaa4121bba261cd51e70c655ee0d2d0af171ab8b82441e35fb27773fd1e0L84-R90)
- Added or updated SPDX license identifiers to clarify GPL-2.0-only licensing. [[1]](diffhunk://#diff-0dac1ae4541e9a2edb7b238afcdc52b7f9d6c69f320c4b63067f47a12038a55eR1-R2) [[2]](diffhunk://#diff-4d0cc0b9bf34e952093bec05b871d92b58e6f33fad69b4021ec4ff135256f8b2L1-R1) [[3]](diffhunk://#diff-c0dbdaa4121bba261cd51e70c655ee0d2d0af171ab8b82441e35fb27773fd1e0R1-R18) [[4]](diffhunk://#diff-f125c862dfcdfd9cd7a538e01ac2f29a98b0d72354e2132f95e1b358c87fae3bR1-R2)

**Device and Driver API**
- Improved `XHCIUnit` and `XHCIDevice` structures for better library and device tracking; updated function signatures for type safety. [[1]](diffhunk://#diff-4d0cc0b9bf34e952093bec05b871d92b58e6f33fad69b4021ec4ff135256f8b2R31) [[2]](diffhunk://#diff-4d0cc0b9bf34e952093bec05b871d92b58e6f33fad69b4021ec4ff135256f8b2L41-R74)
- Implemented lazy opening of the PCIe library with fallback logic.

**Build System**
- Enhanced CMake build scripts with stricter compile options and clarified installation targets. [[1]](diffhunk://#diff-088f87957cc3abbc2f31bec42719f6a7f03e645ee7258a4032a97f35e6138cf2L4-R36) [[2]](diffhunk://#diff-088f87957cc3abbc2f31bec42719f6a7f03e645ee7258a4032a97f35e6138cf2L29-R72) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL16-L18)