### PR TITLE
Provisional compatibility fix for AROS Poseidon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-xhci-driver VERSION 5.1)
+project(emu68-xhci-driver VERSION 5.2)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR} ${CURRENT_DATE}")

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,33 @@
+# Release notes — xhci.device 5.2
+
+Changes since v5.1.
+
+---
+
+## Compatibility
+
+### Returned device descriptors report USB 2.0 to match the presented speed
+
+`xhci.device` presents SuperSpeed devices to the USB stack as high-speed and
+handles the SuperSpeed specifics internally through its USB 3.0 ↔ USB 2.0
+translation layer.  The device descriptor returned to the stack now has its
+`bcdUSB` field clamped to `0x0210` whenever a device reports USB 3.0 or later
+(`bcdUSB >= 0x0300`), so the advertised USB revision is consistent with that
+high-speed presentation.
+
+This matters for USB 3.0-aware stacks: one that reads `bcdUSB` would otherwise
+see a SuperSpeed revision that contradicts the high-speed device it is handed,
+and could mis-handle it.  Clamping the field keeps the translation transparent
+to the stack above.
+
+---
+
+## Build & tooling
+
+* The explicit `<exec/execbase.h>` and `<minlist.h>` includes added in 5.1 for
+  older NDK headers have been dropped; the driver targets the NDK 3.2 headers.
+
+
 # Release notes — xhci.device 5.1
 
 Changes since v5.0.

--- a/xhci.device/include/xhci/xhci.h
+++ b/xhci.device/include/xhci/xhci.h
@@ -24,7 +24,6 @@
 #include <proto/exec.h>
 #endif
 
-#include <exec/execbase.h> /* DMA_ReadFromRAM for CachePreDMA(); older NDKs don't pull it in transitively */
 #include <bits.h>
 #include <iomem.h>
 #include <slab.h>

--- a/xhci.device/src/xhci/xhci-commands.c
+++ b/xhci.device/src/xhci/xhci-commands.c
@@ -15,7 +15,6 @@
 #include <xhci/xhci-udev.h>
 #include <xhci/xhci-ring.h>
 #include <devices/hcd_api.h>
-#include <minlist.h>
 
 #ifdef DEBUG
 #undef Kprintf

--- a/xhci.device/src/xhci/xhci-descriptors.c
+++ b/xhci.device/src/xhci/xhci-descriptors.c
@@ -13,7 +13,6 @@
 #include <xhci/xhci-context.h>
 
 #include <debug.h>
-#include <minlist.h>
 
 #ifdef DEBUG
 #undef Kprintf

--- a/xhci.device/src/xhci/xhci-udev.c
+++ b/xhci.device/src/xhci/xhci-udev.c
@@ -1124,8 +1124,8 @@ static void handle_get_device_descriptor(struct usb_device *udev, struct USBIORe
     if (le16(dev_desc->bcdUSB) >= 0x0300)
     {
         KprintfH("Device at addr=%lu is USB 3.0 capable, bcdUSB=0x%04lx\n", (ULONG)udev->virtual_address, (ULONG)le16(dev_desc->bcdUSB));
-        KprintfH("Clamping bcdUSB to 0x0200 for compatibility\n");
-        dev_desc->bcdUSB = le16(0x0200);
+        KprintfH("Clamping bcdUSB to 0x0210 for compatibility\n");
+        dev_desc->bcdUSB = le16(0x0210);
     }
 }
 

--- a/xhci.device/src/xhci/xhci-udev.c
+++ b/xhci.device/src/xhci/xhci-udev.c
@@ -1120,6 +1120,13 @@ static void handle_get_device_descriptor(struct usb_device *udev, struct USBIORe
             udev->ss_hub_emulation = TRUE;
         }
     }
+
+    if (le16(dev_desc->bcdUSB) >= 0x0300)
+    {
+        KprintfH("Device at addr=%lu is USB 3.0 capable, bcdUSB=0x%04lx\n", (ULONG)udev->virtual_address, (ULONG)le16(dev_desc->bcdUSB));
+        KprintfH("Clamping bcdUSB to 0x0200 for compatibility\n");
+        dev_desc->bcdUSB = le16(0x0200);
+    }
 }
 
 static void xhci_trim_string_descriptor(struct USBIORequest *io)


### PR DESCRIPTION
The Poseidon stack ported from AROS is USB3.0 capable.
For the time being, we keep our USB3.0<->USB2.0 translation layer in xhci.device, however it needs one small improvement so that the new Poseidon doesn't get confused.
bcdUSB field in device descriptors must be clamped.