### PR TITLE
Remove workarounds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14.0)
-project(emu68-xhci-driver VERSION 5.2)
+project(emu68-xhci-driver VERSION 5.3)
 
 string(TIMESTAMP CURRENT_DATE "(%d.%m.%Y)")
 set(VERSTRING "$VER: ${PROJECT_NAME} ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR} ${CURRENT_DATE}")

--- a/README.md
+++ b/README.md
@@ -5,50 +5,53 @@
 > `.lha` and bundled documentation are published there. This repository is source-only
 > and versioned via git tags.
 
-AmigaOS xHCI USB 2.0 / USB 3.0 host controller driver for [Emu68](https://github.com/michalsc/Emu68)
-on Raspberry Pi 4 (BCM2711).
+**xhci.device** is an AmigaOS USB 2.0 / USB 3.0 host controller driver for the xHCI
+controllers on the Raspberry Pi 4B and CM4, for use with PiStorm32-lite and
+[Emu68](https://github.com/michalsc/Emu68). The xHCI code is derived from
+[Das U-Boot](https://source.denx.de/u-boot/u-boot).
 
-The xHCI stack is derived from the [Das U-Boot](https://source.denx.de/u-boot/u-boot) xHCI driver.
-The driver exposes a Poseidon-compatible HCD API and is loaded as a standard AmigaOS `.device`.
-The API is not an exact match — certain fields passed by the stack are intentionally ignored
- in favour of the driver's own internal structures.
+> **Which line do you need?** `xhci.device` **5.x** — this line — is the compatibility
+> line: it speaks the classic Poseidon HCD ABI, so it drives **classic Poseidon 4.x** and
+> also works with **Poseidon for AmigaOS 6.x**, which keeps that ABI alongside its own.
+> On Poseidon 4.x this is your only option. On Poseidon 6.x prefer the driver's **6.x**
+> line — through this one, SuperSpeed devices still go through the USB 2.0 emulation and
+> run slower, whereas the 6.x line hands the stack real USB 3.0 devices and adds bulk
+> streams. It is maintained on the
+> [`context_release` branch](https://github.com/rondoval/emu68-xhci-driver/tree/context_release).
 
-> **Note for users upgrading from pre-3.x releases:** unit numbering has changed.
-> Unit 0 used to be the VL805 (PCIe).  It is now the onboard OTG port.
-> Unit 1 is now the VL805.  Update your USB stack configuration accordingly.
+> **Upgrading from an older release?** See the *Upgrade notes* at the top of
+> [RELEASE-NOTES.md](RELEASE-NOTES.md) — unit renumbering and the `bcmpcie.library`
+> requirement.
 
-> **Note for users upgrading from 3.x releases:** `bcmpcie.library` must be installed
-> in `LIBS:` for PCIe-based units (unit 1+, VL805 on Pi 4B) to work.
-> See release notes for the full change log from 3.7 to 4.4.
+## What you get
 
-> **Note for users upgrading from 4.4:** no configuration changes are required.
-> 5.0 adds USB 3.0 Link Power Management (U1/U2), USB 2.0 hardware LPM (L1),
-> Latency Tolerance Messaging and multi-TT hub support, and is more robust
-> across machine resets and SuperSpeed device bring-up.  See
-> `RELEASE-NOTES-5.0.md` for details.
+- **USB 3.0 devices on a USB 2.0 stack** — SuperSpeed devices, hubs and their
+  descriptors are translated to what classic Poseidon understands, so a USB 3.0 drive or
+  hub works on a stack that has no USB 3.0 support of its own. Devices are presented as
+  high-speed.
+- **All four transfer types** — control, bulk, interrupt and real-time isochronous, in
+  both directions, at low, full, high and SuperSpeed.
+- **Both of the Pi's USB paths** — the onboard OTG port and the PCIe VL805 (the four
+  USB-A ports on a Pi 4B), each as its own unit, each with its own driver task.
+- **Hub chains** — external USB 2.0 hubs including multi-TT, and USB 3.0 hubs through the
+  SuperSpeed hub emulation.
+- **Working devices** — keyboards, mice and other HID, thumb drives and other mass
+  storage, and USB audio cards.
+- **Link power management** — USB 3.0 U1/U2, USB 2.0 hardware LPM (L1) and Latency
+  Tolerance Messaging, plus suspend with the correct ring-stop ordering.
+- **ROM-able** — the driver contains no writable data sections.
 
----
+## Requirements
 
-## Status
-
-The following has been verified:
-
-- Root hub enumeration, USB 2.0 hub support, external hubs (including multi-TT hubs)
-- Control, bulk, interrupt and real-time isochronous transfers (both directions)
-- HID devices, mass storage (thumb drives), USB audio cards
-- Experimental SuperSpeed (USB 3.0) support, including USB 3.0 hubs
-- USB 3.0 Link Power Management (U1/U2), USB 2.0 hardware LPM (L1) and Latency
-  Tolerance Messaging
-
-Known gaps / issues:
-
-- Non-RT isochronous transfers not tested
-- RT isochronous audio may have glitches
-- AHI 4.x not yet supported
-
-> Data corruption is possible in edge cases.  Back up before heavy use.
-
----
+- AmigaOS 3.1 or later (Kickstart V39 minimum).
+- **Classic Poseidon 4.x**, or **Poseidon for AmigaOS 6.x** — this line works with both,
+  though on 6.x the 6.x driver line is faster. See the note above.
+- [PiStorm32-lite](https://github.com/PiStorm/pistorm32-lite) with a Raspberry Pi 4B or CM4.
+- Emu68 1.1 alpha.1 or later — needed to map the PCIe BAR window into the lower 4 GB.
+- `gic400.library` — [emu68-gic400-library](https://github.com/rondoval/emu68-gic400-library).
+- `bcmpcie.library` — [emu68-pcie-library](https://github.com/rondoval/emu68-pcie-library) —
+  **required for unit 1+ (the VL805 and any other PCIe controller)**.
+- `otg_mode=1` in `config.txt` if you want to use the OTG port.
 
 ## Unit numbering
 
@@ -57,275 +60,55 @@ Known gaps / issues:
 | 0 | Onboard OTG port (Pi 4B and CM4) |
 | 1+ | PCIe xHCI controllers, indexed from 1 |
 
-On a stock Pi 4B: unit 0 is the OTG port, unit 1 is the VL805 (four USB-A ports).
-On a CM4: unit 0 is the OTG port; unit 1 exists only if a PCIe xHCI device is attached.
+On a stock Pi 4B, unit 0 is the OTG port and unit 1 is the VL805 with the four USB-A
+ports. On a CM4, unit 1 exists only if you have attached a PCIe xHCI card.
 
-The OTG port requires `otg_mode=1` in `config.txt`.
+## Known limitations
 
----
-
-## How the driver works
-
-One `XHCIUnit` is created per physical xHCI controller, each managed by a dedicated task.
-
-### Startup
-
-On `OpenDevice()`:
-
-1. For unit 0 (OTG), the BCM2711 onboard xHCI controller is located via the Emu68
-   device tree (`/scb/xhci`).
-2. For unit 1+ (PCIe), `bcmpcie.library` initialises the Broadcom STB PCIe
-   controller, enumerates the bus and assigns BARs.
-   If a VIA VL805 is found, its firmware is loaded via the VideoCore mailbox.
-   `bcmpcie.library` is a shared dynamic library; it must be present in `LIBS:`
-   before opening any PCIe-based unit.
-3. The xHCI controller is reset: command, event and transfer rings are allocated, the
-   DCBAA is set up and the controller is started.
-4. An interrupt handler is registered via `gic400.library` (MSI) or a wired IRQ line.
-5. The unit task is spawned and enters its event loop.
-
-### Transfer processing
-
-`BeginIO()` either handles the request immediately or enqueues it to the unit's message
-port.  The unit task dequeues requests and dispatches them:
-
-- Control transfers → command ring + control TD
-- Bulk / interrupt → async or periodic transfer ring
-- Isochronous → periodic ring with frame-accurate scheduling
-
-The interrupt handler signals the unit task when the event ring has entries.  The task
-drains the event ring, completes pending `IORequest`s and re-arms the interrupt.  A
-watchdog timer fires every 100 ms to catch missed events and enforce command-ring
-timeouts (5 s).
-
-### USB 3.0 on a USB 2.0 stack
-
-An USB 2.0 stack has no knowledge of USB 3.0 specifics.  The driver bridges the gap
-in several ways:
-
-**Root hub emulation.** `xhci-root-hub.c` maintains both a USB 2.0 and a USB 3.0 root
-hub descriptor set.  The stack always sees a USB 2.0 root hub regardless of the physical
-port speed.
-
-**SS hub emulation.** When a USB 3.0 hub is discovered it is marked with
-`ss_hub_emulation`.  USB 2.0 hub control requests from the stack are then translated on
-the fly to their SuperSpeed equivalents — for example `SUSPEND`/`RESUME` feature
-requests are converted to `LINK_STATE` transitions, and USB 2.0-only features such as
-`ENABLE`/`C_ENABLE` (which have no SS equivalent) are silently swallowed.
-
-**SS hub port status translation.** A USB 3.0 hub reports port status using a different
-set of bit positions and semantics from a USB 2.0 hub.  Before a `GET_PORT_STATUS` reply
-is returned to the stack, `xhci_udev_map_ss_port_status` rewrites both the status word
-and the change word in-place: the `USB_SS_PORT_STAT_POWER` bit is remapped to the USB
-2.0 `USB_PORT_STAT_POWER` position; PLS=U3 is reported as `USB_PORT_STAT_SUSPEND`; the
-SS speed field is translated to the USB 2.0 `LOW_SPEED`/`HIGH_SPEED` indicators (a
-SuperSpeed device is presented to the stack as high-speed); and
-`USB_SS_PORT_STAT_C_LINK_STATE` with PLS=U0 is mapped to `USB_PORT_STAT_C_SUSPEND`.
-Other change bits (connection, over-current, reset) carry over unchanged.
-
-**Descriptor translation.** Configuration descriptors returned to the stack have
-SuperSpeed Endpoint Companion descriptors (`USB_DT_SS_ENDPOINT_COMP`) stripped out,
-since the stack does not understand them.  When a hub is being configured, the driver
-internally fetches the hub descriptor first so it can program the correct port count and
-TT think time into the xHCI slot context before the `SET_CONFIGURATION` completes.
-
-**Hub descriptor type selection.** The driver uses `USB_DT_SS_HUB` when talking to a
-SuperSpeed hub and `USB_DT_HUB` for high-speed hubs; the stack only ever sees the
-high-speed variant.
-
-### Descriptor parsing and xHCI context creation
-
-xHCI requires far more detail about each endpoint than a USB 2.0 stack typically
-tracks.  The stack does pass descriptor data to HCD drivers — enough for USB 2.0 — but
-the driver's API header intentionally ignores it.  Instead, all data used to build the
-xHCI slot and endpoint contexts comes from the driver's own internal descriptor tree,
-populated during enumeration, which additionally captures SuperSpeed Endpoint Companion
-descriptors and other details that the stack would never see or pass through.
-
-**Configuration descriptor ingestion.** When a device enumerates, the driver performs a
-complete walk of the raw configuration descriptor bytes.  It builds an internal tree:
-`usb_config` → `usb_interface[]` → `usb_interface_altsetting[]` → `usb_endpoint_descriptor[]`.
-Critically, whenever a SuperSpeed Endpoint Companion descriptor
-(`USB_DT_SS_ENDPOINT_COMP`) immediately follows a standard endpoint descriptor, it is
-captured into a parallel `ss_ep_comp_desc[]` array alongside the endpoint — one entry per
-endpoint.  This data is kept internally and is never exposed to the stack.
-
-**Companion descriptor stripping.** Before any configuration descriptor is returned
-upward, `xhci_filter_ss_ep_companion_desc` performs an in-place compaction of the raw
-byte buffer: it copies every non-`USB_DT_SS_ENDPOINT_COMP` descriptor forward over the
-gaps left by the stripped entries, zeroes the tail, and adjusts `wTotalLength`
-accordingly.  The stack receives a well-formed, USB 2.0-shaped configuration blob.
-
-**Slot context (`ENABLE_SLOT` / `ADDRESS_DEVICE`).** When a device receives its address,
-`xhci_setup_addressable_virt_dev` programs the xHCI input slot context:
-
-- *Route string* — `build_route_string` packs the port number at each hub tier as a
-  4-bit nibble into the 20-bit route string field (bits [19:0]).  The first tier below
-  the root occupies bits [3:0], the second tier [7:4], and so on up to a maximum of five
-  tiers as required by the xHCI spec.  Port numbers greater than 15 are clamped to
-  `0xF`.
-- *Speed* — one of `SLOT_SPEED_SS/HS/FS/LS` is written into `dev_info`.
-- *Root port* — `find_root_port` walks the parent chain to the root hub and records that
-  port number in the `ROOT_HUB_PORT` field of `dev_info2`.
-- *Transaction Translator info* — for low- or full-speed devices the driver walks the
-  parent chain upward until it finds the nearest high-speed hub ancestor, then programs
-  `TT_SLOT` with that hub's slot ID and `TT_PORT` with the downstream port number.
-- *EP0 max packet size* — set to 512 for SuperSpeed, 64 for high-speed and
-  full-speed (the correct value is confirmed after reading the device descriptor), and
-  8 for low-speed.
-- *Virtual address vs xHCI address* — the USB address on the wire is chosen by the
-  xHCI controller and returned in the `ADDRESS_DEVICE` completion event; it is stored
-  as `xhci_address` and is the address the hardware actually uses (e.g., in
-  `CLEAR_TT_BUFFER` requests to parent hubs).  The address the stack assigns via
-  `SET_ADDRESS` is tracked separately in `virtual_address` and used only as a lookup key
-  for the internal device context.  The two values are independent and will generally
-  differ.
-
-**Endpoint context (`CONFIGURE_ENDPOINT`).** When the stack issues `SET_CONFIGURATION`
-or `SET_INTERFACE`, the driver builds one xHCI endpoint context for each active endpoint:
-
-- *DCI index* — `xhci_get_ep_index` maps USB endpoint addresses to xHCI Doorbell Context
-  Indices: `epnum × 2` for the control endpoint, `epnum × 2 − (IN ? 0 : 1)` for all
-  others.  The highest active DCI becomes the `LAST_CTX` field in the slot context.
-  `xhci_collect_config_masks` simultaneously builds the `ADD_FLAGS` bitmask for the
-  `CONFIGURE_ENDPOINT` command.
-- *Polling interval* — `xhci_get_endpoint_interval` converts `bInterval` into xHCI's
-  power-of-two exponent `Interval` field using different rules per speed and transfer
-  type.  High-speed bulk/control: `log₂(bInterval)` raw microframe count, clamped to
-  0–15.  High-speed and SuperSpeed periodic (interrupt/isoc): `bInterval − 1` (already
-  an exponent in the `2^(n-1)` encoding).  Full-speed isoc: the same exponent formula,
-  then add 3 to convert frames to microframes (`1 frame = 2³ µframes`).  Low-speed and
-  full-speed interrupt: `bInterval` in frames multiplied by 8, expressed as a
-  power-of-two exponent.
-- *Max burst and ESIT payload* — for SuperSpeed endpoints the companion descriptor
-  provides `bMaxBurst` directly; for high-speed periodic endpoints the two transaction-
-  opportunity bits in the high byte of `wMaxPacketSize` encode `max_burst − 1`.  The
-  maximum ESIT payload is `wBytesPerInterval` from the companion descriptor for
-  SuperSpeed, or `wMaxPacketSize × max_burst` for high-speed periodic endpoints.
-
-**Hub descriptor prefetch.** The xHCI slot context for a hub must contain the number of
-downstream ports and, for high-speed hubs, the TT think time.  Those values are only
-available in the hub class descriptor, which the stack does not fetch before
-`SET_CONFIGURATION`.  The driver therefore intercepts the `SET_CONFIGURATION` IOReq for
-any hub device, issues an internal `GET_DESCRIPTOR` for `USB_DT_SS_HUB` or `USB_DT_HUB`
-on EP0, and stashes the original IOReq.  The `GET_DESCRIPTOR` completion handler
-(`xhci_udev_handle_hub_prefetch`) caches the result in `udev->ss_hub_desc`, programs
-the slot context accordingly, and then lets the original `SET_CONFIGURATION` proceed.
-
-**Multi-TT hubs.** When a high-speed hub advertises the multiple-Transaction-
-Translator capability and its multi-TT interface alternate setting is selected,
-the driver sets the `MTT` bit in the relevant slot contexts — the hub's own
-context and the context of any low-/full-speed device behind it — so the
-controller routes split transactions through the hub's per-port translators.
-Hubs without that capability are programmed as single-TT.
-
-### Power management (LPM)
-
-After a device finishes configuration, the driver enables link power management
-where the device and host support it.  This is driven entirely by the driver
-from its own enumeration state — the USB 2.0 stack is not involved.
-
-**USB 3.0 U1/U2.** For SuperSpeed devices the driver parses the BOS descriptor,
-computes the U1/U2 SEL/PEL/MEL latency parameters (USB 3.1 Appendix C), applies
-the Max Exit Latency to the slot context via an Evaluate Context command (the
-xHC only evaluates MEL on Address Device / Evaluate Context, never from a
-Configure Endpoint context), sends `SET_SEL` to the device, programs the port
-U1/U2 timeouts and enables device-initiated transitions with
-`SET_FEATURE(U1_ENABLE/U2_ENABLE)`.  The sequence starts only once the
-`SET_CONFIGURATION` control transfer has completed on the wire, since devices
-reject `U1/U2_ENABLE` until configured.  On the Raspberry Pi 4B the VL805 root
-ports never enter U1/U2 (seems to be a firmware bug?), so
-USB 3.0 LPM is effective only on the downstream links of external SuperSpeed
-hubs.
-
-**USB 2.0 hardware LPM (L1).** For a USB 2.0 device directly on a root-hub port,
-hardware-controlled L1 is enabled when both ends advertise BESL: the driver
-reads the device's BOS USB 2.0 Extension capability and programs the port's
-HIRD/BESL value.
-
-**Latency Tolerance Messaging.** For configured SuperSpeed devices that
-advertise LTM (and when the controller reports LTM capability), the driver
-enables it with `SET_FEATURE(LTM_ENABLE)`; the xHC then consumes the device's
-LTM packets in hardware.
-
-**Suspend.** When Poseidon suspends a device, the driver stops the device's
-endpoint rings before writing the port into U3 (xHCI §4.15.1).
-
-### Teardown
-
-On `CloseDevice()` / `Expunge()` the unit task is stopped, all rings are freed, the
-interrupt is removed and the PCIe controller is left in a quiescent state.
-
-A reset guard installed at init halts every controller — stopping all ring,
-event and MSI DMA — before the machine resets, so in-flight DMA cannot corrupt
-memory or hang the host across a reboot.
+- **SuperSpeed (USB 3.0) is experimental**, hubs included.
+- **Data corruption is possible in edge cases** — back up before heavy use.
+- **Real-time isochronous audio may glitch**, and non-RT isochronous transfers are
+  untested. AHI 4.x is not supported yet.
+- **No USB 3.0 bulk streams** — the fast UAS path for mass storage is only in the 6.x
+  line, so USB 3.0 storage is slower here even under Poseidon 6.x.
+- **USB 3.0 link power management does nothing on the Pi 4B's own ports** — the VL805
+  never enters U1/U2 by fixed firmware policy, exactly as under Linux. It works on the
+  downstream links of external SuperSpeed hubs.
 
 ---
 
-## Requirements
+## For developers
 
-- AmigaOS 3.1 or later (Kickstart V39 minimum)
-- Poseidon 4.5 or compatible USB stack
-- [PiStorm32-lite](https://github.com/PiStorm/pistorm32-lite) with Raspberry Pi 4B or CM4
-- Emu68 1.1 alpha.1 or later — required for MMU mapping of the PCIe BAR window into the lower 4 GB
-- `gic400.library` — [emu68-gic400-library](https://github.com/rondoval/emu68-gic400-library)
-- `bcmpcie.library` — [emu68-pcie-library](https://github.com/rondoval/emu68-pcie-library) — **required for unit 1+ (VL805 / PCIe)**
+### Layout
 
----
+`xhci.device/src/` is the AmigaOS device and unit layer — device entry points, the
+BeginIO/AbortIO dispatchers, unit lifecycle and hardware bring-up, the per-unit task and
+its watchdog, and the interrupt service routine. `xhci.device/src/xhci/` is the xHCI core:
+controller init, ring and TD management, device/slot/endpoint contexts, event and command
+processing, descriptor parsing, link power management, and the translation layer that
+makes USB 3.0 devices and hubs look like USB 2.0 ones to the stack (`xhci-root-hub.c`,
+`xhci-hub.c`, `xhci-udev.c`). Headers live in `xhci.device/include/`.
 
-## Building
+### Building
 
-Build dependencies (must be installed first):
-
-| Package | Where | Purpose |
-|---|---|---|
-| `Emu68Common` | `emu68-common` | Pool allocators, shared utilities |
-| `Emu68PCIe` | `emu68-pcie-library` | BCM2711 PCIe controller + bus enumeration (builds `bcmpcie.library`) |
-| `GIC400` | `emu68-gic400-library` | ARM GIC-400 interrupt controller (MSI) |
+Built through the **emu68-driver-stack** superproject, which supplies the Bebbo
+cross-toolchain and the companion CMake packages (`emu68-common`, `emu68-pcie-library`,
+`emu68-gic400-library`). From a superproject checkout:
 
 ```sh
-cmake -S . -B build \
-  -DCMAKE_TOOLCHAIN_FILE=cmake/toolchain.cmake \
-  -DCMAKE_PREFIX_PATH=/path/to/emu68-driver-stack \
-  -DCMAKE_INSTALL_PREFIX=/path/to/emu68-driver-stack
-cmake --build build
-cmake --install build
+./scripts/docker-build.sh --target emu68-xhci-driver-legacy   # no local toolchain needed
 ```
 
-Recommended workflow: install all dependencies and this package into the same prefix.
+The build runs inside the toolchain container, so do not invoke `cmake` on the host. The
+superproject installs this line under `Storage/` — `Storage/DEVS/USBHardware/xhci.device`
+— so it does not collide with the 6.x line's device of the same name; the installer copies
+whichever one you pick to `DEVS:USBHardware/`.
 
-If you keep dependencies in separate install trees instead, set `CMAKE_PREFIX_PATH` to the `emu68-common` and `emu68-pcie-library` install prefixes.
+Debug backend: `EMU68_CONFIGURE_ARGS="-DEMU68_DEBUG_BACKEND=serial" ./scripts/docker-build.sh`
+(`pistorm` default | `serial` | `off`), selected stack-wide via `emu68-common`. `serial`
+links `debug.lib` and is not ROM-able.
 
-The installed binary is written to `/path/to/emu68-driver-stack/DEVS/USBHardware/xhci.device`.
+## License
 
----
-
-## Repository layout
-
-```
-xhci.device/
-  src/
-    device.c                AmigaOS Device init/open/close/expunge
-    device_beginio.c        BeginIO dispatcher
-    device_abortio.c        AbortIO handler
-    unit.c                  Unit lifecycle: PCIe init, hardware bring-up, IRQ setup
-    unit_task.c             Per-unit task: event loop, watchdog timer, command dispatch
-    unit_commands.c         USB command processing (control, bulk, interrupt, iso)
-    irq.c                   MSI / INTx interrupt service routine
-    xhci/
-      xhci.c                xHCI controller init/reset
-      xhci-ring.c           Transfer and command ring management
-      xhci-context.c        Device/slot/endpoint context management
-      xhci-events.c         Event ring processing
-      xhci-commands.c       Command TRB submission and completion
-      xhci-td.c             Transfer descriptor construction
-      xhci-descriptors.c    USB descriptor parsing helpers
-      xhci-root-hub.c       Root hub emulation (USB 2.0 and USB 3.0 descriptor sets)
-      xhci-udev.c           USB device state and SS-to-HS translation
-      xhci-hub.c            SuperSpeed hub emulation (descriptor/port-feature translation)
-      xhci-lpm.c            Link Power Management (USB 3.0 U1/U2, USB 2.0 L1/BESL, LTM)
-      xhci-endpoint.c       Endpoint open/close/reset
-  include/
-    device.h                XHCIDevice / XHCIUnit structs, device interface
-    config.h                Compile-time tunables (stack size, timeouts, …)
-```
+GPL-family, per file — see the SPDX headers and [LICENSE](LICENSE). The xHCI core is
+derived from Das U-Boot.

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,3 +1,57 @@
+# Upgrade notes
+
+Configuration-relevant changes across all releases, newest first:
+
+* **5.x is the compatibility line.**  It speaks the classic Poseidon HCD ABI, so
+  it drives **classic Poseidon 4.x** and also works with **Poseidon for AmigaOS
+  6.x**, which retains that ABI.  On Poseidon 6.x prefer the driver's **6.x**
+  line — it is faster there — maintained on the
+  [`context_release` branch](https://github.com/rondoval/emu68-xhci-driver/tree/context_release).
+* **From 4.4 or later:** no configuration changes are required.
+* **From 3.x:** `bcmpcie.library` must be installed in `LIBS:` for PCIe-based
+  units (unit 1+, VL805 on Pi 4B) to work.
+* **From pre-3.x:** unit numbering differs.  Unit 0 was the VL805 (PCIe) and
+  is now the onboard OTG port; unit 1 is now the VL805.  Update your USB
+  stack configuration accordingly.
+
+
+# Release notes — xhci.device 5.3
+
+Changes since v5.2.
+
+---
+
+## The 5.x line now ships alongside a 6.x line
+
+`xhci.device` is released in two lines — only one can be installed at a time, and
+the Emu68 driver stack installer asks which — differing in the USB stack ABI they
+speak:
+
+* **5.x — this line.**  Speaks the classic Poseidon HCD ABI.  Required on
+  **classic Poseidon 4.x**, and usable on **Poseidon for AmigaOS 6.x** too, since
+  that stack keeps the classic ABI alongside its own.  SuperSpeed devices go
+  through the driver's internal USB 3.0 ↔ USB 2.0 translation either way.
+* **6.x** — speaks only the newer context HCD ABI, so it needs Poseidon for
+  AmigaOS 6.x.  It hands the stack real USB 3.0 devices with no emulation and
+  adds USB 3.0 bulk streams for mass storage.
+
+If you run classic Poseidon nothing changes: stay on this line.  If you run
+Poseidon 6.x, this line still works, but the 6.x line is the faster choice.  In
+the stack archive the 5.x driver rides under `Storage/` and is copied to
+`DEVS:USBHardware/` only when you pick it.
+
+---
+
+## Maintenance
+
+No functional changes to the driver.  It is built against the current
+`emu68-common` debug API so the 5.x line compiles in the present driver stack
+again: the old two-level `DEBUG` / `DEBUG_HIGH` scheme becomes the cumulative
+tier ladder (`off` / `profile` / `debug` / `trace`), and one switch fall-through
+is now spelled with the attribute the current compiler expects.  The emitted
+code and runtime behaviour are unchanged.
+
+
 # Release notes — xhci.device 5.2
 
 Changes since v5.1.

--- a/xhci.device/CMakeLists.txt
+++ b/xhci.device/CMakeLists.txt
@@ -24,7 +24,7 @@ add_compile_options(
 )
 
 # Debug-output backend defines (EMU68_DEBUG_BACKEND, see emu68-common).
-emu68_debug_backend_definitions()
+emu68_debug_definitions()
 
 add_compile_definitions(
     PRIVATE

--- a/xhci.device/include/xhci/xhci-endpoint.h
+++ b/xhci.device/include/xhci/xhci-endpoint.h
@@ -60,7 +60,6 @@ struct xhci_ring *xhci_ep_get_ring(struct ep_context *ep_ctx);
 BOOL xhci_ep_complete_by_trb(struct ep_context *ep_ctx, dma_addr_t trb_addr,
                              u32 residue, BOOL short_packet,
                              struct xhci_td_completion *out, BOOL *deferred);
-BOOL xhci_ep_has_request(struct ep_context *ep_ctx, struct USBIORequest *io);
 void xhci_ep_enqueue(struct ep_context *ep_ctx, struct USBIORequest *io);
 void xhci_ep_flush(struct ep_context *ep_ctx, s8 reply_code);
 

--- a/xhci.device/src/device.c
+++ b/xhci.device/src/device.c
@@ -190,7 +190,7 @@ static void xhci_reset_prepare(APTR user)
 APTR initFunction(struct XHCIDevice *base asm("d0"), ULONG segList asm("a0"), struct ExecBase *_SysBase asm("a6"))
 {
     (void)_SysBase;
-    KprintfH("[xhci] %s: Initializing device\n", __func__);
+    KprintfT("[xhci] %s: Initializing device\n", __func__);
     base->segList = segList;
     base->device.dd_Library.lib_Revision = DEVICE_REVISION;
     _NewMinList(&base->units);
@@ -211,7 +211,7 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
     BOOL firstOpen = FALSE;
     BOOL createdUnit = FALSE;
 
-    KprintfH("[xhci] %s: Opening device with unit number %ld and flags %lx\n", __func__, unitNumber, flags);
+    KprintfT("[xhci] %s: Opening device with unit number %ld and flags %lx\n", __func__, unitNumber, flags);
 
     if (io->req.io_Message.mn_Length < sizeof(struct IOStdReq))
     {
@@ -234,7 +234,7 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
 
     if (unit == NULL)
     {
-        KprintfH("[xhci] %s: Allocating unit structure\n", __func__);
+        KprintfT("[xhci] %s: Allocating unit structure\n", __func__);
         unit = AllocMem(sizeof(struct XHCIUnit), MEMF_FAST | MEMF_PUBLIC | MEMF_CLEAR);
         if (unit == NULL)
         {
@@ -249,7 +249,7 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
 
     if (unit->unit.unit_OpenCnt > 0)
     {
-        KprintfH("[xhci] %s: Unit is already open, we only support exclusive access\n", __func__);
+        KprintfT("[xhci] %s: Unit is already open, we only support exclusive access\n", __func__);
         io->req.io_Error = IOERR_UNITBUSY;
         return;
     }
@@ -270,7 +270,7 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
 
     if (result == ERR_NO_ERROR)
     {
-        KprintfH("[xhci] %s: Unit opened successfully\n", __func__);
+        KprintfT("[xhci] %s: Unit opened successfully\n", __func__);
         io->req.io_Unit = (struct Unit *)unit;
         base->device.dd_Library.lib_OpenCnt++;
         base->device.dd_Library.lib_Flags &= (UBYTE)~LIBF_DELEXP;
@@ -295,12 +295,12 @@ void openLib(struct USBIORequest *io asm("a1"), LONG unitNumber asm("d0"),
 ULONG closeLib(struct USBIORequest *io asm("a1"), struct XHCIDevice *base asm("a6"))
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    KprintfH("[xhci] %s: Closing device\n", __func__);
+    KprintfT("[xhci] %s: Closing device\n", __func__);
 
     int result = UnitClose(unit);
     if (result == 0) // last user of Unit disappeared
     {
-        KprintfH("[xhci] %s: Unit closed successfully, freeing resources\n", __func__);
+        KprintfT("[xhci] %s: Unit closed successfully, freeing resources\n", __func__);
         RemoveMinNode((struct MinNode *)unit);
         FreeMem(unit, sizeof(struct XHCIUnit));
     }
@@ -321,10 +321,10 @@ ULONG closeLib(struct USBIORequest *io asm("a1"), struct XHCIDevice *base asm("a
 
 ULONG expungeLib(struct XHCIDevice *base asm("a6"))
 {
-    KprintfH("[xhci] %s: Expunging device\n", __func__);
+    KprintfT("[xhci] %s: Expunging device\n", __func__);
     if (base->device.dd_Library.lib_OpenCnt > 0)
     {
-        KprintfH("[xhci] %s: Device is still open, cannot expunge\n", __func__);
+        KprintfT("[xhci] %s: Device is still open, cannot expunge\n", __func__);
         base->device.dd_Library.lib_Flags |= LIBF_DELEXP;
         return 0;
     }
@@ -334,7 +334,7 @@ ULONG expungeLib(struct XHCIDevice *base asm("a6"))
          * stub — then the code must stay resident. */
         if (!reset_guard_remove(&base->resetGuard))
         {
-            KprintfH("[xhci] %s: reset guard not removable, staying resident\n", __func__);
+            KprintfT("[xhci] %s: reset guard not removable, staying resident\n", __func__);
             return 0;
         }
 

--- a/xhci.device/src/device_abortio.c
+++ b/xhci.device/src/device_abortio.c
@@ -36,7 +36,7 @@ static LONG post_abort_request(struct XHCIUnit *unit, struct USBIORequest *io)
 LONG abortIO(struct USBIORequest *io asm("a1"), struct XHCIDevice *base asm("a6") __attribute__((unused)))
 {
     /* AbortIO is a *wish* call. Someone would like to abort current IORequest */
-    KprintfH("[xhci] %s: Aborting IO request %lx\n", __func__, io);
+    KprintfT("[xhci] %s: Aborting IO request %lx\n", __func__, io);
     if (!io)
         return -1;
 

--- a/xhci.device/src/irq.c
+++ b/xhci.device/src/irq.c
@@ -38,7 +38,7 @@ static inline void xhci_irq_enable_runtime(struct xhci_ctrl *ctrl)
 
 static inline void xhci_irq_update_cmd(struct xhci_ctrl *ctrl, BOOL enable)
 {
-	KprintfH("[xhci] %s: %s CMD_EIE | CMD_HSEIE\n", __func__, enable ? "enabling" : "disabling");
+	KprintfT("[xhci] %s: %s CMD_EIE | CMD_HSEIE\n", __func__, enable ? "enabling" : "disabling");
 	u32 cmd = mmio_read32(&ctrl->hcor->or_usbcmd);
 	if (enable)
 		cmd |= (CMD_EIE | CMD_HSEIE);

--- a/xhci.device/src/unit.c
+++ b/xhci.device/src/unit.c
@@ -152,12 +152,12 @@ static s32 pcie_xhci_init(struct Library *pcielibBase, struct pci_dev *pd,
 		Kprintf("[xhci] %s: BAR0 not mapped\n", __func__);
 		return -EIO;
 	}
-	KprintfH("[xhci] %s: init mapped hccr %lx\n", __func__, *hccr);
+	KprintfT("[xhci] %s: init mapped hccr %lx\n", __func__, *hccr);
 
 	*hcor = (struct xhci_hcor *)((uintptr_t)*hccr +
 								 HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
-	KprintfH("[xhci] %s: init hccr %lx and hcor %lx hc_length %lu\n",
+	KprintfT("[xhci] %s: init hccr %lx and hcor %lx hc_length %lu\n",
 			__func__, *hccr, *hcor, (ULONG)HC_LENGTH(mmio_read32(&(*hccr)->cr_capbase)));
 
 	pci_set_master(pd);
@@ -268,7 +268,7 @@ err_free_ctrl:
 
 s32 UnitOpen(struct XHCIUnit *unit, LONG unitNumber, LONG flags)
 {
-	KprintfH("[xhci] %s: Opening unit %ld with flags %lx\n", __func__, unitNumber, flags);
+	KprintfT("[xhci] %s: Opening unit %ld with flags %lx\n", __func__, unitNumber, flags);
 	if (unit->unit.unit_OpenCnt > 0)
 	{
 		unit->unit.unit_OpenCnt++;

--- a/xhci.device/src/unit_commands.c
+++ b/xhci.device/src/unit_commands.c
@@ -48,7 +48,7 @@ static const UWORD SupportedCommands[] = {
 
 static u32 Do_NSCMD_DEVICEQUERY(struct IOStdReq *io)
 {
-    KprintfH("[xhci] %s: NSCMD_DEVICEQUERY\n", __func__);
+    KprintfT("[xhci] %s: NSCMD_DEVICEQUERY\n", __func__);
     struct NSDeviceQueryResult *dq = io->io_Data;
 
     /* Fill out structure */
@@ -86,7 +86,7 @@ static inline void flush_queued_unit_request(struct XHCIUnit *unit, struct USBIO
 static u32 Do_CMD_FLUSH(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    KprintfH("[xhci] %s: CMD_FLUSH\n", __func__);
+    KprintfT("[xhci] %s: CMD_FLUSH\n", __func__);
 
     struct USBIORequest *req;
     /* Flush and cancel all requests */
@@ -115,7 +115,7 @@ static u32 Do_CMD_FLUSH(struct USBIORequest *io)
         }
     }
 
-    KprintfH("[xhci] %s: Flush completed\n", __func__);
+    KprintfT("[xhci] %s: Flush completed\n", __func__);
     return COMMAND_PROCESSED;
 }
 
@@ -131,7 +131,7 @@ static void uword_to_hex(UWORD value, UBYTE *buf)
 
 static inline u32 Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
 {
-    KprintfH("[xhci] %s: CMD_DEVICE_QUERY\n", __func__);
+    KprintfT("[xhci] %s: CMD_DEVICE_QUERY\n", __func__);
 
     if (!io->data_buffer)
     {
@@ -143,7 +143,7 @@ static inline u32 Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
 
     struct TagItem *tag, *tagList = (struct TagItem *)io->data_buffer;
     u32 filled = 0;
-    KprintfH("[xhci] %s: Processing tag list at 0x%lx\n", __func__, tagList);
+    KprintfT("[xhci] %s: Processing tag list at 0x%lx\n", __func__, tagList);
     while ((tag = NextTagItem(&tagList)))
     {
         if (!tag->ti_Data)
@@ -215,13 +215,13 @@ static inline u32 Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
             break;
         default:
             // Unknown tag: leave untouched
-            KprintfH("[xhci] %s: Unknown tag 0x%lx, skipping\n", __func__, tag->ti_Tag);
+            KprintfT("[xhci] %s: Unknown tag 0x%lx, skipping\n", __func__, tag->ti_Tag);
             break;
         }
-        KprintfH("[xhci] %s: Processed tag 0x%lx\n", __func__, tag->ti_Tag);
+        KprintfT("[xhci] %s: Processed tag 0x%lx\n", __func__, tag->ti_Tag);
     }
 
-    KprintfH("[xhci] %s: Completed UHCMD_QUERYDEVICE\n", __func__);
+    KprintfT("[xhci] %s: Completed UHCMD_QUERYDEVICE\n", __func__);
     io->req.io_Error = ERR_NO_ERROR;
     io->actual_length = filled;
     return COMMAND_PROCESSED;
@@ -233,7 +233,7 @@ static inline u32 Do_CMD_DEVICE_QUERY(struct USBIORequest *io)
 static inline u32 Do_CMD_DEVICE_RESET(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    KprintfH("[xhci] %s: CMD_DEVICE_RESET\n", __func__);
+    KprintfT("[xhci] %s: CMD_DEVICE_RESET\n", __func__);
 
     /* Issue SET_FEATURE(RESET) on all root hub ports */
     struct xhci_ctrl *ctrl = unit->xhci_ctrl;
@@ -262,7 +262,7 @@ static inline u32 Do_CMD_DEVICE_RESET(struct USBIORequest *io)
 static u32 Do_CMD_RESET(struct USBIORequest *io)
 {
     // struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    KprintfH("[xhci] %s: CMD_RESET\n", __func__);
+    KprintfT("[xhci] %s: CMD_RESET\n", __func__);
     // TODO should reset entire controller...
     return Do_CMD_DEVICE_RESET(io);
 }
@@ -392,7 +392,7 @@ static inline u32 Do_CMD_INTERNAL_ABORT(struct USBIORequest *io)
 static inline u32 Do_CMD_REGISTER_ISO_HANDLER(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    KprintfH("[xhci] %s: CMD_REGISTER_ISO_HANDLER\n", __func__);
+    KprintfT("[xhci] %s: CMD_REGISTER_ISO_HANDLER\n", __func__);
 
     // TODO check if state is operational
     if (!io->data_buffer)
@@ -423,7 +423,7 @@ badparams:
 static inline u32 Do_CMD_UNREGISTER_ISO_HANDLER(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    KprintfH("[xhci] %s: CMD_UNREGISTER_ISO_HANDLER\n", __func__);
+    KprintfT("[xhci] %s: CMD_UNREGISTER_ISO_HANDLER\n", __func__);
 
     if (!io->data_buffer)
         goto badparams;
@@ -451,9 +451,9 @@ badparams:
 static inline u32 Do_CMD_STARTRTISO(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    KprintfH("[xhci] %s: CMD_START_REALTIME_ISOCHRONOUS\n", __func__);
+    KprintfT("[xhci] %s: CMD_START_REALTIME_ISOCHRONOUS\n", __func__);
 
-    KprintfH("RT ISO start addr=%lu ep=%lu dir=%s len=%lu\n",
+    KprintfT("RT ISO start addr=%lu ep=%lu dir=%s len=%lu\n",
              (ULONG)io->virtual_address,
              (ULONG)(io->endpoint & 0x0F),
              (io->direction == DIRECTION_IN) ? "IN" : "OUT",
@@ -482,9 +482,9 @@ badparams:
 static inline u32 Do_CMD_STOPRTISO(struct USBIORequest *io)
 {
     struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    KprintfH("[xhci] %s: CMD_STOP_REALTIME_ISOCHRONOUS\n", __func__);
+    KprintfT("[xhci] %s: CMD_STOP_REALTIME_ISOCHRONOUS\n", __func__);
 
-    KprintfH("RT ISO stop requested addr=%lu ep=%lu\n",
+    KprintfT("RT ISO stop requested addr=%lu ep=%lu\n",
              (ULONG)io->virtual_address, (ULONG)(io->endpoint & 0x0F));
     struct usb_device *udev = xhci_udev_get(unit, io->virtual_address);
     if (!udev)

--- a/xhci.device/src/unit_commands.c
+++ b/xhci.device/src/unit_commands.c
@@ -362,39 +362,6 @@ static inline u32 Do_CMD_START(struct USBIORequest *io)
  */
 static inline u32 Do_CMD_XFER(struct USBIORequest *io)
 {
-    struct XHCIUnit *unit = (struct XHCIUnit *)io->req.io_Unit;
-    struct xhci_ctrl *ctrl = unit ? unit->xhci_ctrl : NULL;
-
-    if (io->req.io_Command == CMD_REQUEST_INTERRUPT && ctrl && io->virtual_address <= USB_MAX_ADDRESS)
-    {
-        struct usb_device *udev = ctrl->devices_by_virtual_address[io->virtual_address];
-        if (udev)
-        {
-            u8 ep_index = xhci_ep_index_from_parts(io->endpoint, io->direction);
-            struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
-            if (ep_ctx && xhci_ep_has_request(ep_ctx, io))
-            {
-                /* Work around the Poseidon hub resume path re-submitting the
-                 * same interrupt IORequest while the original request is still
-                 * active on this endpoint. Treat that second send as a safe
-                 * no-op only when the exact same request object is still
-                 * tracked here; a legitimately re-used request after ReplyMsg()
-                 * must still be accepted as a fresh transfer.
-                 *
-                 * This avoids queueing the same IORequest twice or replying the
-                 * same message twice. It does not fix Poseidon's pending-count
-                 * accounting for the duplicate send. */
-                KprintfH("[xhci] %s: ignoring duplicate hub resume re-send for tracked request %08lx state=%lu flags=%lx dflags=%lx\n",
-                         __func__,
-                         (ULONG)io,
-                         (ULONG)xhci_ep_get_state(ep_ctx),
-                         (ULONG)io->req.io_Flags,
-                         (ULONG)io->driver_private_flags);
-                return COMMAND_SCHEDULED;
-            }
-        }
-    }
-
     io->driver_private_flags = 0;
     io->driver_private_dma_address = NULL;
 

--- a/xhci.device/src/unit_task.c
+++ b/xhci.device/src/unit_task.c
@@ -72,7 +72,7 @@ static void UnitTask(struct XHCIUnit *unit, struct Task *parent)
     /* Signal parent that Unit task is up and running now */
     Signal(parent, SIGBREAKF_CTRL_F);
 
-    KprintfH("[xhci] %s: Entering main unit task loop\n", __func__);
+    KprintfT("[xhci] %s: Entering main unit task loop\n", __func__);
 
     ULONG sigset;
     ULONG waitMask = (1UL << unit->unit.unit_MsgPort.mp_SigBit) |
@@ -120,7 +120,7 @@ static void UnitTask(struct XHCIUnit *unit, struct Task *parent)
 
         if (sigset & SIGBREAKF_CTRL_C)
         {
-            KprintfH("[xhci] %s: Received SIGBREAKF_CTRL_C, stopping xhci task\n", __func__);
+            KprintfT("[xhci] %s: Received SIGBREAKF_CTRL_C, stopping xhci task\n", __func__);
             AbortIO(&packetTimerReq->tr_node);
             WaitIO(&packetTimerReq->tr_node);
         }
@@ -140,7 +140,7 @@ free_signals:
 
 s32 UnitTaskStart(struct XHCIUnit *unit)
 {
-    KprintfH("[xhci] %s: xhci task starting\n", __func__);
+    KprintfT("[xhci] %s: xhci task starting\n", __func__);
 
     // Get all memory we need for the receiver task
     struct MemList *ml = AllocMem(sizeof(struct MemList) + sizeof(struct MemEntry), MEMF_PUBLIC | MEMF_CLEAR);
@@ -203,7 +203,7 @@ s32 UnitTaskStart(struct XHCIUnit *unit)
         FreeMem(&stack[0], STACK_SIZE);
         return ERR_HCI_ERROR;
     }
-    KprintfH("[xhci] %s: xhci task started\n", __func__);
+    KprintfT("[xhci] %s: xhci task started\n", __func__);
     return ERR_NO_ERROR;
 }
 
@@ -212,7 +212,7 @@ void UnitTaskStop(struct XHCIUnit *unit)
     if (!unit->task)
         return;
 
-    KprintfH("[xhci] %s: xhci task stopping\n", __func__);
+    KprintfT("[xhci] %s: xhci task stopping\n", __func__);
 
     struct MsgPort *timerPort = CreateMsgPort();
     struct timerequest *timerReq = CreateIORequest(timerPort, sizeof(struct timerequest));
@@ -249,5 +249,5 @@ void UnitTaskStop(struct XHCIUnit *unit)
     if (timerPort)
         DeleteMsgPort(timerPort);
 
-    KprintfH("[xhci] %s: xhci task stopped\n", __func__);
+    KprintfT("[xhci] %s: xhci task stopped\n", __func__);
 }

--- a/xhci.device/src/xhci/xhci-commands.c
+++ b/xhci.device/src/xhci/xhci-commands.c
@@ -21,9 +21,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci-commands] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci-commands] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci-commands] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 struct pending_command; /* forward declaration */
@@ -44,7 +44,7 @@ struct pending_command
 
 static const command_handler command_handlers[];
 
-#ifdef DEBUG_HIGH
+#ifdef TRACE
 static u32 xhci_pending_command_count(struct xhci_ctrl *ctrl)
 {
     u32 count = 0;
@@ -185,7 +185,7 @@ static void xhci_queue_command(struct xhci_ctrl *ctrl, dma_addr_t addr, u32 slot
     pending_cmd->complete = command_handlers[cmd];
     AddTailMinList(&ctrl->pending_commands, (struct MinNode *)pending_cmd);
 
-    KprintfH("Queued command type=%s trb_dma=%lx ptr=%lx slot=%lu ep=%lu vaddr=%ld pending=%lu abort=%ld\n",
+    KprintfT("Queued command type=%s trb_dma=%lx ptr=%lx slot=%lu ep=%lu vaddr=%ld pending=%lu abort=%ld\n",
              xhci_command_type_name(cmd),
              (ULONG)trb_dma,
              (ULONG)addr,
@@ -240,7 +240,7 @@ static void handle_reset_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd,
     struct xhci_ring *ring = xhci_ep_get_ring(ep_ctx);
     u32 deq_ptr = xhci_ring_get_new_dequeue_ptr(ring);
 
-    KprintfH("Reset EP %lu completed (comp=%lu)\n", (ULONG)ep_index, (ULONG)comp);
+    KprintfT("Reset EP %lu completed (comp=%lu)\n", (ULONG)ep_index, (ULONG)comp);
     xhci_set_deq_pointer(cmd->udev, ep_index, deq_ptr);
 }
 
@@ -267,11 +267,11 @@ static void handle_set_deq(struct xhci_ctrl *ctrl, struct pending_command *cmd, 
         xhci_ep_set_failed(ep_ctx);
         return;
     }
-    KprintfH("Set DEQ for EP %lu completed successfully, status code %lu (success=1)\n", (ULONG)ep_index, (ULONG)comp);
+    KprintfT("Set DEQ for EP %lu completed successfully, status code %lu (success=1)\n", (ULONG)ep_index, (ULONG)comp);
 
     if (xhci_ep_get_state(ep_ctx) == USB_DEV_EP_STATE_RESETTING)
     {
-        KprintfH("EP %lu was resetting, completing reset\n", (ULONG)ep_index);
+        KprintfT("EP %lu was resetting, completing reset\n", (ULONG)ep_index);
         /*
          * If this is due to e.g. STALL recovery, we need to sort out the device itself...:
          * issue ClearFeature(CLEAR_TT_BUFFER) to the hub if its control or bulk ep and dev is behind a TT
@@ -348,7 +348,7 @@ static void handle_stop_ring(struct xhci_ctrl *ctrl, struct pending_command *cmd
         return;
     }
 
-    KprintfH("Stopped EP %lu with completion code %lu\n", (ULONG)ep_index, (ULONG)comp);
+    KprintfT("Stopped EP %lu with completion code %lu\n", (ULONG)ep_index, (ULONG)comp);
 
     dma_addr_t deq_ptr = 0;
     xhci_ep_process_stop(ep_ctx, &deq_ptr);
@@ -377,7 +377,7 @@ static void handle_config_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd
     (void)ctrl;
     const u32 status = le32(event->event_cmd.status);
     xhci_comp_code comp = GET_COMP_CODE(status);
-#ifdef DEBUG_HIGH
+#ifdef TRACE
     const u32 flags = le32(event->event_cmd.flags);
     const u32 slot_id = TRB_TO_SLOT_ID(flags);
     trb_type type = cmd->type;
@@ -410,7 +410,7 @@ static void handle_config_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd
                                         ? udev->max_exit_latency_us - eld
                                         : 0;
         udev->mel_retry_count++;
-        KprintfH("COMP_MEL_ERR slot %lu: eld=%lu new_mel=%lu retry=%lu\n",
+        KprintfT("COMP_MEL_ERR slot %lu: eld=%lu new_mel=%lu retry=%lu\n",
                  (ULONG)udev->slot_id, (ULONG)eld,
                  (ULONG)udev->max_exit_latency_us, (ULONG)udev->mel_retry_count);
         xhci_update_mel_in_input_ctx(udev);
@@ -420,13 +420,13 @@ static void handle_config_ep(struct xhci_ctrl *ctrl, struct pending_command *cmd
 
     if (comp != COMP_SUCCESS)
     {
-        KprintfH("ERROR: %s command for slot %lu returned completion code 0x%lx.\n", type_name, (ULONG)slot_id, (ULONG)comp);
+        KprintfT("ERROR: %s command for slot %lu returned completion code 0x%lx.\n", type_name, (ULONG)slot_id, (ULONG)comp);
         if (cmd->type == TRB_EVAL_CONTEXT && cmd->udev)
             xhci_udev_op_cancel(cmd->udev, UDEV_OP_LPM_ENABLE, ERR_NO_ERROR);
         return;
     }
 
-    KprintfH("%s command for slot %lu completed successfully\n", type_name, (ULONG)slot_id);
+    KprintfT("%s command for slot %lu completed successfully\n", type_name, (ULONG)slot_id);
 
     cmd->udev->mel_retry_count = 0;
 
@@ -454,7 +454,7 @@ static void handle_enable_slot(struct xhci_ctrl *ctrl, struct pending_command *c
     const u32 status = le32(event->event_cmd.status);
     const u32 flags = le32(event->event_cmd.flags);
 
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)flags);
+    KprintfT("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)flags);
     if (GET_COMP_CODE(status) != COMP_SUCCESS)
     {
         Kprintf("ERROR: Enable Slot command failed.\n");
@@ -468,13 +468,13 @@ static void handle_enable_slot(struct xhci_ctrl *ctrl, struct pending_command *c
     udev->slot_id = slot_id & 0xffU;
     udev->slot_state = USB_DEV_SLOT_STATE_ENABLED;
     ctrl->devices_by_slot_id[slot_id] = udev;
-    KprintfH("assigned slot_id=%lu for addr=%lu\n", (ULONG)slot_id, (ULONG)udev->virtual_address);
+    KprintfT("assigned slot_id=%lu for addr=%lu\n", (ULONG)slot_id, (ULONG)udev->virtual_address);
 
     /* Point to output device context in dcbaa. */
     ctrl->dcbaa->dev_context_ptrs[slot_id] = le64((dma_addr_t)udev->out_ctx->bytes);
 
     xhci_flush_cache(&ctrl->dcbaa->dev_context_ptrs[slot_id], sizeof(__le64), 0);
-    KprintfH("DCBAA[%lu]=%lx\n", (ULONG)slot_id, (ULONG)le64(ctrl->dcbaa->dev_context_ptrs[slot_id]));
+    KprintfT("DCBAA[%lu]=%lx\n", (ULONG)slot_id, (ULONG)le64(ctrl->dcbaa->dev_context_ptrs[slot_id]));
 
     // Continue with Address Device command, passing cmd->req
     xhci_address_device(udev, cmd->req);
@@ -486,7 +486,7 @@ static void handle_disable_slot(struct xhci_ctrl *ctrl, struct pending_command *
     const u32 status = le32(event->event_cmd.status);
     const xhci_comp_code comp = GET_COMP_CODE(status);
 
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)le32(event->event_cmd.flags));
+    KprintfT("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)le32(event->event_cmd.flags));
     if (comp != COMP_SUCCESS)
     {
         Kprintf("ERROR: Disable Slot command failed for slot %lu (comp=%lu).\n",
@@ -494,7 +494,7 @@ static void handle_disable_slot(struct xhci_ctrl *ctrl, struct pending_command *
     }
     else
     {
-        KprintfH("Disabled slot %lu successfully (comp=%lu).\n", (ULONG)cmd->udev->slot_id, (ULONG)comp);
+        KprintfT("Disabled slot %lu successfully (comp=%lu).\n", (ULONG)cmd->udev->slot_id, (ULONG)comp);
     }
     cmd->udev->slot_state = USB_DEV_SLOT_STATE_DISABLED;
     xhci_udev_free(cmd->udev);
@@ -506,7 +506,7 @@ static void handle_address_device(struct xhci_ctrl *ctrl, struct pending_command
     const u32 status = le32(event->event_cmd.status);
     const xhci_comp_code comp = GET_COMP_CODE(status);
 
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)le32(event->event_cmd.flags));
+    KprintfT("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)le32(event->event_cmd.flags));
 
     s8 err = ERR_NO_ERROR;
     switch (comp)
@@ -525,7 +525,7 @@ static void handle_address_device(struct xhci_ctrl *ctrl, struct pending_command
         err = ERR_BAD_PARAMETERS;
         break;
     case COMP_SUCCESS:
-        KprintfH("Successful Address Device command\n");
+        KprintfT("Successful Address Device command\n");
         break;
     default:
         Kprintf("ERROR: unexpected command completion code 0x%lx.\n",
@@ -554,7 +554,7 @@ static void handle_address_device(struct xhci_ctrl *ctrl, struct pending_command
 
     cmd->udev->xhci_address = xhci_get_hardware_address(cmd->udev) & 0xffU;
     cmd->udev->slot_state = USB_DEV_SLOT_STATE_ADDRESSED;
-    KprintfH("Assigned xHCI address %lu to slot %lu (Virtual address %lu)\n",
+    KprintfT("Assigned xHCI address %lu to slot %lu (Virtual address %lu)\n",
              (ULONG)cmd->udev->xhci_address, (ULONG)cmd->udev->slot_id, (cmd->req) ? (ULONG)cmd->req->virtual_address : (ULONG)0);
 
     /* Continue the original request after the device is addressed. */
@@ -586,14 +586,14 @@ static void handle_reset_device(struct xhci_ctrl *ctrl, struct pending_command *
 #endif
     const u32 status = le32(event->event_cmd.status);
 
-    KprintfH("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)le32(event->event_cmd.flags));
+    KprintfT("event status=%08lx flags=%08lx\n", (ULONG)status, (ULONG)le32(event->event_cmd.flags));
     if (GET_COMP_CODE(status) != COMP_SUCCESS)
     {
         Kprintf("ERROR: Reset Device command failed for slot %lu.\n", (ULONG)cmd->udev->slot_id);
         return;
     }
 
-    KprintfH("Reset Device for slot %lu completed successfully.\n", (ULONG)cmd->udev->slot_id);
+    KprintfT("Reset Device for slot %lu completed successfully.\n", (ULONG)cmd->udev->slot_id);
 }
 
 /*
@@ -776,7 +776,7 @@ void xhci_reset_ep(struct usb_device *udev, u8 ep_index)
 
     if (xhci_read_hw_ep_state(udev, ep_index) == EP_STATE_ERROR)
     {
-        KprintfH("EP %lu in Error state, skipping Reset Endpoint\n", (ULONG)ep_index);
+        KprintfT("EP %lu in Error state, skipping Reset Endpoint\n", (ULONG)ep_index);
         struct xhci_ring *ring = xhci_ep_get_ring(ep_ctx);
         xhci_set_deq_pointer(udev, ep_index, xhci_ring_get_new_dequeue_ptr(ring));
         return;
@@ -875,7 +875,7 @@ void xhci_disable_slot(struct usb_device *udev)
 
     if (udev->slot_state == USB_DEV_SLOT_STATE_DISABLED)
     {
-        KprintfH("queue DISABLE_SLOT skipped; slot_id=%lu already disabled\n", (ULONG)udev->slot_id);
+        KprintfT("queue DISABLE_SLOT skipped; slot_id=%lu already disabled\n", (ULONG)udev->slot_id);
         return;
     }
 
@@ -891,7 +891,7 @@ static void xhci_set_address(struct usb_device *udev, struct USBIORequest *req)
     /* If already addressed (internal address non-zero), don't re-issue. */
     if (udev->slot_state >= USB_DEV_SLOT_STATE_ADDRESSED)
     {
-        KprintfH("slot %lu already addressed (xhci_address=0x%lx), skipping.\n",
+        KprintfT("slot %lu already addressed (xhci_address=0x%lx), skipping.\n",
                  (ULONG)slot_id, (ULONG)udev->xhci_address);
         if (req)
             xhci_udev_io_reply_data(udev, req, ERR_NO_ERROR, 0);
@@ -908,7 +908,7 @@ static void xhci_set_address(struct usb_device *udev, struct USBIORequest *req)
      */
     xhci_setup_addressable_virt_dev(udev);
 
-    KprintfH("queue ADDR_DEV cmd, in_ctx->bytes=%lx addr=%lu slot=%lu parent_addr=%lu parent_port=%lu route=0x%lx, depth=%lu\n",
+    KprintfT("queue ADDR_DEV cmd, in_ctx->bytes=%lx addr=%lu slot=%lu parent_addr=%lu parent_port=%lu route=0x%lx, depth=%lu\n",
              (ULONG)udev->in_ctx->bytes,
              (ULONG)udev->virtual_address,
              (ULONG)slot_id,
@@ -917,7 +917,7 @@ static void xhci_set_address(struct usb_device *udev, struct USBIORequest *req)
              (ULONG)udev->route,
              (ULONG)udev->route_depth);
 
-#ifdef DEBUG_HIGH
+#ifdef TRACE
     /* Dump parent hub's slot context so we can verify DEV_HUB is set */
     if (udev->parent && udev->parent->out_ctx && udev->parent->slot_id != 0)
         xhci_dump_slot_ctx("[xhci-commands] ADDR_DEV parent hub:", udev->parent, FALSE);
@@ -947,7 +947,7 @@ void xhci_address_device(struct usb_device *udev, struct USBIORequest *req)
     /* If we don't have a slot yet, enable one and allocate Virt Dev */
     if (udev->slot_id == 0)
     {
-        KprintfH("no slot_id yet; enabling slot...\n");
+        KprintfT("no slot_id yet; enabling slot...\n");
         xhci_enable_slot(udev, req);
         return;
     }

--- a/xhci.device/src/xhci/xhci-context.c
+++ b/xhci.device/src/xhci/xhci-context.c
@@ -42,9 +42,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci-context] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci-context] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci-context] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 /**
@@ -290,7 +290,7 @@ static BOOL xhci_hub_multi_tt_enabled(struct usb_device *hub)
 void xhci_setup_addressable_virt_dev(struct usb_device *udev)
 {
     struct xhci_ctrl *ctrl = udev->controller;
-    KprintfH("Setting up addressable virtual device addr=%lu parent_addr=%lu parent_port=%lu\n",
+    KprintfT("Setting up addressable virtual device addr=%lu parent_addr=%lu parent_port=%lu\n",
              (ULONG)udev->virtual_address,
              (ULONG)(udev->parent ? udev->parent->virtual_address : 0),
              (ULONG)udev->parent_port);
@@ -299,7 +299,7 @@ void xhci_setup_addressable_virt_dev(struct usb_device *udev)
     /* Extract the EP0 and Slot Ctrl */
     struct xhci_ep_ctx *ep0_ctx = xhci_get_ep_ctx(ctrl, udev->in_ctx, 0);
     struct xhci_slot_ctx *slot_ctx = xhci_get_slot_ctx(ctrl, udev->in_ctx);
-    KprintfH("slot=%lu in_ctx=%lx out_ctx=%lx ep0_ctx=%lx slot_ctx=%lx\n",
+    KprintfT("slot=%lu in_ctx=%lx out_ctx=%lx ep0_ctx=%lx slot_ctx=%lx\n",
              (ULONG)udev->slot_id, (ULONG)udev->in_ctx, (ULONG)udev->out_ctx,
              (ULONG)ep0_ctx, (ULONG)slot_ctx);
 
@@ -334,7 +334,7 @@ void xhci_setup_addressable_virt_dev(struct usb_device *udev)
     // Find root hub port number
     u32 root_port = xhci_find_root_port(udev);
 
-    KprintfH("xhci_setup_addressable_virt_dev: parent_addr=%lu port_num=%lu root_port_num=%lu speed=%lu route=%lx route_depth=%lu\n",
+    KprintfT("xhci_setup_addressable_virt_dev: parent_addr=%lu port_num=%lu root_port_num=%lu speed=%lu route=%lx route_depth=%lu\n",
              (ULONG)udev->parent->virtual_address, (ULONG)udev->parent_port, (ULONG)root_port, (ULONG)udev->speed, (ULONG)udev->route, (ULONG)udev->route_depth);
 
     u32 dev_info2 = le32(slot_ctx->dev_info2);
@@ -363,7 +363,7 @@ void xhci_setup_addressable_virt_dev(struct usb_device *udev)
                     slot_ctx->dev_info = le32(dev_info);
                 }
 
-                KprintfH("xhci_setup_addressable_virt_dev: tt_slot=%lu tt_port=%lu tt_info=%08lx mtt=%ld\n",
+                KprintfT("xhci_setup_addressable_virt_dev: tt_slot=%lu tt_port=%lu tt_info=%08lx mtt=%ld\n",
                          (ULONG)tt_hub->slot_id, (ULONG)parent_port, (ULONG)tt_info,
                          (LONG)((dev_info & DEV_MTT) != 0));
                 break;
@@ -386,7 +386,7 @@ void xhci_setup_addressable_virt_dev(struct usb_device *udev)
     /* Step 4 - ring already allocated */
     /* Step 5 */
     ep0_ctx->ep_info2 = le32(EP_TYPE(CTRL_EP));
-    KprintfH("xhci_setup_addressable_virt_dev: SPEED=%lu\n", (ULONG)udev->speed);
+    KprintfT("xhci_setup_addressable_virt_dev: SPEED=%lu\n", (ULONG)udev->speed);
 
     u32 max_packet_size = 0;
     switch (udev->speed)
@@ -395,19 +395,19 @@ void xhci_setup_addressable_virt_dev(struct usb_device *udev)
     case USB_SPEED_SUPER_PLUS:
         ep0_ctx->ep_info2 |= le32(MAX_PACKET(512));
         max_packet_size = 512;
-        KprintfH("xhci_setup_addressable_virt_dev: MPS=512\n");
+        KprintfT("xhci_setup_addressable_virt_dev: MPS=512\n");
         break;
     case USB_SPEED_HIGH:
     /* USB core guesses at a 64-byte max packet first for FS devices */
     case USB_SPEED_FULL:
         ep0_ctx->ep_info2 |= le32(MAX_PACKET(64));
         max_packet_size = 64;
-        KprintfH("xhci_setup_addressable_virt_dev: MPS=64\n");
+        KprintfT("xhci_setup_addressable_virt_dev: MPS=64\n");
         break;
     case USB_SPEED_LOW:
         ep0_ctx->ep_info2 |= le32(MAX_PACKET(8));
         max_packet_size = 8;
-        KprintfH("xhci_setup_addressable_virt_dev: MPS=8\n");
+        KprintfT("xhci_setup_addressable_virt_dev: MPS=8\n");
         break;
     default:
         /* New speed? */
@@ -435,7 +435,7 @@ void xhci_setup_addressable_virt_dev(struct usb_device *udev)
 
     xhci_flush_cache(ep0_ctx, sizeof(struct xhci_ep_ctx), 0);
     xhci_flush_cache(slot_ctx, sizeof(struct xhci_slot_ctx), 0);
-    KprintfH("xhci_setup_addressable_virt_dev: ep0 deq=%lx tx_info=%08lx dev_info=%08lx dev_info2=%08lx\n",
+    KprintfT("xhci_setup_addressable_virt_dev: ep0 deq=%lx tx_info=%08lx dev_info=%08lx dev_info2=%08lx\n",
              (ULONG)le64(ep0_ctx->deq), (ULONG)le32(ep0_ctx->tx_info),
              (ULONG)le32(slot_ctx->dev_info), (ULONG)le32(slot_ctx->dev_info2));
 
@@ -504,19 +504,19 @@ void xhci_update_maxpacket(struct usb_device *udev, u16 max_packet_size)
     u8 ep_index = 0; /* control endpoint */
 
     xhci_inval_cache(udev->out_ctx->bytes, udev->out_ctx->size);
-    KprintfH("Checking max packet size for ep 0 of address %lu (slot %lu)\n", (ULONG)udev->virtual_address, (ULONG)udev->slot_id);
+    KprintfT("Checking max packet size for ep 0 of address %lu (slot %lu)\n", (ULONG)udev->virtual_address, (ULONG)udev->slot_id);
 
     struct xhci_ep_ctx *ep_ctx = xhci_get_ep_ctx(ctrl, udev->out_ctx, ep_index);
     u16 hw_max_packet_size = (u16)MAX_PACKET_DECODED(le32(ep_ctx->ep_info2));
 
     if (hw_max_packet_size == max_packet_size)
     {
-        KprintfH("Max Packet Size for ep 0 is already correct at %lu.\n", (ULONG)max_packet_size);
+        KprintfT("Max Packet Size for ep 0 is already correct at %lu.\n", (ULONG)max_packet_size);
         return;
     }
 
-    KprintfH("Max Packet Size for ep 0 changed to %lu.\n", (ULONG)max_packet_size);
-    KprintfH("Max packet size in xHCI HW = %lu\n", (ULONG)hw_max_packet_size);
+    KprintfT("Max Packet Size for ep 0 changed to %lu.\n", (ULONG)max_packet_size);
+    KprintfT("Max packet size in xHCI HW = %lu\n", (ULONG)hw_max_packet_size);
 
     // Update the EP context's max packet size as well
     struct ep_context *ep_context = xhci_ep_get_context_for_index(udev, ep_index);
@@ -553,7 +553,7 @@ void xhci_update_maxpacket(struct usb_device *udev, u16 max_packet_size)
 static s8 xhci_init_ep_contexts_if(struct usb_device *udev, struct usb_interface *ifdesc)
 {
     struct xhci_ctrl *ctrl = udev->controller;
-    KprintfH("xhci_init_ep_contexts_if: enter\n");
+    KprintfT("xhci_init_ep_contexts_if: enter\n");
     struct xhci_ep_ctx *ep_ctx[USB_MAX_ENDPOINT_CONTEXTS];
     u8 cur_ep;
     u8 ep_index;
@@ -647,7 +647,7 @@ static s8 xhci_init_ep_contexts_if(struct usb_device *udev, struct usb_interface
             avg_trb_len = 8;
         ep_ctx[ep_index]->tx_info = le32(EP_MAX_ESIT_PAYLOAD_LO(max_esit_payload) | EP_AVG_TRB_LENGTH(avg_trb_len));
 
-        KprintfH("EP%lu %s: type=%lu maxp=%lu maxesit=%lu "
+        KprintfT("EP%lu %s: type=%lu maxp=%lu maxesit=%lu "
                  "interval=%lu mult=%lu maxburst=%lu\n",
                  (ULONG)usb_endpoint_num(endpt_desc),
                  dir ? "IN" : "OUT",
@@ -717,7 +717,7 @@ static void xhci_compute_and_apply_mel(struct usb_device *udev)
  */
 s8 xhci_set_configuration(struct usb_device *udev, u32 config_value)
 {
-    KprintfH("xhci_set_configuration: config_val=%lu\n", (ULONG)config_value);
+    KprintfT("xhci_set_configuration: config_val=%lu\n", (ULONG)config_value);
 
     struct usb_config *cfg = xhci_find_config(udev, (int)config_value);
     if (!cfg)
@@ -730,7 +730,7 @@ s8 xhci_set_configuration(struct usb_device *udev, u32 config_value)
     for (u8 i = 0; i < cfg->no_of_if; ++i)
         xhci_select_active_alt(&cfg->if_desc[i]);
 
-#ifdef DEBUG_HIGH
+#ifdef TRACE
     /* Dump entire cfg using kprintf (all fields and all interfaces and endpoints) */
     xhci_dump_config("[xhci] xhci_set_configuration:", cfg, udev->virtual_address);
 #endif
@@ -801,7 +801,7 @@ s8 xhci_set_interface(struct usb_device *udev, u8 iface_number, u8 alt_setting)
 
     if (current_alt && current_alt->desc.bAlternateSetting == alt_setting)
     {
-        KprintfH("xhci_set_interface: iface %lu already at alt %lu\n",
+        KprintfT("xhci_set_interface: iface %lu already at alt %lu\n",
                  (ULONG)iface_number, (ULONG)alt_setting);
         return ERR_NO_ERROR;
     }
@@ -857,7 +857,7 @@ s8 xhci_set_interface(struct usb_device *udev, u8 iface_number, u8 alt_setting)
     u32 max_ep_flag = compute_max_ep_flag(cfg);
     xhci_update_slot_last_ctx(ctrl, udev, max_ep_flag);
 
-    KprintfH("xhci_set_interface: updating device context for addr=%lu iface=%lu alt=%lu drop=0x%lx add=0x%lx\n",
+    KprintfT("xhci_set_interface: updating device context for addr=%lu iface=%lu alt=%lu drop=0x%lx add=0x%lx\n",
              (ULONG)udev->virtual_address,
              (ULONG)iface_number,
              (ULONG)alt_setting,
@@ -1033,7 +1033,7 @@ void xhci_evaluate_mel(struct usb_device *udev)
     struct xhci_slot_ctx *slot = xhci_get_slot_ctx(ctrl, udev->in_ctx);
     slot->dev_state = 0;
 
-    KprintfH("Evaluate Context: MEL=%lu us for addr %lu (slot %lu)\n",
+    KprintfT("Evaluate Context: MEL=%lu us for addr %lu (slot %lu)\n",
              (ULONG)udev->max_exit_latency_us, (ULONG)udev->virtual_address,
              (ULONG)udev->slot_id);
     xhci_configure_endpoints(udev, TRUE, NULL);

--- a/xhci.device/src/xhci/xhci-descriptors.c
+++ b/xhci.device/src/xhci/xhci-descriptors.c
@@ -19,9 +19,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci-descriptors] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci-descriptors] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci-descriptors] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 /**
@@ -113,7 +113,7 @@ u32 xhci_collect_config_masks(const struct usb_config *cfg, u32 limit, u32 *max_
         if (!active_alt)
             continue;
 
-        KprintfH("Preparing iface=%lu alt=%lu\n", (ULONG)ifnum, (ULONG)active_alt->desc.bAlternateSetting);
+        KprintfT("Preparing iface=%lu alt=%lu\n", (ULONG)ifnum, (ULONG)active_alt->desc.bAlternateSetting);
 
         mask |= xhci_collect_ep_mask(active_alt, max_flag);
     }
@@ -129,7 +129,7 @@ struct usb_config *xhci_find_config(struct usb_device *udev, int config_value)
     for (struct MinNode *node = udev->configurations.mlh_Head; node->mln_Succ != NULL; node = node->mln_Succ)
     {
         struct usb_config *cfg = (struct usb_config *)node;
-        KprintfH("  found config: bConfigurationValue=%lu\n", (ULONG)cfg->desc.bConfigurationValue);
+        KprintfT("  found config: bConfigurationValue=%lu\n", (ULONG)cfg->desc.bConfigurationValue);
         if (cfg->desc.bConfigurationValue == config_value)
             return cfg;
     }
@@ -187,9 +187,9 @@ static u8 xhci_microframes_to_exponent(u32 desc_interval,
 {
     u32 interval = log2_floor_u64(desc_interval);
     interval = clamp_val(interval, min_exponent, max_exponent);
-#ifdef DEBUG_HIGH
+#ifdef TRACE
     if ((1U << interval) != desc_interval)
-        KprintfH("rounding interval to %lu microframes, ep desc says %lu microframes\n",
+        KprintfT("rounding interval to %lu microframes, ep desc says %lu microframes\n",
                  (ULONG)(1U << interval), (ULONG)desc_interval);
 #endif
 
@@ -283,7 +283,7 @@ u8 xhci_get_endpoint_interval(struct usb_device *udev, struct usb_endpoint_descr
          * since it uses the same rules as low speed interrupt
          * endpoints.
          */
-        /*fallthrough;*/
+        __attribute__((fallthrough));
     case USB_SPEED_LOW:
         if (usb_endpoint_xfer_int(endpt_desc) ||
             usb_endpoint_xfer_isoc(endpt_desc))
@@ -497,7 +497,7 @@ static BOOL parse_interface_descriptor(struct cfg_parse_state *st, struct usb_in
     CopyMem(ifd, &st->current_alt->desc, sizeof(struct usb_interface_descriptor));
     st->current_alt->no_of_ep = 0;
 
-    KprintfH("interface %lu alt %lu: bInterfaceNumber=%lu bAlternateSetting=%lu bNumEndpoints=%lu bInterfaceClass=0x%02lx bInterfaceSubClass=0x%02lx bInterfaceProtocol=0x%02lx iInterface=%lu\n",
+    KprintfT("interface %lu alt %lu: bInterfaceNumber=%lu bAlternateSetting=%lu bNumEndpoints=%lu bInterfaceClass=0x%02lx bInterfaceSubClass=0x%02lx bInterfaceProtocol=0x%02lx iInterface=%lu\n",
              (ULONG)st->if_index,
              (ULONG)st->current_alt_index,
              (ULONG)ifd->bInterfaceNumber,
@@ -530,7 +530,7 @@ static void parse_endpoint_descriptor(struct cfg_parse_state *st, struct usb_end
 
     u32 ep_idx = st->current_alt->no_of_ep;
     CopyMem(epd, &st->current_alt->ep_desc[ep_idx], sizeof(struct usb_endpoint_descriptor));
-    KprintfH("  endpoint %lu: bEndpointAddress=0x%02lx bmAttributes=0x%02lx wMaxPacketSize=%lu bInterval=%lu\n",
+    KprintfT("  endpoint %lu: bEndpointAddress=0x%02lx bmAttributes=0x%02lx wMaxPacketSize=%lu bInterval=%lu\n",
              (ULONG)ep_idx,
              (ULONG)epd->bEndpointAddress,
              (ULONG)epd->bmAttributes,
@@ -544,7 +544,7 @@ static void parse_endpoint_descriptor(struct cfg_parse_state *st, struct usb_end
  * it follows. */
 static void parse_ss_ep_comp_descriptor(struct cfg_parse_state *st, struct usb_ss_ep_comp_descriptor *comp)
 {
-    KprintfH("found SS EP COMP descriptor\n");
+    KprintfT("found SS EP COMP descriptor\n");
     if (st->current_if && st->current_alt && st->current_alt->no_of_ep > 0)
     {
         u32 ep_slot = (u32)(st->current_alt->no_of_ep - 1U);
@@ -559,7 +559,7 @@ void xhci_parse_config_descriptor(struct usb_device *udev, u8 *data, u16 len)
 {
     if (len < 2)
     {
-        KprintfH("too short, len=%lu\n", (ULONG)len);
+        KprintfT("too short, len=%lu\n", (ULONG)len);
         return;
     }
 
@@ -580,7 +580,7 @@ void xhci_parse_config_descriptor(struct usb_device *udev, u8 *data, u16 len)
     u16 total_len = le16(desc->wTotalLength);
     if (len < total_len)
     {
-        KprintfH("short buffer len=%lu total_len=%lu\n", (ULONG)len, (ULONG)total_len);
+        KprintfT("short buffer len=%lu total_len=%lu\n", (ULONG)len, (ULONG)total_len);
         return;
     }
 
@@ -595,7 +595,7 @@ void xhci_parse_config_descriptor(struct usb_device *udev, u8 *data, u16 len)
     CopyMem(desc, &conf->desc, sizeof(struct usb_config_descriptor));
     cursor += desc->bLength;
 
-    KprintfH("wTotalLength=%lu bNumInterfaces=%lu bConfigurationValue=%lu iConfiguration=%lu bmAttributes=0x%02lx bMaxPower=%lu\n",
+    KprintfT("wTotalLength=%lu bNumInterfaces=%lu bConfigurationValue=%lu iConfiguration=%lu bmAttributes=0x%02lx bMaxPower=%lu\n",
              (ULONG)le16(desc->wTotalLength),
              (ULONG)desc->bNumInterfaces,
              (ULONG)desc->bConfigurationValue,
@@ -644,13 +644,13 @@ void xhci_parse_config_descriptor(struct usb_device *udev, u8 *data, u16 len)
             break;
         default:
             // Skip class- or vendor-specific descriptors gracefully.
-            KprintfH("found class/vendor-specific descriptor 0x%lx, len=%lu\n", (ULONG)dtype, (ULONG)dlen);
+            KprintfT("found class/vendor-specific descriptor 0x%lx, len=%lu\n", (ULONG)dtype, (ULONG)dlen);
             break;
         }
 
         cursor += dlen;
     }
-    KprintfH("parsed config with %lu interfaces\n", (ULONG)conf->no_of_if);
+    KprintfT("parsed config with %lu interfaces\n", (ULONG)conf->no_of_if);
 
     if (conf->no_of_if != desc->bNumInterfaces)
     {
@@ -664,7 +664,7 @@ void xhci_parse_config_descriptor(struct usb_device *udev, u8 *data, u16 len)
         struct usb_config *oldconf = (struct usb_config *)n;
         if (oldconf->desc.bConfigurationValue == conf->desc.bConfigurationValue)
         {
-            KprintfH("removing old config with value %lu\n", (ULONG)oldconf->desc.bConfigurationValue);
+            KprintfT("removing old config with value %lu\n", (ULONG)oldconf->desc.bConfigurationValue);
             RemoveMinNode(n);
             pool_free(udev->controller->metaPool, oldconf);
             break;

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -31,9 +31,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci-endpoint] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci-endpoint] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci-endpoint] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 struct ep_context
@@ -106,7 +106,7 @@ static void xhci_ep_transition(struct ep_context *ep_ctx, enum ep_state new_stat
 {
     if (ep_ctx->state != new_state)
     {
-        KprintfH("EP %lu state %lu -> %lu\n", (ULONG)ep_ctx->ep_index,
+        KprintfT("EP %lu state %lu -> %lu\n", (ULONG)ep_ctx->ep_index,
                  (ULONG)ep_ctx->state, (ULONG)new_state);
     }
     ep_ctx->state = new_state;
@@ -161,7 +161,7 @@ void xhci_ep_destroy_contexts(struct usb_device *udev, s8 reply_code)
         struct ep_context *ep_ctx = udev->ep_context[i];
         if (ep_ctx)
         {
-            KprintfH("tearing down addr %lu EP %lu context, state %lu\n", (ULONG)udev->virtual_address, (ULONG)i, (ULONG)ep_ctx->state);
+            KprintfT("tearing down addr %lu EP %lu context, state %lu\n", (ULONG)udev->virtual_address, (ULONG)i, (ULONG)ep_ctx->state);
             struct MinNode *node;
             while ((node = RemHeadMinList(&ep_ctx->pending_reqs)) != NULL)
             {
@@ -253,7 +253,7 @@ void xhci_ep_enqueue(struct ep_context *ep_ctx, struct USBIORequest *io)
         AddTailMinList(&ep_ctx->pending_reqs, (struct MinNode *)io);
     }
 
-    KprintfH("Ring busy, queued request cmd=%lu ep=%lu\n",
+    KprintfT("Ring busy, queued request cmd=%lu ep=%lu\n",
              (ULONG)io->req.io_Command,
              (ULONG)(io->endpoint & 0x0F));
 }
@@ -265,7 +265,7 @@ static void xhci_ep_schedule_next(struct ep_context *ep_ctx)
     {
         struct USBIORequest *req = (struct USBIORequest *)node;
 
-        KprintfH("starting queued request cmd=%lu ep=%lu\n",
+        KprintfT("starting queued request cmd=%lu ep=%lu\n",
                  (ULONG)req->req.io_Command,
                  (ULONG)(req->endpoint & 0x0F));
 
@@ -447,7 +447,7 @@ void xhci_ep_request_stop(struct ep_context *ep_ctx)
         state != USB_DEV_EP_STATE_RT_ISO_RUNNING)
         return;
 
-    KprintfH("EP %lu state %lu -> ABORTING (stop requested)\n", (ULONG)ep_ctx->ep_index, (ULONG)state);
+    KprintfT("EP %lu state %lu -> ABORTING (stop requested)\n", (ULONG)ep_ctx->ep_index, (ULONG)state);
     xhci_ep_set_aborting(ep_ctx);
     xhci_stop_ring(ep_ctx->udev, ep_ctx->ep_index);
 }
@@ -693,15 +693,15 @@ s8 xhci_ep_rt_iso_add_handler(struct ep_context *ep_ctx, struct USBIORequest *re
     ep_ctx->rt->hooks = (struct USBRealtimeHooks *)req->data_buffer;
     ep_ctx->rt->direction = req->direction;
 
-#ifdef DEBUG_HIGH
+#ifdef TRACE
     struct USBRealtimeHooks *rt = (struct USBRealtimeHooks *)req->data_buffer;
     if (req->direction == DIRECTION_IN)
     {
-        KprintfH("Added ISO handler: EP %lu in req hook: %lx, in done hook: %lx, prefetch: %lu\n", (ULONG)ep_ctx->ep_index, (ULONG)rt->input_request_hook, (ULONG)rt->input_done_hook, (ULONG)rt->max_output_prefetch);
+        KprintfT("Added ISO handler: EP %lu in req hook: %lx, in done hook: %lx, prefetch: %lu\n", (ULONG)ep_ctx->ep_index, (ULONG)rt->input_request_hook, (ULONG)rt->input_done_hook, (ULONG)rt->max_output_prefetch);
     }
     else
     {
-        KprintfH("Added ISO handler: EP %lu out req hook: %lx, out done hook: %lx, prefetch: %lu\n", (ULONG)ep_ctx->ep_index, (ULONG)rt->output_request_hook, (ULONG)rt->output_done_hook, (ULONG)rt->max_output_prefetch);
+        KprintfT("Added ISO handler: EP %lu out req hook: %lx, out done hook: %lx, prefetch: %lu\n", (ULONG)ep_ctx->ep_index, (ULONG)rt->output_request_hook, (ULONG)rt->output_done_hook, (ULONG)rt->max_output_prefetch);
     }
 #endif
     return ERR_NO_ERROR;
@@ -731,7 +731,7 @@ s8 xhci_ep_rt_iso_rem_handler(struct ep_context *ep_ctx, struct USBIORequest *re
     pool_free(ep_ctx->udev->controller->metaPool, ep_ctx->rt);
     ep_ctx->rt = NULL;
     xhci_ep_set_idle(ep_ctx);
-    KprintfH("Successfully removed ISO handler (state reset to IDLE)\n");
+    KprintfT("Successfully removed ISO handler (state reset to IDLE)\n");
     return ERR_NO_ERROR;
 }
 
@@ -803,7 +803,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
         rt_buffer_req.flags = 0;
         rt_buffer_req.frame = frame; /* monotonic frame counter to avoid jumps */
 
-        KprintfH("RT ISO OUT sched frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
+        KprintfT("RT ISO OUT sched frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
                  (ULONG)rt_buffer_req.length,
                  (ULONG)ep_ctx->rt->inflight_bytes,
@@ -813,7 +813,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
 
         if (!rt_buffer_req.data || rt_buffer_req.length == 0)
         {
-            KprintfH("RT ISO hook provided no buffer/length\n");
+            KprintfT("RT ISO hook provided no buffer/length\n");
             break;
         }
 
@@ -841,7 +841,7 @@ static void xhci_ep_schedule_rt_iso_out(struct ep_context *ep_ctx)
 
         ep_ctx->rt->next_uframe = (u16)(((u32)ep_ctx->rt->next_uframe + ep_ctx->rt_uframes_per_esit) & RT_ISO_UF_MASK);
         ep_ctx->rt->inflight_bytes += length;
-        KprintfH("RT ISO OUT queued frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
+        KprintfT("RT ISO OUT queued frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
                  (ULONG)length,
                  (ULONG)ep_ctx->rt->inflight_bytes,
@@ -878,7 +878,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
             break;
         }
 
-        KprintfH("RT ISO IN sched frame=%lu maxpkt=%lu inflight_bytes=%lu inflight_tds=%lu\n",
+        KprintfT("RT ISO IN sched frame=%lu maxpkt=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
                  (ULONG)packet_size,
                  (ULONG)ep_ctx->rt->inflight_bytes,
@@ -898,7 +898,7 @@ static void xhci_ep_schedule_rt_iso_in(struct ep_context *ep_ctx)
 
         ep_ctx->rt->next_uframe = (u16)(((u32)ep_ctx->rt->next_uframe + ep_ctx->rt_uframes_per_esit) & RT_ISO_UF_MASK);
         ep_ctx->rt->inflight_bytes += packet_size;
-        KprintfH("RT ISO IN queued frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
+        KprintfT("RT ISO IN queued frame=%lu len=%lu inflight_bytes=%lu inflight_tds=%lu\n",
                  (ULONG)frame,
                  (ULONG)packet_size,
                  (ULONG)ep_ctx->rt->inflight_bytes,
@@ -985,7 +985,7 @@ s8 xhci_ep_rt_iso_start(struct ep_context *ep_ctx)
         ep_ctx->rt->in_staging_active = TRUE;
     }
 
-    KprintfH("Starting RT ISO stream: IST=%lu uframes rt_next_uframe=%lu target_ms=%lu target_uframes=%lu uframes_per_td=%lu target_tds=%lu\n",
+    KprintfT("Starting RT ISO stream: IST=%lu uframes rt_next_uframe=%lu target_ms=%lu target_uframes=%lu uframes_per_td=%lu target_tds=%lu\n",
              (ULONG)ep_ctx->rt->ist,
              (ULONG)ep_ctx->rt->next_uframe,
              (ULONG)RT_ISO_IN_TARGET_FRAMES,
@@ -1026,7 +1026,7 @@ s8 xhci_ep_rt_iso_stop(struct ep_context *ep_ctx, struct USBIORequest *req)
     }
     else
     {
-        KprintfH("RT ISO stopping addr=%lu ep=%lu inflight_tds=%lu inflight_bytes=%lu\n",
+        KprintfT("RT ISO stopping addr=%lu ep=%lu inflight_tds=%lu inflight_bytes=%lu\n",
                  (ULONG)req->virtual_address,
                  (ULONG)ep_ctx->ep_index,
                  (ULONG)xhci_ep_get_active_td_count(ep_ctx),

--- a/xhci.device/src/xhci/xhci-endpoint.c
+++ b/xhci.device/src/xhci/xhci-endpoint.c
@@ -258,22 +258,6 @@ void xhci_ep_enqueue(struct ep_context *ep_ctx, struct USBIORequest *io)
              (ULONG)(io->endpoint & 0x0F));
 }
 
-BOOL xhci_ep_has_request(struct ep_context *ep_ctx, struct USBIORequest *io)
-{
-    if (!ep_ctx || !io)
-        return FALSE;
-
-    struct MinNode *node = ep_ctx->pending_reqs.mlh_Head;
-    while (node && node->mln_Succ)
-    {
-        if ((struct USBIORequest *)node == io)
-            return TRUE;
-        node = node->mln_Succ;
-    }
-
-    return xhci_td_has_request(ep_ctx->active_tds, io);
-}
-
 static void xhci_ep_schedule_next(struct ep_context *ep_ctx)
 {
     struct MinNode *node;

--- a/xhci.device/src/xhci/xhci-events.c
+++ b/xhci.device/src/xhci/xhci-events.c
@@ -41,9 +41,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci-event] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci-event] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci-event] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 typedef void (*ep_state_handler)(struct usb_device *udev, struct ep_context *ep_ctx, union xhci_trb *event);
@@ -82,14 +82,14 @@ static void dispatch_ep_event(struct usb_device *udev, union xhci_trb *event)
     struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
     if (!ep_ctx)
     {
-        KprintfH("No ep context for addr %lu ep %lu\n", (ULONG)udev->virtual_address, (ULONG)ep_index);
+        KprintfT("No ep context for addr %lu ep %lu\n", (ULONG)udev->virtual_address, (ULONG)ep_index);
         return;
     }
     enum ep_state state = xhci_ep_get_state(ep_ctx);
 
     if (ep_state_dispatch[state])
     {
-        KprintfH("addr %lu EP %lu state %lu -> handling event\n", (ULONG)udev->virtual_address, (ULONG)ep_index, (ULONG)state);
+        KprintfT("addr %lu EP %lu state %lu -> handling event\n", (ULONG)udev->virtual_address, (ULONG)ep_index, (ULONG)state);
         ep_state_handler handler = ep_state_dispatch[state];
         handler(udev, ep_ctx, event);
     }
@@ -114,7 +114,7 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
         {
             const u32 flags = le32(event->trans_event.flags);
             const u32 slot = TRB_TO_SLOT_ID(flags);
-            KprintfH("Transfer Event TRB detected: slot %lu ep %lu (%08lx %08lx %08lx %08lx)\n",
+            KprintfT("Transfer Event TRB detected: slot %lu ep %lu (%08lx %08lx %08lx %08lx)\n",
                      (ULONG)slot,
                      (ULONG)TRB_TO_EP_INDEX(flags),
                      (ULONG)le32(event->generic.field[0]),
@@ -128,7 +128,7 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
                 Kprintf("No usb_device for slot %lu\n", (ULONG)slot);
                 break;
             }
-            KprintfH("USB device addr %lu on slot %lu\n", (ULONG)udev->virtual_address, (ULONG)slot);
+            KprintfT("USB device addr %lu on slot %lu\n", (ULONG)udev->virtual_address, (ULONG)slot);
 
             dispatch_ep_event(udev, event);
         }
@@ -140,7 +140,7 @@ BOOL xhci_process_event_trb(struct xhci_ctrl *ctrl)
 
         case TRB_PORT_STATUS:
         {
-#ifdef DEBUG_HIGH
+#ifdef TRACE
             const u32 port_field = le32(event->generic.field[0]);
             const u32 field1 = le32(event->generic.field[1]);
             const u32 field2 = le32(event->generic.field[2]);
@@ -194,7 +194,7 @@ void xhci_process_event_timeouts(struct xhci_ctrl *ctrl)
             struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
             if (ep_ctx && xhci_ep_is_expired(ep_ctx))
             {
-                KprintfH("XHCI TD timeout on slot %lu ep %lu\n", (ULONG)udev->slot_id, (ULONG)ep_index);
+                KprintfT("XHCI TD timeout on slot %lu ep %lu\n", (ULONG)udev->slot_id, (ULONG)ep_index);
                 xhci_ep_request_timeout_recovery(ep_ctx);
             }
         }
@@ -218,7 +218,7 @@ inline static s8 translate_status(xhci_comp_code comp)
         status = ERR_NO_ERROR;
         break;
     case COMP_STALL:
-        KprintfH("Device stalled\n");
+        KprintfT("Device stalled\n");
         status = ERR_DEVICE_STALL;
         break;
     case COMP_TX_ERR:
@@ -235,19 +235,19 @@ inline static s8 translate_status(xhci_comp_code comp)
         status = ERR_HCI_ERROR;
         break;
     case COMP_BABBLE:
-        KprintfH("Babble detected\n");
+        KprintfT("Babble detected\n");
         status = ERR_DEVICE_BABBLE;
         break;
     case COMP_BUFF_OVER:
-        KprintfH("Isoc buffer overrun\n");
+        KprintfT("Isoc buffer overrun\n");
         status = ERR_ISOC_OVERRUN;
         break;
     case COMP_BW_OVER:
-        KprintfH("Bandwidth overrun\n");
+        KprintfT("Bandwidth overrun\n");
         status = ERR_HCI_ERROR;
         break;
     case COMP_SPLIT_ERR:
-        KprintfH("Split transaction error\n");
+        KprintfT("Split transaction error\n");
         status = ERR_TIMEOUT;
         break;
     default:
@@ -273,7 +273,7 @@ static void ep_handle_default(struct usb_device *udev, struct ep_context *ep_ctx
     const u8 ep_index = xhci_ep_get_ep_index(ep_ctx);
 
     Kprintf("No handler for addr %lu endpoint %lu state %lu\n", (ULONG)udev->virtual_address, (ULONG)ep_index, (ULONG)state);
-    KprintfH("Event TRB: (%08lx %08lx %08lx %08lx)\n",
+    KprintfT("Event TRB: (%08lx %08lx %08lx %08lx)\n",
              (ULONG)le32(event->generic.field[0]),
              (ULONG)le32(event->generic.field[1]),
              (ULONG)le32(event->generic.field[2]),
@@ -291,7 +291,7 @@ static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_conte
     const xhci_comp_code comp = GET_COMP_CODE(transfer_len);
 
 #ifdef DEBUG_CONTEXT
-    KprintfH("event flags=%08lx xfer_len=%08lx buf=%08lx%08lx\n",
+    KprintfT("event flags=%08lx xfer_len=%08lx buf=%08lx%08lx\n",
              (ULONG)flags,
              (ULONG)transfer_len,
              (ULONG)u64_hi32(trb_addr),
@@ -352,7 +352,7 @@ static void ep_handle_receiving_generic(struct usb_device *udev, struct ep_conte
     u32 act_len = done.act_len;
 
     s8 status = translate_status(comp);
-    KprintfH("result status=%ld act_len=%lu comp=%lu\n", (LONG)status, (ULONG)act_len, (ULONG)comp);
+    KprintfT("result status=%ld act_len=%lu comp=%lu\n", (LONG)status, (ULONG)act_len, (ULONG)comp);
 
     /* Flag short IN transfers as runts unless explicitly allowed or expected (control). */
     if (status == ERR_NO_ERROR && act_len < req->data_buffer_length &&
@@ -402,7 +402,7 @@ static void ep_handle_suspended(struct usb_device *udev, struct ep_context *ep_c
 
     if (comp == COMP_STOP || comp == COMP_STOP_INVAL || comp == COMP_STOP_SHORT)
     {
-        KprintfH("addr %lu EP %lu stopped for suspend (comp=%lu)\n",
+        KprintfT("addr %lu EP %lu stopped for suspend (comp=%lu)\n",
                  (ULONG)udev->virtual_address,
                  (ULONG)xhci_ep_get_ep_index(ep_ctx), (ULONG)comp);
         return;
@@ -426,13 +426,13 @@ static void ep_handle_aborting(struct usb_device *udev, struct ep_context *ep_ct
     switch(comp)
     {
         case COMP_STOP:
-            KprintfH("Transfer stopped successfully\n");
+            KprintfT("Transfer stopped successfully\n");
             break;
         case COMP_STOP_INVAL:
-            KprintfH("Transfer stopped with invalid length\n");
+            KprintfT("Transfer stopped with invalid length\n");
             break;
         case COMP_STOP_SHORT:
-            KprintfH("Transfer stopped after short packet\n");
+            KprintfT("Transfer stopped after short packet\n");
             break;
         default:
             Kprintf("Expected a TRB with STOP, got %lu\n", (ULONG)comp);

--- a/xhci.device/src/xhci/xhci-hub.c
+++ b/xhci.device/src/xhci/xhci-hub.c
@@ -33,9 +33,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci-hub] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci-hub] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci-hub] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 static enum usb_device_speed xhci_hub_speed_from_port_status(u16 status)
@@ -86,7 +86,7 @@ static void xhci_hub_cache_ss_hub_descriptor(struct usb_device *udev, struct usb
         len = (u8)(actual < sizeof(struct usb_hub_descriptor) ? actual : sizeof(struct usb_hub_descriptor));
 
     CopyMem(hub, &udev->ss_hub_desc, len);
-    KprintfH("Cached SS hub descriptor for addr %lu with %lu ports\n",
+    KprintfT("Cached SS hub descriptor for addr %lu with %lu ports\n",
              (ULONG)udev->virtual_address, (ULONG)hub->bNbrPorts);
 }
 
@@ -102,7 +102,7 @@ static void xhci_hub_set_ss_hub_depth(struct usb_device *udev)
     if (udev->ss_hub_depth_set)
         return;
 
-    KprintfH("SS hub addr=%lu route=0x%lx -> SET_HUB_DEPTH depth=%lu\n",
+    KprintfT("SS hub addr=%lu route=0x%lx -> SET_HUB_DEPTH depth=%lu\n",
              (ULONG)udev->virtual_address, (ULONG)udev->route, (ULONG)udev->route_depth);
 
     xhci_udev_send_control_request(udev,
@@ -151,45 +151,45 @@ static void xhci_hub_map_ss_port_status(u16 *wStatus, u16 *wChange, enum usb_dev
 
     if ((*wStatus & PORT_PLS_MASK) == XDEV_U3)
     {
-        KprintfH("SS hub: PLS=U3 detected, mapping to USB_PORT_STAT_SUSPEND\n");
+        KprintfT("SS hub: PLS=U3 detected, mapping to USB_PORT_STAT_SUSPEND\n");
         wStatusNew |= USB_PORT_STAT_SUSPEND;
     }
     if (*wStatus & USB_SS_PORT_STAT_POWER)
     {
-        KprintfH("SS hub: POWER bit set, mapping to USB_PORT_STAT_POWER\n");
+        KprintfT("SS hub: POWER bit set, mapping to USB_PORT_STAT_POWER\n");
         wStatusNew |= USB_PORT_STAT_POWER;
     }
 
     switch (speed)
     {
     case USB_SPEED_LOW:
-        KprintfH("SS hub: detected LowSpeed device, mapping to USB_PORT_STAT_LOW_SPEED\n");
+        KprintfT("SS hub: detected LowSpeed device, mapping to USB_PORT_STAT_LOW_SPEED\n");
         wStatusNew |= USB_PORT_STAT_LOW_SPEED;
         break;
     case USB_SPEED_FULL:
-        KprintfH("SS hub: detected FullSpeed device\n");
+        KprintfT("SS hub: detected FullSpeed device\n");
         break;
     case USB_SPEED_HIGH:
-        KprintfH("SS hub: detected HighSpeed device, mapping to USB_PORT_STAT_HIGH_SPEED\n");
+        KprintfT("SS hub: detected HighSpeed device, mapping to USB_PORT_STAT_HIGH_SPEED\n");
         wStatusNew |= USB_PORT_STAT_HIGH_SPEED;
         break;
     default:
-        KprintfH("SS hub: detected SuperSpeed device, mapping to USB_PORT_STAT_HIGH_SPEED for compatibility\n");
+        KprintfT("SS hub: detected SuperSpeed device, mapping to USB_PORT_STAT_HIGH_SPEED for compatibility\n");
         wStatusNew |= USB_PORT_STAT_HIGH_SPEED;
         break;
     }
 
-    KprintfH("SS hub: mapped status 0x%04lx -> 0x%04lx\n", (ULONG)*wStatus, (ULONG)wStatusNew);
+    KprintfT("SS hub: mapped status 0x%04lx -> 0x%04lx\n", (ULONG)*wStatus, (ULONG)wStatusNew);
 
     u16 wChangeNew = *wChange & (USB_PORT_STAT_C_CONNECTION | USB_PORT_STAT_C_OVERCURRENT | USB_PORT_STAT_C_RESET);
 
     if (*wChange & USB_SS_PORT_STAT_C_LINK_STATE && ((*wStatus & PORT_PLS_MASK) == XDEV_U0))
     {
-        KprintfH("SS hub: C_LINK_STATE detected and PLS=U0, mapping to C_SUSPEND\n");
+        KprintfT("SS hub: C_LINK_STATE detected and PLS=U0, mapping to C_SUSPEND\n");
         wChangeNew |= USB_PORT_STAT_C_SUSPEND;
     }
 
-    KprintfH("SS hub: mapped change 0x%04lx -> 0x%04lx\n", (ULONG)*wChange, (ULONG)wChangeNew);
+    KprintfT("SS hub: mapped change 0x%04lx -> 0x%04lx\n", (ULONG)*wChange, (ULONG)wChangeNew);
     *wStatus = wStatusNew;
     *wChange = wChangeNew;
 }
@@ -303,7 +303,7 @@ void xhci_hub_translate_descriptor_request(struct usb_device *udev, struct USBIO
     u16 old_value = le16(setup->wValue);
     setup->wValue = le16((USB_DT_SS_HUB << 8) | (old_value & 0xFF));
 
-    KprintfH("SS hub addr=%lu: modified wValue from 0x%04lx (USB_DT_HUB) to 0x%04lx (USB_DT_SS_HUB)\n",
+    KprintfT("SS hub addr=%lu: modified wValue from 0x%04lx (USB_DT_HUB) to 0x%04lx (USB_DT_SS_HUB)\n",
              (ULONG)udev->virtual_address, (ULONG)old_value, (ULONG)le16(setup->wValue));
 
     /* Return FALSE to let the request proceed normally - it will be translated back in parse */
@@ -316,7 +316,7 @@ void xhci_hub_handle_get_descriptor(struct usb_device *udev, struct USBIORequest
         return;
 
     struct usb_hub_descriptor *hub = (struct usb_hub_descriptor *)io->data_buffer;
-    KprintfH("Hub Descriptor: bLength=%lu bDescriptorType=%lu bNbrPorts=%lu wHubCharacteristics=0x%04lx bPwrOn2PwrGood=%lu bHubContrCurrent=%lu\n",
+    KprintfT("Hub Descriptor: bLength=%lu bDescriptorType=%lu bNbrPorts=%lu wHubCharacteristics=0x%04lx bPwrOn2PwrGood=%lu bHubContrCurrent=%lu\n",
              (ULONG)hub->bLength,
              (ULONG)hub->bDescriptorType,
              (ULONG)hub->bNbrPorts,
@@ -329,7 +329,7 @@ void xhci_hub_handle_get_descriptor(struct usb_device *udev, struct USBIORequest
     {
         const u16 characteristics = le16(hub->wHubCharacteristics);
         udev->tt_think_time = (u8)((characteristics >> 5) & 0x3);
-        KprintfH("hub addr %lu TT think time code=%lu (bit-times=%lu)\n",
+        KprintfT("hub addr %lu TT think time code=%lu (bit-times=%lu)\n",
                  (ULONG)udev->virtual_address, (ULONG)udev->tt_think_time, (ULONG)((udev->tt_think_time + 1) * 8));
     }
 
@@ -338,7 +338,7 @@ void xhci_hub_handle_get_descriptor(struct usb_device *udev, struct USBIORequest
     /* If this is an SS hub descriptor response, cache it */
     if (descriptorType == USB_DT_SS_HUB)
     {
-        KprintfH("SS hub addr=%lu: caching USB3 hub descriptor (len=%lu)\n", (ULONG)udev->virtual_address, (ULONG)io->actual_length);
+        KprintfT("SS hub addr=%lu: caching USB3 hub descriptor (len=%lu)\n", (ULONG)udev->virtual_address, (ULONG)io->actual_length);
         xhci_hub_cache_ss_hub_descriptor(udev, hub, io->actual_length);
         xhci_hub_set_ss_hub_depth(udev);
 
@@ -347,7 +347,7 @@ void xhci_hub_handle_get_descriptor(struct usb_device *udev, struct USBIORequest
         {
             /* Build USB 2.0 descriptor from the SS descriptor we just cached */
             io->actual_length = xhci_hub_build_usb2_hub_descriptor(udev, (u8 *)io->data_buffer, io->data_buffer_length);
-            KprintfH("SS hub addr=%lu: translated USB3 descriptor to USB2 format. Size %lu bytes\n", (ULONG)udev->virtual_address, (ULONG)io->actual_length);
+            KprintfT("SS hub addr=%lu: translated USB3 descriptor to USB2 format. Size %lu bytes\n", (ULONG)udev->virtual_address, (ULONG)io->actual_length);
         }
     }
 }
@@ -376,7 +376,7 @@ void xhci_hub_handle_get_port_status(struct usb_device *udev, struct USBIOReques
         ((u16 *)io->data_buffer)[1] = le16(wChange);
     }
 
-    KprintfH("hub addr=%lu port=%lu status=%04lx change=%04lx\n", (ULONG)udev->virtual_address, (ULONG)port, (ULONG)wStatus, (ULONG)wChange);
+    KprintfT("hub addr=%lu port=%lu status=%04lx change=%04lx\n", (ULONG)udev->virtual_address, (ULONG)port, (ULONG)wStatus, (ULONG)wChange);
 
     /* Tear down any existing child as soon as the port is powered-but-disabled,
      * otherwise re-enumeration races the stale slot/context we still own. */
@@ -388,12 +388,12 @@ void xhci_hub_handle_get_port_status(struct usb_device *udev, struct USBIOReques
 
     if (port_lost_child)
     {
-        KprintfH("hub addr=%lu port=%lu lost power, disconnected, or disabled; removing child if any\n",
+        KprintfT("hub addr=%lu port=%lu lost power, disconnected, or disabled; removing child if any\n",
                  (ULONG)udev->virtual_address, (ULONG)port);
         struct usb_device *child = xhci_udev_find_child_on_port(udev, port);
         if (child)
         {
-            KprintfH("hub addr=%lu port=%lu tearing down child addr=%lu slot=%lu before re-enumeration\n",
+            KprintfT("hub addr=%lu port=%lu tearing down child addr=%lu slot=%lu before re-enumeration\n",
                      (ULONG)udev->virtual_address, (ULONG)port, (ULONG)child->virtual_address, (ULONG)child->slot_id);
             xhci_udev_disconnect(child, TRUE);
         }
@@ -411,7 +411,7 @@ void xhci_hub_handle_get_port_status(struct usb_device *udev, struct USBIOReques
                           USB_SS_PORT_STAT_C_BH_RESET |
                           USB_SS_PORT_STAT_C_LINK_STATE)))
         {
-            KprintfH("hub addr=%lu port=%lu speed=%lu SS attach ready; remembering for pending attach (raw_status=%04lx)\n",
+            KprintfT("hub addr=%lu port=%lu speed=%lu SS attach ready; remembering for pending attach (raw_status=%04lx)\n",
                      (ULONG)udev->virtual_address, (ULONG)port, (ULONG)speed, (ULONG)rawStatus);
             ctrl->pending_parent = udev;
             ctrl->pending_parent_port = port;
@@ -421,7 +421,7 @@ void xhci_hub_handle_get_port_status(struct usb_device *udev, struct USBIOReques
     /* USB 2.0 enables device after reset completes */
     else if ((wChange & USB_PORT_STAT_C_RESET) && (wStatus & (USB_PORT_STAT_CONNECTION | USB_PORT_STAT_ENABLE)))
     {
-        KprintfH("hub addr=%lu port=%lu speed=%lu reset-complete; remembering for pending attach (status=%04lx)\n",
+        KprintfT("hub addr=%lu port=%lu speed=%lu reset-complete; remembering for pending attach (status=%04lx)\n",
                  (ULONG)udev->virtual_address, (ULONG)port, (ULONG)speed, (ULONG)wStatus);
         ctrl->pending_parent = udev;
         ctrl->pending_parent_port = port;

--- a/xhci.device/src/xhci/xhci-lpm.c
+++ b/xhci.device/src/xhci/xhci-lpm.c
@@ -36,9 +36,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci-lpm] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci-lpm] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci-lpm] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 /* BESL selector (0-15) to microseconds — USB 2.0 LPM ECN Table; identical to
@@ -144,7 +144,7 @@ u32 xhci_calculate_mel(struct usb_device *udev)
     u32 mel_us = (mel_ns + 999u) / 1000u;
     if (mel_us > 0xffffU)
         mel_us = 0xffffU;
-    KprintfH("Calculated MEL for addr %lu: %lu us (u1_mel=%lu u2_mel=%lu ns)\n",
+    KprintfT("Calculated MEL for addr %lu: %lu us (u1_mel=%lu u2_mel=%lu ns)\n",
              (ULONG)udev->virtual_address, (ULONG)mel_us,
              (ULONG)udev->u1_mel, (ULONG)udev->u2_mel);
     return mel_us;
@@ -282,7 +282,7 @@ static void xhci_set_lpm_parameters(struct usb_device *udev)
     udev->u1_sel = udev->u1_pel + sel_extra;
     udev->u2_sel = udev->u2_pel + sel_extra;
 
-    KprintfH("LPM params addr %lu: U1 sel=%lu pel=%lu mel=%lu | U2 sel=%lu pel=%lu mel=%lu (ns)\n",
+    KprintfT("LPM params addr %lu: U1 sel=%lu pel=%lu mel=%lu | U2 sel=%lu pel=%lu mel=%lu (ns)\n",
              (ULONG)udev->virtual_address,
              (ULONG)udev->u1_sel, (ULONG)udev->u1_pel, (ULONG)udev->u1_mel,
              (ULONG)udev->u2_sel, (ULONG)udev->u2_pel, (ULONG)udev->u2_mel);
@@ -297,7 +297,7 @@ void xhci_lpm_parse_bos_caps(struct usb_device *udev, const u8 *buf, u32 len)
     if (!buf || hdr->bDescriptorType != USB_DT_BOS)
         return;
 
-    KprintfH("BOS descriptor total length is %lu, num device caps is %lu\n",
+    KprintfT("BOS descriptor total length is %lu, num device caps is %lu\n",
              (ULONG)le16(hdr->wTotalLength), (ULONG)hdr->bNumDeviceCaps);
     const u8 *cursor = buf + sizeof(struct usb_bos_descriptor);
     const u8 *end = buf + (u32)le16(hdr->wTotalLength);
@@ -328,7 +328,7 @@ void xhci_lpm_parse_bos_caps(struct usb_device *udev, const u8 *buf, u32 len)
                     udev->besl_baseline = (u8)USB_20_EXTENSION_ATT_BESL_BASELINE(att);
                 if (udev->besl_deep_valid)
                     udev->besl_deep = (u8)USB_20_EXTENSION_ATT_BESL_DEEP(att);
-                KprintfH("USB2 Ext Cap: lpm=%ld besl=%ld baseline=%lu(v=%ld) deep=%lu(v=%ld)\n",
+                KprintfT("USB2 Ext Cap: lpm=%ld besl=%ld baseline=%lu(v=%ld) deep=%lu(v=%ld)\n",
                          (LONG)udev->lpm_capable, (LONG)udev->besl_supported,
                          (ULONG)udev->besl_baseline, (LONG)udev->besl_baseline_valid,
                          (ULONG)udev->besl_deep, (LONG)udev->besl_deep_valid);
@@ -341,17 +341,17 @@ void xhci_lpm_parse_bos_caps(struct usb_device *udev, const u8 *buf, u32 len)
                 udev->u1_dev_exit_lat = ss->bU1DevExitLat;
                 udev->u2_dev_exit_lat = le16(ss->wU2DevExitLat);
                 udev->ltm_capable = (ss->bmAttributes & USB_SS_DEVICE_ATT_LATENCY_TOLERANCE_MESSAGES) != 0;
-                KprintfH("SS Dev Cap: U1=%lu U2=%lu\n",
+                KprintfT("SS Dev Cap: U1=%lu U2=%lu\n",
                          (ULONG)udev->u1_dev_exit_lat, (ULONG)udev->u2_dev_exit_lat);
             }
         }
 
         cursor += caplen;
     }
-    KprintfH("Finished parsing BOS device capabilities for addr=%lu\n", (ULONG)udev->virtual_address);
-    KprintfH("Device LPM capability: %ld, BESL support: %ld, BESL baseline: %lu\n",
+    KprintfT("Finished parsing BOS device capabilities for addr=%lu\n", (ULONG)udev->virtual_address);
+    KprintfT("Device LPM capability: %ld, BESL support: %ld, BESL baseline: %lu\n",
              (LONG)udev->lpm_capable, (LONG)udev->besl_supported, (ULONG)udev->besl_baseline);
-    KprintfH("Device U1 exit latency: %lu us, U2 exit latency: %lu us\n",
+    KprintfT("Device U1 exit latency: %lu us, U2 exit latency: %lu us\n",
              (ULONG)udev->u1_dev_exit_lat, (ULONG)udev->u2_dev_exit_lat);
 
     /* For SS devices, LPM capability comes from the SS Device Cap exit
@@ -437,7 +437,7 @@ static BOOL xhci_udev_send_set_sel(struct usb_device *udev)
         return FALSE;
     }
 
-    KprintfH("SET_SEL addr %lu: u1 sel=%lu pel=%lu, u2 sel=%lu pel=%lu (us)\n",
+    KprintfT("SET_SEL addr %lu: u1 sel=%lu pel=%lu, u2 sel=%lu pel=%lu (us)\n",
              (ULONG)udev->virtual_address, (ULONG)u1_sel, (ULONG)u1_pel,
              (ULONG)u2_sel, (ULONG)u2_pel);
     return TRUE;
@@ -454,7 +454,7 @@ static void xhci_udev_set_device_lpm(struct usb_device *udev, BOOL u2)
                                    0 /* wIndex */,
                                    0 /* wLength */,
                                    FALSE /* send now */);
-    KprintfH("SET_FEATURE %s_ENABLE addr %lu\n", u2 ? "U2" : "U1", (ULONG)udev->virtual_address);
+    KprintfT("SET_FEATURE %s_ENABLE addr %lu\n", u2 ? "U2" : "U1", (ULONG)udev->virtual_address);
 }
 
 /* Enable device-initiated Latency Tolerance Messaging via SET_FEATURE.
@@ -538,7 +538,7 @@ static void xhci_usb2_set_hw_lpm(struct usb_device *udev)
     xhci_roothub_set_usb2_hw_lpm(ctrl->root_hub, root_port, hird, udev->slot_id,
                                  besl_mode, besld, XHCI_L1_TIMEOUT);
 
-    KprintfH("USB2 HW LPM enabled: port %lu slot %lu hird=%lu besl_cap=%ld\n",
+    KprintfT("USB2 HW LPM enabled: port %lu slot %lu hird=%lu besl_cap=%ld\n",
              (ULONG)root_port, (ULONG)udev->slot_id, (ULONG)hird, (LONG)besl_mode);
 }
 

--- a/xhci.device/src/xhci/xhci-ring.c
+++ b/xhci.device/src/xhci/xhci-ring.c
@@ -31,9 +31,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci-ring] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci-ring] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci-ring] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 static inline void xhci_copy_to_bounce_buffer(CONST_APTR src, APTR dst, u32 size)
@@ -1279,7 +1279,7 @@ static inline u32 iso_burst_bits(struct usb_device *udev,
 
 inline static s8 enqueue_td_internal(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms, BOOL defer_doorbell, u32 iso_extra_bits)
 {
-	// #ifdef DEBUG_HIGH
+	// #ifdef TRACE
 	// 	xhci_dump_request("[xhci-ring] xhci_ring_enqueue_td: ", io);
 	// #endif
 	struct xhci_ctrl *ctrl = udev->controller;
@@ -1298,7 +1298,7 @@ inline static s8 enqueue_td_internal(struct usb_device *udev, struct USBIOReques
 	 * instead of queueing into a list nothing will ever drain. */
 	if (cur_state == USB_DEV_EP_STATE_FAILED)
 	{
-		KprintfH("Rejecting transfer, ep %lu failed\n", (ULONG)ep_index);
+		KprintfT("Rejecting transfer, ep %lu failed\n", (ULONG)ep_index);
 		io->req.io_Error = ERR_HCI_ERROR;
 		return ERR_HCI_ERROR;
 	}
@@ -1307,7 +1307,7 @@ inline static s8 enqueue_td_internal(struct usb_device *udev, struct USBIOReques
 		cur_state == USB_DEV_EP_STATE_RESETTING ||
 		cur_state == USB_DEV_EP_STATE_SUSPENDED)
 	{
-		KprintfH("Cannot submit transfer, ep in state %d\n", cur_state);
+		KprintfT("Cannot submit transfer, ep in state %d\n", cur_state);
 		xhci_ep_enqueue(udev_ep_ctx, io);
 		return ERR_NO_ERROR;
 	}
@@ -1320,7 +1320,7 @@ inline static s8 enqueue_td_internal(struct usb_device *udev, struct USBIOReques
 	u32 trb_buff_len = 0; // non-control only
 	u64 addr = 0;		  // non-control only
 	u32 num_trbs = xhci_ring_calc_num_trbs(ctrl, io, &trb_buff_len, &addr);
-	// KprintfH("Calculated num_trbs=%lu trb_buff_len=%lu addr=%lx\n", (ULONG)num_trbs, (ULONG)trb_buff_len, (ULONG)addr);
+	// KprintfT("Calculated num_trbs=%lu trb_buff_len=%lu addr=%lx\n", (ULONG)num_trbs, (ULONG)trb_buff_len, (ULONG)addr);
 
 	struct xhci_ring *ep_ring = xhci_ep_get_ring(udev_ep_ctx);
 	if (!ep_ring)
@@ -1331,17 +1331,17 @@ inline static s8 enqueue_td_internal(struct usb_device *udev, struct USBIOReques
 
 	if (!ring_has_room(ep_ring, udev_ep_ctx, num_trbs + 1))
 	{
-		KprintfH("Ring full ep=%lu needed %lu TRBs, attempting grow\n", (ULONG)ep_index, (ULONG)num_trbs);
+		KprintfT("Ring full ep=%lu needed %lu TRBs, attempting grow\n", (ULONG)ep_index, (ULONG)num_trbs);
 		if (!xhci_ring_grow(ctrl, ep_ring, XHCI_SEGMENTS_PER_RING))
 		{
-			KprintfH("Ring grow failed, queueing request\n");
+			KprintfT("Ring grow failed, queueing request\n");
 			xhci_ep_enqueue(udev_ep_ctx, io);
 			return ERR_NO_ERROR;
 		}
-		KprintfH("Ring grew, retrying room check\n");
+		KprintfT("Ring grew, retrying room check\n");
 		if (!ring_has_room(ep_ring, udev_ep_ctx, num_trbs + 1))
 		{
-			KprintfH("Still no room after grow, queueing\n");
+			KprintfT("Still no room after grow, queueing\n");
 			xhci_ep_enqueue(udev_ep_ctx, io);
 			return ERR_NO_ERROR;
 		}

--- a/xhci.device/src/xhci/xhci-root-hub.c
+++ b/xhci.device/src/xhci/xhci-root-hub.c
@@ -45,9 +45,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci_root_hub] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci_root_hub] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci_root_hub] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 #define STATUS_CHANGE_BITMAP_LENGTH 2 /* in bytes; supports up to 15 ports */
@@ -223,120 +223,120 @@ struct xhci_root_hub
 						 * the xHC manages root-port wake hardware itself) */
 };
 
-#ifdef DEBUG_HIGH
+#ifdef TRACE
 static void xhci_roothub_debug_port(struct xhci_root_hub *rh, u32 port)
 {
 	struct xhci_ctrl *ctrl = rh->udev->controller;
 	u32 portsc = mmio_read32(&ctrl->hcor->portregs[port].or_portsc);
-	KprintfH("port %lu status: 0x%08lx\n", (ULONG)port + 1, (ULONG)portsc);
+	KprintfT("port %lu status: 0x%08lx\n", (ULONG)port + 1, (ULONG)portsc);
 
 	if (portsc & PORT_CONNECT) // ROS
-		KprintfH("  device connected\n");
+		KprintfT("  device connected\n");
 	else
-		KprintfH("  no device\n");
+		KprintfT("  no device\n");
 
 	if (portsc & PORT_PE) // RW1CS don't disable 3.0 ports
-		KprintfH("  port enabled\n");
+		KprintfT("  port enabled\n");
 	else
-		KprintfH("  port disabled\n");
+		KprintfT("  port disabled\n");
 
 	if (portsc & PORT_OC) // RO
-		KprintfH("  over-current condition\n");
+		KprintfT("  over-current condition\n");
 
 	if (portsc & PORT_RESET) // RW1S
-		KprintfH("  port in reset\n");
+		KprintfT("  port in reset\n");
 	else
-		KprintfH("  port not in reset\n");
+		KprintfT("  port not in reset\n");
 
 	u32 pls = portsc & PORT_PLS_MASK; // RWS
 	switch (pls)
 	{
 	case XDEV_U0:
-		KprintfH("  link state: U0 (active)\n");
+		KprintfT("  link state: U0 (active)\n");
 		break;
 	case XDEV_U1:
-		KprintfH("  link state: U1\n");
+		KprintfT("  link state: U1\n");
 		break;
 	case XDEV_U2:
-		KprintfH("  link state: U2\n");
+		KprintfT("  link state: U2\n");
 		break;
 	case XDEV_U3:
-		KprintfH("  link state: U3 (suspended)\n");
+		KprintfT("  link state: U3 (suspended)\n");
 		break;
 	case XDEV_DISABLED:
-		KprintfH("  link state: Disabled\n");
+		KprintfT("  link state: Disabled\n");
 		break;
 	case XDEV_RXDETECT:
-		KprintfH("  link state: RxDetect\n");
+		KprintfT("  link state: RxDetect\n");
 		break;
 	case XDEV_INACTIVE:
-		KprintfH("  link state: Inactive\n");
+		KprintfT("  link state: Inactive\n");
 		break;
 	case XDEV_POLLING:
-		KprintfH("  link state: Polling\n");
+		KprintfT("  link state: Polling\n");
 		break;
 	case XDEV_RECOVERY:
-		KprintfH("  link state: Recovery\n");
+		KprintfT("  link state: Recovery\n");
 		break;
 	case XDEV_HOTRESET:
-		KprintfH("  link state: Hot Reset\n");
+		KprintfT("  link state: Hot Reset\n");
 		break;
 	case XDEV_COMPLIANCE:
-		KprintfH("  link state: Compliance Mode\n");
+		KprintfT("  link state: Compliance Mode\n");
 		break;
 	case XDEV_TESTMODE:
-		KprintfH("  link state: Test Mode\n");
+		KprintfT("  link state: Test Mode\n");
 		break;
 	case XDEV_RESUME:
-		KprintfH("  link state: Resume\n");
+		KprintfT("  link state: Resume\n");
 		break;
 	default:
-		KprintfH("  link state: unknown (%lu)\n", (ULONG)(pls >> 5));
+		KprintfT("  link state: unknown (%lu)\n", (ULONG)(pls >> 5));
 		break;
 	}
 
 	if (portsc & PORT_POWER) // RWS
-		KprintfH("  port has power\n");
+		KprintfT("  port has power\n");
 	else
-		KprintfH("  port has no power\n");
+		KprintfT("  port has no power\n");
 
 	u32 speed = (portsc & DEV_SPEED_MASK); // ROS
 	switch (speed)
 	{
 	case XDEV_FS:
-		KprintfH("  device speed: Full Speed\n");
+		KprintfT("  device speed: Full Speed\n");
 		break;
 	case XDEV_LS:
-		KprintfH("  device speed: Low Speed\n");
+		KprintfT("  device speed: Low Speed\n");
 		break;
 	case XDEV_HS:
-		KprintfH("  device speed: High Speed\n");
+		KprintfT("  device speed: High Speed\n");
 		break;
 	case XDEV_SS:
-		KprintfH("  device speed: Super Speed\n");
+		KprintfT("  device speed: Super Speed\n");
 		break;
 	default:
-		KprintfH("  device speed: unknown (%lu)\n", (ULONG)(speed >> 10));
+		KprintfT("  device speed: unknown (%lu)\n", (ULONG)(speed >> 10));
 		break;
 	}
 
 	if (portsc & PORT_CSC) // RW1CS connect or disconnect sets this to 1
-		KprintfH("  connect status change\n");
+		KprintfT("  connect status change\n");
 	if (portsc & PORT_PEC) // RW1CS set to 1 on transition to disabled from enabled USB 2.0 only
-		KprintfH("  port enable change\n");
+		KprintfT("  port enable change\n");
 	if (portsc & PORT_WRC) // RW1CS 1 when warm reset completes (WPR 1->0)
-		KprintfH("  warm reset change\n");
+		KprintfT("  warm reset change\n");
 	if (portsc & PORT_OCC) // RW1CS when OC transitions to 1
-		KprintfH("  over-current change\n");
+		KprintfT("  over-current change\n");
 	if (portsc & PORT_RC) // RW1CS 1 when reset completes (PR 1->0 or WR 1->0)
-		KprintfH("  reset change\n");
+		KprintfT("  reset change\n");
 	if (portsc & PORT_PLC) // RW1CS when PLS changes - 4.19.1
-		KprintfH("  port link state change\n");
+		KprintfT("  port link state change\n");
 	if (portsc & PORT_CEC) // RW1CS
-		KprintfH("  port config error change\n");
+		KprintfT("  port config error change\n");
 
 	if (portsc & PORT_WR) // RW1S
-		KprintfH("  warm reset in progress\n");
+		KprintfT("  warm reset in progress\n");
 }
 #endif
 
@@ -445,7 +445,7 @@ struct xhci_root_hub *xhci_roothub_create(struct usb_device *udev, io_reply_data
 
 	rh->udev->speed = rh->is_super_speed ? USB_SPEED_SUPER : USB_SPEED_HIGH;
 
-#ifdef DEBUG_HIGH
+#ifdef TRACE
 	for (u32 i = 0; i < ports; ++i)
 		xhci_roothub_debug_port(rh, i);
 #endif
@@ -505,7 +505,7 @@ void xhci_roothub_set_usb3_port_timeout(struct xhci_root_hub *rh, u32 port, BOOL
 	if (!rh || port == 0 || port > rh->num_ports)
 		return;
 
-	KprintfH("Setting USB3 port %lu timeout: U%lu timeout=%lu %s\n", (ULONG)port, (ULONG)(u2 ? 2 : 1),
+	KprintfT("Setting USB3 port %lu timeout: U%lu timeout=%lu %s\n", (ULONG)port, (ULONG)(u2 ? 2 : 1),
 			 (ULONG)timeout, u2 ? "x256 microseconds" : "microseconds");
 
 	volatile u32 *pmsc = &rh->udev->controller->hcor->portregs[port - 1].or_portpmsc;
@@ -534,7 +534,7 @@ void xhci_roothub_set_usb2_hw_lpm(struct xhci_root_hub *rh, u32 port, u8 hird, u
 
 	struct xhci_hcor_port_regs *pr = &rh->udev->controller->hcor->portregs[port - 1];
 
-	KprintfH("Setting USB2 hardware LPM on port %lu: HIRD=%u, slot ID=%u, BESL mode=%u, BESLD=%u, L1 timeout=%u microseconds\n",
+	KprintfT("Setting USB2 hardware LPM on port %lu: HIRD=%u, slot ID=%u, BESL mode=%u, BESLD=%u, L1 timeout=%u microseconds\n",
 			 (ULONG)port, (ULONG)hird, (ULONG)slot_id, (ULONG)besl_mode, (ULONG)besld, (ULONG)l1_timeout_us);
 
 	if (besl_mode)
@@ -620,13 +620,13 @@ void xhci_roothub_complete_int_request(struct xhci_root_hub *rh)
 			continue;
 
 		buffer[index] |= (u8)(1U << (((u32)port + 1U) & 7U));
-		KprintfH("port %lu status change detected: changebits=0x%08lx\n", (ULONG)(port + 1), (ULONG)change_bits);
+		KprintfT("port %lu status change detected: changebits=0x%08lx\n", (ULONG)(port + 1), (ULONG)change_bits);
 		change = TRUE;
 	}
 
 	if (!change)
 	{
-		KprintfH("no status change, not completing root hub interrupt\n");
+		KprintfT("no status change, not completing root hub interrupt\n");
 		return;
 	}
 
@@ -647,7 +647,7 @@ inline static void xhci_roothub_stall(struct USBIORequest *req)
 {
 	if (req)
 	{
-		KprintfH("stall\n");
+		KprintfT("stall\n");
 		req->actual_length = 0;
 		req->req.io_Error = ERR_DEVICE_STALL;
 	}
@@ -707,7 +707,7 @@ inline static void xhci_roothub_delay_ms(u32 milliseconds)
 
 static void xhci_roothub_handle_device_get_configuration(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
-	KprintfH("USB_REQ_GET_CONFIGURATION\n");
+	KprintfT("USB_REQ_GET_CONFIGURATION\n");
 	xhci_roothub_reply(req, &rh->descriptor.config.bConfigurationValue, 1);
 }
 
@@ -718,22 +718,22 @@ static void xhci_roothub_handle_device_get_descriptor(struct xhci_root_hub *rh, 
 	switch (le16(setup->wValue) >> 8)
 	{
 	case USB_DT_BOS:
-		KprintfH("get USB_DT_BOS\n");
+		KprintfT("get USB_DT_BOS\n");
 		xhci_roothub_reply(req, &rh->descriptor.bos, le16(rh->descriptor.bos.wTotalLength));
 		break;
 	case USB_DT_DEVICE:
-		KprintfH("get USB_DT_DEVICE\n");
+		KprintfT("get USB_DT_DEVICE\n");
 		if (rh->is_super_speed)
 			xhci_roothub_reply(req, &rh->descriptor.device_30, rh->descriptor.device_30.bLength);
 		else
 			xhci_roothub_reply(req, &rh->descriptor.device_20, rh->descriptor.device_20.bLength);
 		break;
 	case USB_DT_CONFIG:
-		KprintfH("get USB_DT_CONFIG\n");
+		KprintfT("get USB_DT_CONFIG\n");
 		xhci_roothub_reply(req, &rh->descriptor.config, le16(rh->descriptor.config.wTotalLength));
 		break;
 	case USB_DT_STRING:
-		KprintfH("get USB_DT_STRING\n");
+		KprintfT("get USB_DT_STRING\n");
 		switch (le16(setup->wValue) & 0xff)
 		{
 		case 0: /* Language */
@@ -758,7 +758,7 @@ static void xhci_roothub_handle_device_get_descriptor(struct xhci_root_hub *rh, 
 
 static void xhci_roothub_handle_device_get_status(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
-	KprintfH("USB_REQ_GET_STATUS\n");
+	KprintfT("USB_REQ_GET_STATUS\n");
 	/* Device GET_STATUS: bit0=self-powered, bit1=remote-wakeup */
 	u8 status[2] = {(u8)(1 | (rh->remote_wakeup ? 2 : 0)), 0};
 	xhci_roothub_reply(req, status, 2);
@@ -773,7 +773,7 @@ void xhci_roothub_set_port_u3(struct xhci_root_hub *rh, u8 port)
 		return;
 
 	xhci_port_set_link_state(rh->udev->controller->hcor, port, XDEV_U3);
-	KprintfH("port %lu -> U3 standby (endpoints stopped)\n", (ULONG)port);
+	KprintfT("port %lu -> U3 standby (endpoints stopped)\n", (ULONG)port);
 }
 
 /**
@@ -831,9 +831,9 @@ inline static void xhci_roothub_clear_port_change_bit(u16 wValue, u8 portNo, vol
 	/* Change bits are all write 1 to clear */
 	mmio_write32(port_status | status, addr);
 
-#ifdef DEBUG_HIGH
+#ifdef TRACE
 	port_status = mmio_read32(addr);
-	KprintfH("clear port %s change, actual port %lu status  = 0x%lx\n", port_change_bit, (ULONG)portNo, (ULONG)port_status);
+	KprintfT("clear port %s change, actual port %lu status  = 0x%lx\n", port_change_bit, (ULONG)portNo, (ULONG)port_status);
 #else
 	(void)port_change_bit;
 	(void)portNo;
@@ -856,7 +856,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 	const u16 wValue = le16(req->setup.wValue); // feature selector
 	const u16 wIndex = le16(req->setup.wIndex); // selector | port
 	const u8 portNo = wIndex & 0xffU;
-#ifdef DEBUG_HIGH
+#ifdef TRACE
 	xhci_roothub_debug_port(rh, portNo - 1u);
 #endif
 
@@ -868,7 +868,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 	{
 	// Common for USB2 and USB3 ports
 	case USB_PORT_FEAT_POWER:
-		KprintfH("Clear port %lu PORT_POWER\n", (ULONG)portNo);
+		KprintfT("Clear port %lu PORT_POWER\n", (ULONG)portNo);
 		reg &= ~PORT_POWER;
 		mmio_write32(reg, &port->or_portsc);
 		break;
@@ -899,7 +899,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 
 		// USB3 specific features
 	case USB_SS_PORT_FEAT_FORCE_LINKPM_ACCEPT:
-		KprintfH("Clear port %lu FORCE_LINKPM_ACCEPT\n", (ULONG)portNo);
+		KprintfT("Clear port %lu FORCE_LINKPM_ACCEPT\n", (ULONG)portNo);
 		reg = mmio_read32(&port->or_portpmsc);
 		reg &= ~PORT_FLA;
 		mmio_write32(reg, &port->or_portpmsc);
@@ -915,7 +915,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 
 	// USB2 specific features
 	case USB_PORT_FEAT_ENABLE:
-		KprintfH("Clear port %lu PORT_PE\n", (ULONG)portNo);
+		KprintfT("Clear port %lu PORT_PE\n", (ULONG)portNo);
 		if (rh->ports[portNo - 1].major_revision >= 3)
 		{
 			Kprintf("Can't disable USB 3.0 port\n");
@@ -929,7 +929,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 		}
 		break;
 	case USB_PORT_FEAT_SUSPEND:
-		KprintfH("Clear port %lu PORT_SUSPEND\n", (ULONG)portNo);
+		KprintfT("Clear port %lu PORT_SUSPEND\n", (ULONG)portNo);
 		/* For USB2, need to write 15 (XDEV_RESUME) first, wait 20ms, then write U0 */
 		if (rh->ports[portNo - 1].major_revision < 3)
 		{
@@ -958,7 +958,7 @@ static void xhci_roothub_handle_port_clear_feature(struct xhci_root_hub *rh, str
 static void xhci_roothub_handle_hub_get_descriptor(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
 	(void)rh;
-	KprintfH("USB_REQ_GET_DESCRIPTOR HUB\n");
+	KprintfT("USB_REQ_GET_DESCRIPTOR HUB\n");
 	const u16 wValue = le16(req->setup.wValue);
 	if (wValue >> 8 == USB_DT_SS_HUB && rh->is_super_speed)
 	{
@@ -979,7 +979,7 @@ static void xhci_roothub_handle_hub_get_descriptor(struct xhci_root_hub *rh, str
 static void xhci_roothub_handle_hub_get_status(struct xhci_root_hub *rh, struct USBIORequest *req)
 {
 	(void)rh;
-	KprintfH("USB_REQ_GET_STATUS HUB\n");
+	KprintfT("USB_REQ_GET_STATUS HUB\n");
 	/* Hub GET_STATUS: bit0=local power source, bit1=over-current */
 	u8 status[4] = {0, 0, 0, 0};
 	xhci_roothub_reply(req, status, 4);
@@ -1000,7 +1000,7 @@ static void xhci_roothub_handle_port_get_status(struct xhci_root_hub *rh, struct
 		return;
 	}
 
-#ifdef DEBUG_HIGH
+#ifdef TRACE
 	xhci_roothub_debug_port(rh, portNo - 1u);
 #endif
 
@@ -1079,7 +1079,7 @@ static void xhci_roothub_handle_port_get_status(struct xhci_root_hub *rh, struct
 		wPortChange |= USB_PORT_STAT_C_SUSPEND;
 
 	u8 tmpbuf[4] = {wPortStatus & 0xffU, (wPortStatus >> 8) & 0xffU, wPortChange & 0xffU, (wPortChange >> 8) & 0xffU};
-	KprintfH("USB_REQ_GET_STATUS PORT %lu status=0x%lx\n", (ULONG)portNo, (ULONG)reg);
+	KprintfT("USB_REQ_GET_STATUS PORT %lu status=0x%lx\n", (ULONG)portNo, (ULONG)reg);
 	xhci_roothub_reply(req, tmpbuf, 4);
 }
 
@@ -1104,7 +1104,7 @@ static void xhci_roothub_handle_get_port_error_count(struct xhci_root_hub *rh, s
 	struct xhci_hcor_port_regs *port = xhci_roothub_get_port(rh, req);
 	const u16 errors = mmio_read32(&port->or_portli) & 0xffff;
 
-	KprintfH("USB_REQ_GET_PORT_ERROR_COUNT PORT %lu error count=%u\n", (ULONG)wIndex, errors);
+	KprintfT("USB_REQ_GET_PORT_ERROR_COUNT PORT %lu error count=%u\n", (ULONG)wIndex, errors);
 	u8 tmpbuf[2] = {errors & 0xffU, (u8)(errors >> 8)};
 	xhci_roothub_reply(req, tmpbuf, 2);
 }
@@ -1115,7 +1115,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 	const u16 wIndex = le16(req->setup.wIndex);
 	const u8 portNo = wIndex & 0xffU;
 
-#ifdef DEBUG_HIGH
+#ifdef TRACE
 	xhci_roothub_debug_port(rh, portNo - 1u);
 #endif
 
@@ -1137,7 +1137,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 		 * reset still works after a warm reset. */
 		if (rh->ports[portNo - 1].major_revision >= 3)
 		{
-			KprintfH("SS port %lu warm reset (PLS=%lu portsc=%08lx)\n",
+			KprintfT("SS port %lu warm reset (PLS=%lu portsc=%08lx)\n",
 					 (ULONG)portNo, (ULONG)((reg & PORT_PLS_MASK) >> 5),
 					 (ULONG)mmio_read32(&port->or_portsc));
 
@@ -1180,7 +1180,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 				}
 				else
 				{
-					KprintfH("SS port %lu warm reset completed in %ld0ms "
+					KprintfT("SS port %lu warm reset completed in %ld0ms "
 							 "(portsc=%08lx)\n",
 							 (ULONG)portNo, (LONG)attempts, (ULONG)temp);
 				}
@@ -1188,7 +1188,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 		}
 		else
 		{
-			KprintfH("Set port %lu PORT_RESET\n", (ULONG)portNo);
+			KprintfT("Set port %lu PORT_RESET\n", (ULONG)portNo);
 			reg |= PORT_RESET;
 			mmio_write32(reg, &port->or_portsc);
 		}
@@ -1199,7 +1199,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 		break;
 	}
 	case USB_PORT_FEAT_POWER:
-		KprintfH("Set port %lu PORT_POWER\n", (ULONG)portNo);
+		KprintfT("Set port %lu PORT_POWER\n", (ULONG)portNo);
 		reg |= PORT_POWER;
 		mmio_write32(reg, &port->or_portsc);
 		break;
@@ -1212,19 +1212,19 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 
 	// USB3 specific features
 	case USB_SS_PORT_FEAT_BH_RESET:
-		KprintfH("Set port %lu PORT_BH_RESET\n", (ULONG)portNo);
+		KprintfT("Set port %lu PORT_BH_RESET\n", (ULONG)portNo);
 		reg |= PORT_WR;
 		mmio_write32(reg, &port->or_portsc);
 		break;
 	case USB_SS_PORT_FEAT_U1_TIMEOUT:
-		KprintfH("Setting port %lu U1 timeout to %lu microseconds\n", (ULONG)portNo, (ULONG)(wIndex >> 8));
+		KprintfT("Setting port %lu U1 timeout to %lu microseconds\n", (ULONG)portNo, (ULONG)(wIndex >> 8));
 		reg = mmio_read32(&port->or_portpmsc);
 		reg &= ~0xffU;
 		reg |= PORT_U1_TIMEOUT(wIndex >> 8);
 		mmio_write32(reg, &port->or_portpmsc);
 		break;
 	case USB_SS_PORT_FEAT_U2_TIMEOUT:
-		KprintfH("Setting port %lu U2 timeout to %lu microseconds\n", (ULONG)portNo, (ULONG)(wIndex >> 8));
+		KprintfT("Setting port %lu U2 timeout to %lu microseconds\n", (ULONG)portNo, (ULONG)(wIndex >> 8));
 		reg = mmio_read32(&port->or_portpmsc);
 		reg &= ~0xff00U;
 		reg |= PORT_U2_TIMEOUT(wIndex >> 8);
@@ -1233,7 +1233,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 	case USB_PORT_FEAT_LINK_STATE:
 	{
 		const u32 link_state = wIndex >> 8;
-		KprintfH("Set port %lu PORT_LINK_STATE to %lu\n", (ULONG)portNo, (ULONG)link_state);
+		KprintfT("Set port %lu PORT_LINK_STATE to %lu\n", (ULONG)portNo, (ULONG)link_state);
 		if (link_state <= 5 || link_state == 10)
 		{
 			reg &= ~PORT_PLS_MASK;
@@ -1252,14 +1252,14 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 	case USB_SS_PORT_FEAT_REMOTE_WAKE_MASK:
 	{
 		const u32 wake_mask = (wIndex >> 8) & 7;
-		KprintfH("Set port %lu REMOTE_WAKE_MASK to %lx\n", (ULONG)portNo, (ULONG)wake_mask);
+		KprintfT("Set port %lu REMOTE_WAKE_MASK to %lx\n", (ULONG)portNo, (ULONG)wake_mask);
 		reg &= ~(PORT_WKCONN_E | PORT_WKDISC_E | PORT_WKOC_E);
 		reg |= wake_mask << 25;
 		mmio_write32(reg, &port->or_portsc);
 		break;
 	}
 	case USB_SS_PORT_FEAT_FORCE_LINKPM_ACCEPT:
-		KprintfH("Set port %lu FORCE_LINKPM_ACCEPT\n", (ULONG)portNo);
+		KprintfT("Set port %lu FORCE_LINKPM_ACCEPT\n", (ULONG)portNo);
 		reg = mmio_read32(&port->or_portpmsc);
 		reg |= PORT_FLA;
 		mmio_write32(reg, &port->or_portpmsc);
@@ -1274,7 +1274,7 @@ static void xhci_roothub_handle_port_set_feature(struct xhci_root_hub *rh, struc
 		 * with nothing to stop: suspend immediately. */
 		if (xhci_udev_suspend_port(rh->udev, (u8)portNo))
 			break;
-		KprintfH("Putting port %lu link to U3 standby\n", (ULONG)portNo);
+		KprintfT("Putting port %lu link to U3 standby\n", (ULONG)portNo);
 		xhci_port_set_link_state(rh->udev->controller->hcor, portNo, XDEV_U3);
 		break;
 	case USB_PORT_FEAT_TEST:
@@ -1335,12 +1335,12 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct USBIORequ
 		xhci_roothub_handle_device_get_status(rh, io);
 		break;
 	case DeviceOutRequest | USB_REQ_SET_ADDRESS:
-		KprintfH("USB_REQ_SET_ADDRESS rootdev=%lu\n", (ULONG)wValue);
+		KprintfT("USB_REQ_SET_ADDRESS rootdev=%lu\n", (ULONG)wValue);
 		/* Do nothing, higher layer will handle context migration */
 		xhci_roothub_no_error(io);
 		break;
 	case DeviceOutRequest | USB_REQ_SET_CONFIGURATION:
-		KprintfH("USB_REQ_SET_CONFIGURATION\n");
+		KprintfT("USB_REQ_SET_CONFIGURATION\n");
 		/* Do nothing */
 		xhci_roothub_no_error(io);
 		break;
@@ -1355,19 +1355,19 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct USBIORequ
 			xhci_roothub_stall(io);
 		break;
 	case DeviceOutRequest | USB_REQ_SET_ISOCH_DELAY:
-		KprintfH("USB_REQ_SET_ISOCH_DELAY\n");
+		KprintfT("USB_REQ_SET_ISOCH_DELAY\n");
 		/* Do nothing */
 		xhci_roothub_no_error(io);
 		break;
 	case DeviceOutRequest | USB_REQ_SET_SEL:
-		KprintfH("USB_REQ_SET_SEL\n");
+		KprintfT("USB_REQ_SET_SEL\n");
 		/* Do nothing */
 		xhci_roothub_no_error(io);
 		break;
 
 	/* Hub class requests */
 	case ClearHubFeature:
-		KprintfH("CLEAR_FEATURE HUB feature=%lx\n", wValue);
+		KprintfT("CLEAR_FEATURE HUB feature=%lx\n", wValue);
 		/* The xHC handles hub power/over-current in hardware and our hub
 		 * GET_STATUS never reports the change bits - ACK as no-ops (mirrors
 		 * Linux rh_call_control). */
@@ -1389,11 +1389,11 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct USBIORequ
 		xhci_roothub_handle_port_get_status(rh, io);
 		break;
 	case GetPortErrorCount:
-		KprintfH("USB_REQ_GET_PORT_ERROR_COUNT\n");
+		KprintfT("USB_REQ_GET_PORT_ERROR_COUNT\n");
 		xhci_roothub_handle_get_port_error_count(rh, io);
 		break;
 	case SetHubFeature:
-		KprintfH("SET_FEATURE HUB feature=%lx\n", wValue);
+		KprintfT("SET_FEATURE HUB feature=%lx\n", wValue);
 		/* Same two features as ClearHubFeature; setting them is nonsensical
 		 * for a root hub but harmless - ACK (mirrors Linux). */
 		if (wValue == C_HUB_LOCAL_POWER || wValue == C_HUB_OVER_CURRENT)
@@ -1402,7 +1402,7 @@ void xhci_roothub_submit_ctrl_request(struct xhci_root_hub *rh, struct USBIORequ
 			xhci_roothub_stall(io);
 		break;
 	case SetHubDepth:
-		KprintfH("SET_HUB_DEPTH depth=%lx\n", wValue);
+		KprintfT("SET_HUB_DEPTH depth=%lx\n", wValue);
 		/* Do nothing */
 		xhci_roothub_no_error(io);
 		break;

--- a/xhci.device/src/xhci/xhci-td.c
+++ b/xhci.device/src/xhci/xhci-td.c
@@ -29,9 +29,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci-td] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci-td] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci-td] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 struct xhci_td
@@ -129,7 +129,7 @@ BOOL xhci_td_is_expired(TransferDescriptorList *td_list)
         struct xhci_td *td = (struct xhci_td *)n;
         if (td->deadline_active && (int32_t)(now - td->deadline_us) >= 0)
         {
-            KprintfH("Found expired TD req=%lx deadline=%lu now=%lu\n",
+            KprintfT("Found expired TD req=%lx deadline=%lu now=%lu\n",
                      td->is_rt_iso ? NULL : td->u.req,
                      (ULONG)td->deadline_us,
                      (ULONG)now);
@@ -538,7 +538,7 @@ BOOL xhci_td_complete_by_trb(TransferDescriptorList *td_list, dma_addr_t trb_add
                             ((trb_len > residue) ? trb_len - residue : 0);
         td->short_seen = TRUE;
         *deferred = TRUE;
-        KprintfH("mid-TD short at TRB %ld/%lu: act_len=%lu\n",
+        KprintfT("mid-TD short at TRB %ld/%lu: act_len=%lu\n",
                  (LONG)idx, (ULONG)td->trb_count, (ULONG)td->short_act_len);
         return FALSE;
     }

--- a/xhci.device/src/xhci/xhci-udev.c
+++ b/xhci.device/src/xhci/xhci-udev.c
@@ -35,9 +35,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci-udev] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci-udev] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci-udev] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 /* Move udev to a new virtual address.  The sole writer of the migration, so
@@ -79,7 +79,7 @@ struct usb_device *xhci_udev_alloc(struct xhci_ctrl *ctrl, u16 virtual_address)
         Kprintf("Failed to allocate out context for addr %lu\n", (ULONG)virtual_address);
         goto free_udev;
     }
-    KprintfH("out_ctx bytes=%lx size=%lu\n",
+    KprintfT("out_ctx bytes=%lx size=%lu\n",
              (ULONG)udev->out_ctx->bytes, (ULONG)udev->out_ctx->size);
 
     /* Allocate the (input) device context for address device command */
@@ -89,7 +89,7 @@ struct usb_device *xhci_udev_alloc(struct xhci_ctrl *ctrl, u16 virtual_address)
         Kprintf("Failed to allocate in context for addr %lu\n", (ULONG)virtual_address);
         goto destroy_out_ctx;
     }
-    KprintfH("in_ctx bytes=%lx size=%lu\n",
+    KprintfT("in_ctx bytes=%lx size=%lu\n",
              (ULONG)udev->in_ctx->bytes, (ULONG)udev->in_ctx->size);
 
     ctrl->devices_by_virtual_address[virtual_address] = udev;
@@ -115,7 +115,7 @@ struct usb_device *xhci_udev_get(struct XHCIUnit *unit, u16 virtual_address)
         // We'll be only creating contexts for newly detected devices
         if (virtual_address != 0 && virtual_address != xhci_roothub_get_address(ctrl->root_hub))
             return NULL;
-        KprintfH("new device addr=%lu\n", (ULONG)virtual_address);
+        KprintfT("new device addr=%lu\n", (ULONG)virtual_address);
         udev = xhci_udev_alloc(ctrl, virtual_address);
     }
 
@@ -130,7 +130,7 @@ static void xhci_udev_flush(struct usb_device *udev, s8 reply_code)
     struct xhci_ctrl *ctrl = udev->controller;
     if (!ctrl)
         return;
-    KprintfH("flushing device addr=%lu slot=%lu\n", (ULONG)udev->virtual_address, (ULONG)udev->slot_id);
+    KprintfT("flushing device addr=%lu slot=%lu\n", (ULONG)udev->virtual_address, (ULONG)udev->slot_id);
 
     if (udev->virtual_address == xhci_roothub_get_address(ctrl->root_hub))
     {
@@ -229,7 +229,7 @@ static BOOL xhci_udev_fetch_hub_descriptor(struct usb_device *udev)
     io->data_buffer_length = desc_len;
     io->direction = DIRECTION_IN;
 
-    KprintfH("Fetching hub descriptor (type=0x%02lx len=%lu) for addr=%lu before CONFIG_EP\n",
+    KprintfT("Fetching hub descriptor (type=0x%02lx len=%lu) for addr=%lu before CONFIG_EP\n",
              (ULONG)desc_type, (ULONG)desc_len, (ULONG)udev->virtual_address);
 
     /* Submit directly to the transfer ring — xhci_ep_enqueue only queues
@@ -288,7 +288,7 @@ static BOOL xhci_udev_fetch_bos(struct usb_device *udev)
     io->data_buffer_length = (u32)sizeof(struct usb_bos_descriptor);
     io->direction = DIRECTION_IN;
 
-    KprintfH("Fetching BOS header for addr=%lu before CONFIG_EP\n",
+    KprintfT("Fetching BOS header for addr=%lu before CONFIG_EP\n",
              (ULONG)udev->virtual_address);
 
     s8 ring_ret = xhci_ring_enqueue_td(udev, io, 1000, FALSE);
@@ -329,7 +329,7 @@ void xhci_udev_io_reply_failed(struct xhci_ctrl *ctrl, struct USBIORequest *io, 
              * those at debug level; a genuine device-level reject (STALL /
              * Request Error) never reports timeout/aborted, so it stays loud. */
             if (err == ERR_TIMEOUT || err == IOERR_ABORTED)
-                KprintfH("internal EP0 request retired (device gone): addr %lu bmReqType=%02lx bReq=%02lx wValue=%lu err=%ld\n",
+                KprintfT("internal EP0 request retired (device gone): addr %lu bmReqType=%02lx bReq=%02lx wValue=%lu err=%ld\n",
                          (ULONG)io->virtual_address, (ULONG)io->setup.bmRequestType,
                          (ULONG)io->setup.bRequest, (ULONG)le16(io->setup.wValue), (LONG)err);
             else
@@ -352,7 +352,7 @@ void xhci_udev_io_reply_failed(struct xhci_ctrl *ctrl, struct USBIORequest *io, 
             return;
         }
 
-        KprintfH("addr %lu EP %lu err=%ld\n", (ULONG)io->virtual_address, (ULONG)io->endpoint, (LONG)err);
+        KprintfT("addr %lu EP %lu err=%ld\n", (ULONG)io->virtual_address, (ULONG)io->endpoint, (LONG)err);
         ReplyMsg((struct Message *)io);
     }
 }
@@ -366,7 +366,7 @@ static void xhci_udev_handle_hub_prefetch(struct usb_device *udev, struct USBIOR
      * SS hubs, the chained BOS fetch below). */
     udev->hub_desc_fetched = TRUE;
 
-    KprintfH("Hub descriptor pre-fetch done for addr=%lu (ports=%lu tt=%lu)\n",
+    KprintfT("Hub descriptor pre-fetch done for addr=%lu (ports=%lu tt=%lu)\n",
              (ULONG)udev->virtual_address,
              (ULONG)udev->ss_hub_desc.bNbrPorts,
              (ULONG)udev->tt_think_time);
@@ -447,7 +447,7 @@ static BOOL xhci_udev_bos_prefetch_phase1(struct usb_device *udev, u8 **pbuf)
     struct xhci_ctrl *ctrl = udev->controller;
     u8 *buf = *pbuf;
 
-    KprintfH("HUB descriptor pre-fetch phase 1: total length field is %lu\n",
+    KprintfT("HUB descriptor pre-fetch phase 1: total length field is %lu\n",
              (ULONG)le16(((struct usb_bos_descriptor *)buf)->wTotalLength));
     const struct usb_bos_descriptor *hdr = (const struct usb_bos_descriptor *)buf;
     if (hdr->bDescriptorType != USB_DT_BOS || hdr->bNumDeviceCaps == 0)
@@ -507,7 +507,7 @@ static void xhci_udev_handle_bos_prefetch(struct usb_device *udev, struct USBIOR
 {
     struct xhci_ctrl *ctrl = udev->controller;
     u8 *buf = io->data_buffer;
-    KprintfH("BOS descriptor pre-fetch done for addr=%lu\n", (ULONG)udev->virtual_address);
+    KprintfT("BOS descriptor pre-fetch done for addr=%lu\n", (ULONG)udev->virtual_address);
 
     io->data_buffer = NULL;
 
@@ -574,14 +574,14 @@ static void xhci_udev_complete_internal(struct usb_device *udev, struct USBIOReq
         xhci_udev_op_advance(udev, UDEV_OP_EVENT_SET_SEL_DONE);
     }
 
-#ifdef DEBUG_HIGH
+#ifdef TRACE
     /* Confirm the device actually accepted the LPM feature enables (rejects
      * land in xhci_udev_io_reply_failed instead). */
     if (io->setup.bRequest == USB_REQ_SET_FEATURE &&
         io->setup.bmRequestType == (USB_DIR_OUT | USB_TYPE_STANDARD | USB_RECIP_DEVICE) &&
         (le16(io->setup.wValue) == USB_DEVICE_U1_ENABLE ||
          le16(io->setup.wValue) == USB_DEVICE_U2_ENABLE))
-        KprintfH("SET_FEATURE U%lu_ENABLE accepted by addr %lu\n",
+        KprintfT("SET_FEATURE U%lu_ENABLE accepted by addr %lu\n",
                 (ULONG)(le16(io->setup.wValue) - USB_DEVICE_U1_ENABLE + 1),
                 (ULONG)io->virtual_address);
 #endif
@@ -653,7 +653,7 @@ void xhci_udev_op_cancel(struct usb_device *udev, enum udev_op which, s8 err)
     if (which != UDEV_OP_NONE && udev->op.op != which)
         return;
 
-    KprintfH("addr %lu: cancelling op %lu (step %lu)\n",
+    KprintfT("addr %lu: cancelling op %lu (step %lu)\n",
              (ULONG)udev->virtual_address, (ULONG)udev->op.op, (ULONG)udev->op.step);
 
     struct USBIORequest *stash = udev->op.stash;
@@ -756,7 +756,7 @@ static BOOL xhci_udev_suspend_device(struct usb_device *udev, u8 root_port, stru
 
     udev->op.waits = stops;
     udev->op.arg = root_port;
-    KprintfH("suspending addr %lu: %lu endpoint stops pending\n",
+    KprintfT("suspending addr %lu: %lu endpoint stops pending\n",
              (ULONG)udev->virtual_address, (ULONG)stops);
     return TRUE;
 }
@@ -819,7 +819,7 @@ void xhci_udev_op_advance(struct usb_device *udev, enum udev_op_event event)
         return;
 
     default:
-        KprintfH("addr %lu: event %lu with no op in flight\n",
+        KprintfT("addr %lu: event %lu with no op in flight\n",
                  (ULONG)udev->virtual_address, (ULONG)event);
         return;
     }
@@ -945,7 +945,7 @@ void xhci_udev_disconnect(struct usb_device *udev, BOOL recursive)
         }
     }
 
-    KprintfH("disconnect device addr=%lu slot=%lu port=%lu\n",
+    KprintfT("disconnect device addr=%lu slot=%lu port=%lu\n",
              (ULONG)udev->virtual_address,
              (ULONG)udev->slot_id,
              (ULONG)udev->parent_port);
@@ -989,7 +989,7 @@ static void handle_get_device_descriptor(struct usb_device *udev, struct USBIORe
         return;
 
     struct usb_device_descriptor *dev_desc = (struct usb_device_descriptor *)io->data_buffer;
-    KprintfH("Device Descriptor: bLength=%lu bDescriptorType=%lu bcdUSB=0x%04lx bDeviceClass=0x%02lx bDeviceSubClass=0x%02lx bDeviceProtocol=0x%02lx bMaxPacketSize0=%lu idVendor=0x%04lx idProduct=0x%04lx bcdDevice=0x%04lx iManufacturer=%lu iProduct=%lu iSerialNumber=%lu bNumConfigurations=%lu\n",
+    KprintfT("Device Descriptor: bLength=%lu bDescriptorType=%lu bcdUSB=0x%04lx bDeviceClass=0x%02lx bDeviceSubClass=0x%02lx bDeviceProtocol=0x%02lx bMaxPacketSize0=%lu idVendor=0x%04lx idProduct=0x%04lx bcdDevice=0x%04lx iManufacturer=%lu iProduct=%lu iSerialNumber=%lu bNumConfigurations=%lu\n",
              (ULONG)dev_desc->bLength,
              (ULONG)dev_desc->bDescriptorType,
              (ULONG)le16(dev_desc->bcdUSB),
@@ -1013,7 +1013,7 @@ static void handle_get_device_descriptor(struct usb_device *udev, struct USBIORe
 
     if (udev->speed == USB_SPEED_SUPER && dev_desc->bMaxPacketSize0 != 64)
     {
-        KprintfH("clamping SS bMaxPacketSize0 from %lu to 64\n", (ULONG)dev_desc->bMaxPacketSize0);
+        KprintfT("clamping SS bMaxPacketSize0 from %lu to 64\n", (ULONG)dev_desc->bMaxPacketSize0);
         dev_desc->bMaxPacketSize0 = 64;
     }
 
@@ -1022,22 +1022,22 @@ static void handle_get_device_descriptor(struct usb_device *udev, struct USBIORe
 
     if (dev_desc->bDeviceClass == USB_CLASS_HUB && (!udev->is_hub || !udev->ss_hub_emulation))
     {
-        KprintfH("Device at addr=%lu is a hub\n", (ULONG)udev->virtual_address);
+        KprintfT("Device at addr=%lu is a hub\n", (ULONG)udev->virtual_address);
         udev->is_hub = TRUE;
 
         /* Only enable SS hub emulation for real external hubs, not the virtual root hub.
          * Root hub (parent == NULL) already provides port status in USB 2.0 format. */
         if (udev->speed >= USB_SPEED_SUPER && !udev->ss_hub_emulation)
         {
-            KprintfH("Detected USB 3.0 hub at addr=%lu, enabling translation mode\n", (ULONG)udev->virtual_address);
+            KprintfT("Detected USB 3.0 hub at addr=%lu, enabling translation mode\n", (ULONG)udev->virtual_address);
             udev->ss_hub_emulation = TRUE;
         }
     }
 
     if (le16(dev_desc->bcdUSB) >= 0x0300)
     {
-        KprintfH("Device at addr=%lu is USB 3.0 capable, bcdUSB=0x%04lx\n", (ULONG)udev->virtual_address, (ULONG)le16(dev_desc->bcdUSB));
-        KprintfH("Clamping bcdUSB to 0x0210 for compatibility\n");
+        KprintfT("Device at addr=%lu is USB 3.0 capable, bcdUSB=0x%04lx\n", (ULONG)udev->virtual_address, (ULONG)le16(dev_desc->bcdUSB));
+        KprintfT("Clamping bcdUSB to 0x0210 for compatibility\n");
         dev_desc->bcdUSB = le16(0x0210);
     }
 }
@@ -1117,7 +1117,7 @@ static void handle_set_address(struct usb_device *udev, struct USBIORequest *io)
 
     xhci_udev_remap(ctrl, current, new_addr);
 
-    KprintfH("migrated ctx from addr %lu to %lu\n", (ULONG)old_addr, (ULONG)new_addr);
+    KprintfT("migrated ctx from addr %lu to %lu\n", (ULONG)old_addr, (ULONG)new_addr);
 }
 
 static void handle_set_interface(struct usb_device *udev, struct USBIORequest *io)
@@ -1135,7 +1135,7 @@ static void handle_set_interface(struct usb_device *udev, struct USBIORequest *i
 
 static void xhci_udev_parse_control_message(struct usb_device *udev, struct USBIORequest *io)
 {
-    KprintfH("dev=%lx addr=%lu bmReqType=%02lx bReq=%02lx wValue=%04lx wIndex=%04lx wLength=%04lx actual=%lu\n",
+    KprintfT("dev=%lx addr=%lu bmReqType=%02lx bReq=%02lx wValue=%04lx wIndex=%04lx wLength=%04lx actual=%lu\n",
              (ULONG)udev, (ULONG)udev->virtual_address,
              (ULONG)io->setup.bmRequestType,
              (ULONG)io->setup.bRequest,
@@ -1231,7 +1231,7 @@ void xhci_udev_io_reply_data(struct usb_device *udev, struct USBIORequest *io, s
     if (io->req.io_Command == CMD_REQUEST_CONTROL && err == ERR_NO_ERROR && io->endpoint == 0)
         xhci_udev_parse_control_message(udev, io);
 
-    KprintfH("err=%ld actual=%lu\n", (LONG)err, (ULONG)actual);
+    KprintfT("err=%ld actual=%lu\n", (LONG)err, (ULONG)actual);
 
     /* Internal, reply-less requests (IOF_QUICK + magic tag) */
     if (io->driver_private_flags & REQ_INTERNAL)
@@ -1317,7 +1317,7 @@ static BOOL xhci_udev_ctrl_clear_ep_halt(struct usb_device *udev, struct USBIORe
     BOOL synced = xhci_ep_consume_halt_synced(halt_ep_ctx);
     if (!synced && xhci_read_hw_ep_state(udev, halt_ep_index) == EP_STATE_HALTED)
     {
-        KprintfH("stack clear-halt on halted EP %lu: running recovery\n", (ULONG)halt_ep_index);
+        KprintfT("stack clear-halt on halted EP %lu: running recovery\n", (ULONG)halt_ep_index);
         xhci_reset_ep(udev, halt_ep_index);
         synced = TRUE;
     }
@@ -1350,7 +1350,7 @@ static BOOL xhci_udev_ctrl_hub_suspend(struct usb_device *udev, struct USBIORequ
 
 static s8 xhci_udev_send_ctrl_first(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms)
 {
-    KprintfH("bmReqType=%02lx bReq=%02lx wValue=%04lx wIndex=%04lx wLength=%04lx\n",
+    KprintfT("bmReqType=%02lx bReq=%02lx wValue=%04lx wIndex=%04lx wLength=%04lx\n",
              (ULONG)io->setup.bmRequestType,
              (ULONG)io->setup.bRequest,
              le16(io->setup.wValue),
@@ -1416,7 +1416,7 @@ s8 xhci_udev_send(struct USBIORequest *req)
     struct usb_device *udev = xhci_udev_get(unit, req->virtual_address);
     if (!udev)
     {
-        KprintfH("Device does not exist for addr %lu\n", (ULONG)req->virtual_address);
+        KprintfT("Device does not exist for addr %lu\n", (ULONG)req->virtual_address);
         return ERR_TIMEOUT;
     }
 
@@ -1424,7 +1424,7 @@ s8 xhci_udev_send(struct USBIORequest *req)
     if ((req->flags & DRIVER_FLAG_TIMEOUT_DEFINED))
         timeout_ms = req->timeout;
 
-    KprintfH("dev=%lx addr=%lu slot=%lu ep=%lu dir=%s len=%lu flags=%lx tmo=%lu\n",
+    KprintfT("dev=%lx addr=%lu slot=%lu ep=%lu dir=%s len=%lu flags=%lx tmo=%lu\n",
              (ULONG)udev, (ULONG)udev->virtual_address, (ULONG)udev->slot_id,
              (ULONG)(req->endpoint & 0x0F), (req->direction == DIRECTION_IN) ? "IN" : "OUT",
              (ULONG)req->data_buffer_length, (ULONG)req->flags,

--- a/xhci.device/src/xhci/xhci-udev.c
+++ b/xhci.device/src/xhci/xhci-udev.c
@@ -169,58 +169,6 @@ void xhci_udev_free(struct usb_device *udev)
     pool_free(ctrl->metaPool, udev);
 }
 
-static u8 xhci_udev_find_epaddr_by_num(struct usb_device *udev, u8 epnum)
-{
-    if (!udev || !udev->active_config || epnum == 0)
-        return 0;
-
-    struct usb_config *cfg = udev->active_config;
-
-    for (int i = 0; i < cfg->no_of_if; ++i)
-    {
-        struct usb_interface *iface = &cfg->if_desc[i];
-        struct usb_interface_altsetting *alt = iface->active_altsetting;
-        if (!alt)
-            continue;
-
-        for (int e = 0; e < alt->no_of_ep; ++e)
-        {
-            u8 addr = alt->ep_desc[e].bEndpointAddress;
-            if ((addr & 0x0F) == epnum)
-                return addr;
-        }
-    }
-
-    return 0;
-}
-
-static void xhci_udev_patch_endpoint_address(struct usb_device *udev, struct USBIORequest *io)
-{
-    struct USBSetupPacket *setup = &io->setup;
-
-    /* Only patch class+endpoint recipient control requests. */
-    if ((setup->bmRequestType & (USB_TYPE_MASK | USB_RECIP_MASK)) != (USB_TYPE_CLASS | USB_RECIP_ENDPOINT))
-        return;
-
-    /* If direction bit is already present, leave untouched. */
-    u16 wIndex = le16(setup->wIndex);
-    if (wIndex & 0x0080)
-        return;
-
-    u8 epnum = wIndex & 0x0F;
-    if (epnum == 0)
-        return;
-
-    u8 fixed = xhci_udev_find_epaddr_by_num(udev, epnum);
-    if (!fixed || fixed == (u8)wIndex)
-        return;
-
-    setup->wIndex = le16(fixed);
-
-    KprintfH("Patched endpoint address wIndex from %02lx to %02lx for epnum %lu\n",
-             (ULONG)wIndex, (ULONG)fixed, (ULONG)epnum);
-}
-
 s8 xhci_udev_send_ctrl(struct usb_device *udev, struct USBIORequest *io)
 {
     if (!udev || !io)
@@ -976,41 +924,6 @@ s32 xhci_ep_type_for_index(struct usb_device *udev, u8 ep_index)
     return -1;
 }
 
-static BOOL xhci_udev_iface_has_active_rt_iso(struct usb_device *udev, u8 iface_number)
-{
-    if (!udev || !udev->active_config)
-        return FALSE;
-
-    struct usb_config *cfg = udev->active_config;
-    for (int i = 0; i < cfg->no_of_if; ++i)
-    {
-        struct usb_interface *iface = &cfg->if_desc[i];
-        if (iface->interface_number != iface_number)
-            continue;
-
-        struct usb_interface_altsetting *alt = iface->active_altsetting;
-        if (!alt)
-            return FALSE;
-
-        for (int e = 0; e < alt->no_of_ep; ++e)
-        {
-            u8 ep_index = xhci_address_to_ep_index(&alt->ep_desc[e]);
-
-            struct ep_context *ep_ctx = xhci_ep_get_context_for_index(udev, ep_index);
-            if (!ep_ctx)
-                continue;
-            enum ep_state state = xhci_ep_get_state(ep_ctx);
-            if (state == USB_DEV_EP_STATE_RT_ISO_RUNNING ||
-                state == USB_DEV_EP_STATE_RT_ISO_STOPPING)
-                return TRUE;
-        }
-
-        return FALSE;
-    }
-
-    return FALSE;
-}
-
 void xhci_udev_disconnect(struct usb_device *udev, BOOL recursive)
 {
     if (!udev || !udev->slot_id)
@@ -1211,25 +1124,12 @@ static void handle_set_interface(struct usb_device *udev, struct USBIORequest *i
 {
     u8 iface = le16(io->setup.wIndex) & 0xFFU;
     u8 alt = le16(io->setup.wValue) & 0xFFU;
-    /*
-     * This is a workaround for Poseidon issue.
-     * Poseidon issues SET_INTERFACE for all devices after connecting a new one.
-     * Thing is, it first sets the alternate setting to 0, then to the desired setting.
-     * This causes issues with active RT ISO endpoints, as they get disabled on alt=0.
-     */
-    if (!xhci_udev_iface_has_active_rt_iso(udev, iface))
+
+    s8 err = xhci_set_interface(udev, iface, alt);
+    if (err != ERR_NO_ERROR)
     {
-        s8 err = xhci_set_interface(udev, iface, alt);
-        if (err != ERR_NO_ERROR)
-        {
-            Kprintf("SET_INTERFACE iface=%lu alt=%lu failed err=%ld\n",
-                    (ULONG)iface, (ULONG)alt, (LONG)err);
-        }
-    }
-    else
-    {
-        KprintfH("SET_INTERFACE iface=%lu alt=%lu ignored (RT ISO active)\n",
-                 (ULONG)iface, (ULONG)alt);
+        Kprintf("SET_INTERFACE iface=%lu alt=%lu failed err=%ld\n",
+                (ULONG)iface, (ULONG)alt, (LONG)err);
     }
 }
 
@@ -1450,9 +1350,6 @@ static BOOL xhci_udev_ctrl_hub_suspend(struct usb_device *udev, struct USBIORequ
 
 static s8 xhci_udev_send_ctrl_first(struct usb_device *udev, struct USBIORequest *io, u32 timeout_ms)
 {
-    /* Work around class drivers that omit the direction bit in endpoint-recipient requests (e.g., UAC1 SET_CUR). */
-    xhci_udev_patch_endpoint_address(udev, io);
-
     KprintfH("bmReqType=%02lx bReq=%02lx wValue=%04lx wIndex=%04lx wLength=%04lx\n",
              (ULONG)io->setup.bmRequestType,
              (ULONG)io->setup.bRequest,

--- a/xhci.device/src/xhci/xhci.c
+++ b/xhci.device/src/xhci/xhci.c
@@ -41,9 +41,9 @@
 #define Kprintf(fmt, ...) PrintPistorm("[xhci] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
-#ifdef DEBUG_HIGH
-#undef KprintfH
-#define KprintfH(fmt, ...) PrintPistorm("[xhci] %s: " fmt, __func__, ##__VA_ARGS__)
+#ifdef TRACE
+#undef KprintfT
+#define KprintfT(fmt, ...) PrintPistorm("[xhci] %s: " fmt, __func__, ##__VA_ARGS__)
 #endif
 
 #define CACHELINE_SIZE 64
@@ -308,7 +308,7 @@ static s32 xhci_start(struct xhci_hcor *hcor)
  */
 static s32 xhci_halt(struct xhci_hcor *hcor)
 {
-	KprintfH("// Halt the HC: %lx\n", hcor);
+	KprintfT("// Halt the HC: %lx\n", hcor);
 	u32 state = mmio_read32(&hcor->or_usbsts) & STS_HALT;
 	if (!state)
 	{
@@ -349,7 +349,7 @@ static s32 xhci_reset(struct xhci_hcor *hcor)
 		return -EBUSY;
 	}
 
-	KprintfH("// Reset the HC\n");
+	KprintfT("// Reset the HC\n");
 	cmd = mmio_read32(&hcor->or_usbcmd);
 	cmd |= CMD_RESET_USB;
 	mmio_write32(cmd, &hcor->or_usbcmd);
@@ -571,7 +571,7 @@ static void xhci_lowlevel_stop(struct xhci_ctrl *ctrl)
 {
 	xhci_reset(ctrl->hcor);
 
-	KprintfH("// Disabling event ring interrupts\n");
+	KprintfT("// Disabling event ring interrupts\n");
 	u32 temp = mmio_read32(&ctrl->hcor->or_usbsts);
 	mmio_write32(temp & ~STS_EINT, &ctrl->hcor->or_usbsts);
 	temp = mmio_read32(&ctrl->ir_set->irq_pending);
@@ -583,7 +583,7 @@ static void xhci_lowlevel_stop(struct xhci_ctrl *ctrl)
 
 s32 xhci_register(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr, struct xhci_hcor *hcor)
 {
-	KprintfH("ctrl=%lx, hccr=%lx, hcor=%lx\n", ctrl, hccr, hcor);
+	KprintfT("ctrl=%lx, hccr=%lx, hcor=%lx\n", ctrl, hccr, hcor);
 
 	s32 ret = xhci_reset(hcor);
 	if (ret)
@@ -601,7 +601,7 @@ s32 xhci_register(struct xhci_ctrl *ctrl, struct xhci_hccr *hccr, struct xhci_hc
 		ret = -ENOMEM;
 		goto err_pool;
 	}
-	KprintfH("memory pools created: dma=%lx meta=%lx\n", (ULONG)ctrl->dmaPool, (ULONG)ctrl->metaPool);
+	KprintfT("memory pools created: dma=%lx meta=%lx\n", (ULONG)ctrl->dmaPool, (ULONG)ctrl->metaPool);
 
 	xhci_td_slab_init(ctrl);
 	slab_cache_init(&ctrl->trb_addr_slab, ctrl->metaPool, NULL,


### PR DESCRIPTION
This pull request removes several workarounds and helper functions related to USB endpoint and interface handling in the xHCI device driver. The main focus is on cleaning up code that previously handled special cases for the Poseidon USB hub and class drivers, resulting in a simpler and more maintainable codebase.

### Removal of Poseidon and class driver workarounds

* Removed the workaround in `Do_CMD_XFER` that ignored duplicate interrupt IORequests for the Poseidon hub, as well as the associated helper function `xhci_ep_has_request`. This eliminates special-case handling for duplicate requests. [[1]](diffhunk://#diff-cc831d4f83701e352c2eb22d56759717e232ece7f61768b657551368d3653caaL365-L397) [[2]](diffhunk://#diff-e2718dc11bf8a58a8913ec30b08847968beb02252650246eb3cdeb4302bef03aL261-L276) [[3]](diffhunk://#diff-8fd47cae4c47dfbd4448d2c215ce02a45767c008ef5b367bd019b7ffdbbc2d3cL63)
* Removed the workaround in `handle_set_interface` that prevented changing interface alternate settings when real-time isochronous endpoints were active, including the helper `xhci_udev_iface_has_active_rt_iso`. [[1]](diffhunk://#diff-0c5db1853d826541b7cb2d1136d7b625a74018f44c987293aa9e638d6789fb3eL1214-L1234) [[2]](diffhunk://#diff-0c5db1853d826541b7cb2d1136d7b625a74018f44c987293aa9e638d6789fb3eL979-L1013)
* Removed the workaround in `xhci_udev_send_ctrl_first` and related helpers that patched endpoint addresses in control requests missing the direction bit (e.g., for UAC1 SET_CUR). This includes deleting `xhci_udev_patch_endpoint_address` and `xhci_udev_find_epaddr_by_num`. [[1]](diffhunk://#diff-0c5db1853d826541b7cb2d1136d7b625a74018f44c987293aa9e638d6789fb3eL1453-L1455) [[2]](diffhunk://#diff-0c5db1853d826541b7cb2d1136d7b625a74018f44c987293aa9e638d6789fb3eL172-L223)

### Codebase simplification

* Deleted now-unused helper functions: `xhci_ep_has_request`, `xhci_udev_find_epaddr_by_num`, `xhci_udev_patch_endpoint_address`, and `xhci_udev_iface_has_active_rt_iso`, reducing code complexity and maintenance burden. [[1]](diffhunk://#diff-e2718dc11bf8a58a8913ec30b08847968beb02252650246eb3cdeb4302bef03aL261-L276) [[2]](diffhunk://#diff-0c5db1853d826541b7cb2d1136d7b625a74018f44c987293aa9e638d6789fb3eL172-L223) [[3]](diffhunk://#diff-0c5db1853d826541b7cb2d1136d7b625a74018f44c987293aa9e638d6789fb3eL979-L1013) [[4]](diffhunk://#diff-8fd47cae4c47dfbd4448d2c215ce02a45767c008ef5b367bd019b7ffdbbc2d3cL63)

Overall, these changes streamline the xHCI driver by removing legacy workarounds and unused code, making it easier to maintain and less error-prone.